### PR TITLE
fix: use relative urls in teaching guide links

### DIFF
--- a/components/PrimarySourceSetsComponents/SingleSet/TeachersGuide/index.js
+++ b/components/PrimarySourceSetsComponents/SingleSet/TeachersGuide/index.js
@@ -22,7 +22,7 @@ const TeachersGuide = ({ route, teachingGuide, setName, currentPath }) =>
             dangerouslySetInnerHTML={{
               __html: markdown.toHTML(
                 teachingGuide.hasPart.find(item => item.name === "Questions")
-                  .text
+                  .text.replace(/(http|https):\/\/dp.la\/primary-source-sets\//, '')
               )
             }}
           />


### PR DESCRIPTION
This is a hack needed because the markdown in PSS has absolute links back to the old site. This replacement makes them relative to the teaching guide, and therefore link to the new site wherever it's deployed.

Welcome to input about how to do this better.