### PR TITLE
Wire Up Guide Banners from Wordpress API

### DIFF
--- a/css/pages/content-pages-wysiwyg.css
+++ b/css/pages/content-pages-wysiwyg.css
@@ -2,7 +2,7 @@
 
 .sidebarAndContentWrapper {
   display: flex;
-  margin-top: 4rem;
+  margin-top: 2rem;
   margin-bottom: 8rem;
 }
 

--- a/css/pages/guide.css
+++ b/css/pages/guide.css
@@ -1,10 +1,12 @@
-.illustration {
-  margin-bottom: 2rem;
+.bannerImage {
+  display: block;
+  height: 12rem;
+  margin: -1rem auto 3rem;
+  max-width: 100%;
 }
 
 .guideTitle {
-  font-size: 3.5rem;
-  font-family: "Lora";
-  font-weight: normal;
   text-align: center;
+  /* Override wysiwyg styles */
+  margin: 0 !important;
 }

--- a/pages/guides/guide/index.js
+++ b/pages/guides/guide/index.js
@@ -24,9 +24,9 @@ const Guides = ({ url, guides, guide }) =>
         <ContentPagesSidebar route={url} guides={guides} />
         <div className={[classNames.content, contentClasses.content].join(" ")}>
           <img
-            src={guide.illustration}
+            src={guide.bannerImage}
             alt=""
-            className={classNames.illustration}
+            className={classNames.bannerImage}
           />
           <h1 className={classNames.guideTitle}>{guide.title}</h1>
           <HeadingRule />
@@ -54,7 +54,7 @@ Guides.getInitialProps = async ({ query }) => {
       summary: guide.acf.summary,
       title: guide.title.rendered,
       color: guide.acf.color,
-      illustration: guide.acf.illustration,
+      bannerImage: guide.acf.banner_image,
       content: guide.content.rendered
     })
   };


### PR DESCRIPTION
Wires up the banners from WP API created in https://github.com/postlight/dpla-backend/issues/12

![screen shot 2017-10-03 at 12 44 57 pm](https://user-images.githubusercontent.com/1767309/31137319-e3040094-a838-11e7-9265-13b8fdfd7223.png)
