### PR TITLE
fix: faceting bug

### DIFF
--- a/components/SearchComponents/MainContent/Sidebar/index.js
+++ b/components/SearchComponents/MainContent/Sidebar/index.js
@@ -17,7 +17,9 @@ const possibleFacets = [
 const paramsToString = query =>
   Object.keys(query)
     .map(key => {
+      // if the query has more than 1 value it is formatted as an array
       if (Array.isArray(query[key])) {
+        // we have to map these into a single string
         return query[key].map(param => `${key}=${param}`).join("&");
       } else {
         return `${key}=${query[key]}`;

--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -64,6 +64,7 @@ Search.getInitialProps = async ({ query }) => {
           .map(
             param =>
               facet === "sourceResource.type" &&
+                // types with spaces in their name need quotes around the value
                 /(image|text|sound)/.test(query[facet])
                 ? `${[facet]}=${param}`
                 : `${[facet]}="${param}"`


### PR DESCRIPTION
There were a few problems that this hopefully fixes which would cause a malformed query string and therefore return 0 results even though there were supposed to be results. This mainly had to do with commas in the param values. So we sometimes have to use a param multiple times, i.e. `?subject=Cats, Dogs, and Other Pets&subject=Fleas, Ticks, and Other Pests` rather than storing the value in one param key. 

There might be a better way to refactor this that would allow us to collapse the values, but this is a workable solution for now (I hope). You can test it by just clicking a whole bunch of facets and making sure they never lead to a blank results screen.