### PR TITLE
feat: add topic browse item metadata, fix encoding of titles

### DIFF
--- a/components/shared/ListView/index.js
+++ b/components/shared/ListView/index.js
@@ -29,10 +29,9 @@ const ListView = ({ items, route }) =>
         <div className={classNames.itemInfo}>
           <Link prefetch href={item.linkHref} as={item.linkAs}>
             <a className={classNames.listItemLink}>
-              <span
-                dangerouslySetInnerHTML={{ __html: item.title }}
-                className={classNames.itemTitle}
-              />
+              <span className={classNames.itemTitle}>
+                {item.title}
+              </span>
             </a>
           </Link>
           <span className={classNames.itemType}>

--- a/pages/browse-by-topic/topic/subtopic/index.js
+++ b/pages/browse-by-topic/topic/subtopic/index.js
@@ -9,7 +9,7 @@ import BreadcrumbsAndNav from "../../../../components/TopicBrowseComponents/Brea
 import ItemList from "../../../../components/TopicBrowseComponents/SubtopicItemsList/ItemList";
 import MainLayout from "../../../../components/MainLayout";
 import Sidebar from "../../../../components/TopicBrowseComponents/SubtopicItemsList/Sidebar";
-import { extractItemId } from "utilFunctions";
+import { decodeHTMLEntities, extractItemId } from "utilFunctions";
 import { API_KEY } from "constants/search";
 import {
   API_ENDPOINT_ALL_TOPICS_100_PER_PAGE,
@@ -104,7 +104,7 @@ SubtopicItemsList.getInitialProps = async ({ query }) => {
       const itemJson = await itemRes.json();
 
       return Object.assign({}, item, {
-        title: item.title.rendered,
+        title: decodeHTMLEntities(item.title.rendered),
         linkHref: `/item?itemId=${itemDplaId}`,
         linkAs: `/item/${itemDplaId}`,
         type: itemJson.docs[0].sourceResource.type,

--- a/utilFunctions/decodeHTMLEntities.js
+++ b/utilFunctions/decodeHTMLEntities.js
@@ -1,0 +1,4 @@
+const decodeHTMLEntities = str =>
+  str.replace(/&#(\w+);/g, (m, n) => String.fromCharCode(n));
+
+export default decodeHTMLEntities;

--- a/utilFunctions/index.js
+++ b/utilFunctions/index.js
@@ -4,6 +4,7 @@ import extractSourceId from "./extractSourceId";
 import extractSourceSetSlug from "./extractSourceSetSlug";
 import joinIfArray from "./joinIfArray";
 import removeQueryParams from "./removeQueryParams";
+import decodeHTMLEntities from "./decodeHTMLEntities";
 
 export {
   addCommasToNumber,
@@ -11,5 +12,6 @@ export {
   extractSourceId,
   extractSourceSetSlug,
   joinIfArray,
-  removeQueryParams
+  removeQueryParams,
+  decodeHTMLEntities
 };


### PR DESCRIPTION
@tinystride i don't know if you have a better idea for fixing the title encoding than this regex (the problem is that some titles come in with HTML char. entities, such as `&#8217;` for an apostrophe). I could also use dangerouslySetInnerHTML I guess.