### PR TITLE
styles: fix exhibition title positioning in firefox

### DIFF
--- a/components/ExhibitionsComponents/Exhibition/ImageAndCaption/ImageAndCaption.css
+++ b/components/ExhibitionsComponents/Exhibition/ImageAndCaption/ImageAndCaption.css
@@ -29,7 +29,6 @@
 .overlayContent {
   width: 90%;
   text-align: center;
-  position: absolute;
   padding-bottom: 56px;
 }
 


### PR DESCRIPTION
fixes #214 