### PR TITLE
fix: swap record/source position and icon

### DIFF
--- a/components/PrimarySourceSetsComponents/Source/components/ContentAndMetadata/index.js
+++ b/components/PrimarySourceSetsComponents/Source/components/ContentAndMetadata/index.js
@@ -109,18 +109,6 @@ const ContentAndMetadata = ({ source }) => {
               <div className={classNames.divider} />
               {source.mainEntity[0]["dct:references"] &&
                 <div className={classNames.linkWrapper}>
-                  <a
-                    href={getSourceLink(source)}
-                    className={classNames.sourceLink}
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    <img alt="" src={link} className={classNames.linkIcon} />
-                    <span className={classNames.linkText}>Item source</span>
-                  </a>
-                </div>}
-              {source.mainEntity[0]["dct:references"] &&
-                <div className={classNames.linkWrapper}>
                   <Link prefetch href={`/item?itemId=${getItemId(source)}`}>
                     <a
                       target="_blank"
@@ -128,13 +116,29 @@ const ContentAndMetadata = ({ source }) => {
                       className={classNames.sourceLink}
                     >
                       <img
-                        alt=""
-                        src={external}
-                        className={classNames.externalIcon}
+                        alt="Link icon"
+                        src={link}
+                        className={classNames.linkIcon}
                       />
                       <span className={classNames.linkText}>DPLA record</span>
                     </a>
                   </Link>
+                </div>}
+              {source.mainEntity[0]["dct:references"] &&
+                <div className={classNames.linkWrapper}>
+                  <a
+                    href={getSourceLink(source)}
+                    className={classNames.sourceLink}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <img
+                      alt="External link icon"
+                      src={external}
+                      className={classNames.externalIcon}
+                    />
+                    <span className={classNames.linkText}>Item source</span>
+                  </a>
                 </div>}
             </div>
             <div className={classNames.tipsForStudents}>


### PR DESCRIPTION
Swaps the order and icon for the record and source on the PSS pages.

![screen shot 2017-09-26 at 4 00 29 pm](https://user-images.githubusercontent.com/1767309/30881467-f770c766-a2d3-11e7-986c-fdceda3dc2e8.png)

For https://trello.com/c/ktYerRJj/82-the-icons-for-item-source-and-dpla-record-are-confusing-the-icon-on-dpla-record-appears-that-it-will-take-you-to-a-separate-page