### PR TITLE
feat: use google docs PDF viewer for PDFs

### DIFF
--- a/components/shared/mediaViewers/PDFViewer.js
+++ b/components/shared/mediaViewers/PDFViewer.js
@@ -1,9 +1,9 @@
 import React from "react";
 
-const PDFViewer = ({ pathToFile, height = "750px" }) =>
+const PDFViewer = ({ pathToFile, height = "650px" }) =>
   <iframe
     title="dpla-pdf-viewer"
-    src={pathToFile}
+    src={`https://docs.google.com/gview?url=${pathToFile}&embedded=true`}
     style={{ width: "100%", height }}
     frameBorder="0"
   />;


### PR DESCRIPTION
For https://trello.com/c/PaDOI1x9/31-document-viewer-for-pss-source-pages-has-a-different-set-of-features-including-a-download-feature-we-dont-want

Uses the Google Docs PDF viewer to remove download features.

![screen shot 2017-09-26 at 3 49 27 pm](https://user-images.githubusercontent.com/1767309/30881079-934084ee-a2d2-11e7-831a-7e4f08453084.png)
