### PR TITLE
fix: clickable 175

### DIFF
--- a/components/ItemComponents/Content/RightsMetadata.js
+++ b/components/ItemComponents/Content/RightsMetadata.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { classNames, stylesheet } from "./Content.css";
+import { makeURLsClickable } from "utilFunctions";
 
 const RightsMetadata = ({ item }) =>
   <div className={classNames.rightsMetadata}>
@@ -34,9 +35,12 @@ const RightsMetadata = ({ item }) =>
           </td>
           <td
             className={[classNames.tableItem, classNames.rightsText].join(" ")}
-          >
-            {Array.isArray(item.rights) ? item.rights.join(" ") : item.rights}
-          </td>
+            dangerouslySetInnerHTML={{
+              __html: Array.isArray(item.rights) 
+              ? makeURLsClickable(item.rights.join(" ")) 
+              : makeURLsClickable(item.rights)
+            }}
+          />
         </tr>}
       </tbody>
     </table>

--- a/utilFunctions/index.js
+++ b/utilFunctions/index.js
@@ -7,6 +7,7 @@ import removeQueryParams from "./removeQueryParams";
 import decodeHTMLEntities from "./decodeHTMLEntities";
 import getCurrentUrl from "./getCurrentUrl";
 import getDefaultThumbnail from "./getDefaultThumbnail";
+import makeURLsClickable from "./makeURLsClickable";
 
 export {
   addCommasToNumber,
@@ -17,5 +18,6 @@ export {
   removeQueryParams,
   decodeHTMLEntities,
   getCurrentUrl,
-  getDefaultThumbnail
+  getDefaultThumbnail,
+  makeURLsClickable
 };

--- a/utilFunctions/makeURLsClickable.js
+++ b/utilFunctions/makeURLsClickable.js
@@ -1,0 +1,5 @@
+// hacky... use only in trusted places
+const makeURLsClickable = str =>
+  str.replace(/(http.+?)(\s|$)/g, (text, link) => '<a href="'+ link +'">'+ link +'</a>');
+
+export default makeURLsClickable;


### PR DESCRIPTION
i had to get a little hacky on this one and it surfaces what i think is an issue related to [this trello ticket](https://trello.com/c/zf8PnqE7/85-on-main-page-of-the-pss-it-is-hard-to-tell-that-the-time-periods-are-links-since-they-are-all-in-gray) in which not every `<a>` element inherits the base link style attributes (orange, underline, etc.). 

ideally, anything inside an `<a>` tag should have basic styling, especially one different from the normal page text.