### PR TITLE
fix: markdown #178

### DIFF
--- a/components/HomePageComponents/HomePageSlider/index.js
+++ b/components/HomePageComponents/HomePageSlider/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import Slider from "react-slick";
 import Link from "next/link";
-import { markdown } from "markdown";
+const markdownit = require("markdown-it")({html: true});
 
 import { stylesheet, classNames } from "./HomePageSlider.css";
 import { classNames as breakpoints } from "css/breakpoints.css";
@@ -91,7 +91,7 @@ const HomePageSlider = ({
                       <div className={classNames.featuredTag}>Featured</div>}
                   </div>
                   <div
-                    dangerouslySetInnerHTML={{ __html: markdown.toHTML(name) }}
+                    dangerouslySetInnerHTML={{ __html: markdownit.render(name) }}
                     className={classNames.itemText}
                   />
                 </a>

--- a/components/ItemComponents/BreadcrumbsModule/index.js
+++ b/components/ItemComponents/BreadcrumbsModule/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { markdown } from "markdown";
+const markdownit = require("markdown-it")({html: true});
 
 import Breadcrumbs from "../../Breadcrumbs";
 
@@ -14,7 +14,7 @@ const BreadcrumbsModule = ({ route, breadcrumbs }) =>
       <Breadcrumbs
         breadcrumbs={breadcrumbs.map(breadcrumb =>
           Object.assign({}, breadcrumb, {
-            title: markdown.toHTML(breadcrumb.title)
+            title: markdownit.render(breadcrumb.title)
           })
         )}
       />

--- a/components/PrimarySourceSetsComponents/AllSets/components/SetsList/index.js
+++ b/components/PrimarySourceSetsComponents/AllSets/components/SetsList/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { markdown } from "markdown";
+const markdownit = require("markdown-it")({html: true});
 import Link from "next/link";
 
 import { classNames, stylesheet } from "./SetsList.css";
@@ -59,7 +59,7 @@ const SetsList = ({ sets, route }) =>
                 >
                   <div
                     dangerouslySetInnerHTML={{
-                      __html: markdown.toHTML(set.name)
+                      __html: markdownit.render(set.name)
                     }}
                   />
                 </a>

--- a/components/PrimarySourceSetsComponents/BreadcrumbsModule/index.js
+++ b/components/PrimarySourceSetsComponents/BreadcrumbsModule/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { markdown } from "markdown";
+const markdownit = require("markdown-it")({html: true});
 
 import Breadcrumbs from "../../Breadcrumbs";
 import StudentMode from "./components/StudentMode";
@@ -15,7 +15,7 @@ const BreadcrumbsModule = ({ route, breadcrumbs }) =>
       <Breadcrumbs
         breadcrumbs={breadcrumbs.map(breadcrumb =>
           Object.assign({}, breadcrumb, {
-            title: markdown.toHTML(breadcrumb.title)
+            title: markdownit.render(breadcrumb.title)
           })
         )}
       />

--- a/components/PrimarySourceSetsComponents/SingleSet/SourceSetInfo/index.js
+++ b/components/PrimarySourceSetsComponents/SingleSet/SourceSetInfo/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 import Link from "next/link";
-import { markdown } from "markdown";
+const markdownit = require("markdown-it")({html: true});
 
 import { stylesheet, classNames } from "./SourceSetInfo.css";
 import { classNames as utilClassNames } from "css/utils.css";
@@ -36,7 +36,7 @@ const SourceSetInfo = set =>
             </h3>
             <h1
               dangerouslySetInnerHTML={{
-                __html: markdown.toHTML(set.set.name)
+                __html: markdownit.render(set.set.name)
               }}
               className={classNames.bannerTitle}
             />
@@ -46,7 +46,7 @@ const SourceSetInfo = set =>
         <div
           className={classNames.description}
           dangerouslySetInnerHTML={{
-            __html: markdown.toHTML(
+            __html: markdownit.render(
               set.set.hasPart.find(item => item.name === "Overview").text
             )
           }}
@@ -59,7 +59,7 @@ const SourceSetInfo = set =>
             {extractAuthors(set.set.author).map((name) =>
               <div
                 dangerouslySetInnerHTML={{
-                  __html: markdown.toHTML(name)
+                  __html: markdownit.render(name)
                 }}
               />
             )}
@@ -80,7 +80,7 @@ const SourceSetInfo = set =>
                 <a
                   className={classNames.link}
                   dangerouslySetInnerHTML={{
-                    __html: markdown.toHTML(period)
+                    __html: markdownit.render(period)
                   }}
                 />
               </Link>
@@ -105,7 +105,7 @@ const SourceSetInfo = set =>
                   <a
                     className={classNames.link}
                     dangerouslySetInnerHTML={{
-                      __html: markdown.toHTML(subject)
+                      __html: markdownit.render(subject)
                     }}
                   />
                 </Link>

--- a/components/PrimarySourceSetsComponents/SingleSet/SourceSetSources/index.js
+++ b/components/PrimarySourceSetsComponents/SingleSet/SourceSetSources/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { markdown } from "markdown";
+const markdownit = require("markdown-it")({html: true});
 
 import Link from "next/link";
 
@@ -45,7 +45,7 @@ const SourceSetSources = ({ route, sources }) =>
               </div>
               <div
                 className={classNames.title}
-                dangerouslySetInnerHTML={{ __html: markdown.toHTML(name) }}
+                dangerouslySetInnerHTML={{ __html: markdownit.render(name) }}
               />
             </a>
           </Link>

--- a/components/PrimarySourceSetsComponents/SingleSet/TeachersGuide/index.js
+++ b/components/PrimarySourceSetsComponents/SingleSet/TeachersGuide/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 import Link from "next/link";
-import { markdown } from "markdown";
+const markdownit = require("markdown-it")({html: true});
 
 import removeQueryParams from "utilFunctions/removeQueryParams";
 import { GOOGLE_CLASSROOMS_SHARE_URL } from "constants/site";
@@ -20,7 +20,7 @@ const TeachersGuide = ({ route, teachingGuide, setName, currentPath }) =>
           <h2 className={classNames.contentHeader}>Discussion questions</h2>
           <div
             dangerouslySetInnerHTML={{
-              __html: markdown.toHTML(
+              __html: markdownit.render(
                 teachingGuide.hasPart.find(item => item.name === "Questions")
                   .text
               )
@@ -29,7 +29,7 @@ const TeachersGuide = ({ route, teachingGuide, setName, currentPath }) =>
           <h2 className={classNames.contentHeader}>Classroom activities</h2>
           <div
             dangerouslySetInnerHTML={{
-              __html: markdown.toHTML(
+              __html: markdownit.render(
                 teachingGuide.hasPart.find(item => item.name === "Activity")
                   .text
               )
@@ -52,7 +52,7 @@ const TeachersGuide = ({ route, teachingGuide, setName, currentPath }) =>
               <a className={classNames.aboutThisLink}>
                 <span
                   dangerouslySetInnerHTML={{
-                    __html: markdown.toHTML(teachingGuide.isPartOf.name)
+                    __html: markdownit.render(teachingGuide.isPartOf.name)
                   }}
                 />
               </a>

--- a/components/PrimarySourceSetsComponents/Source/components/ContentAndMetadata/index.js
+++ b/components/PrimarySourceSetsComponents/Source/components/ContentAndMetadata/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 import Link from "next/link";
-import { markdown } from "markdown";
+const markdownit = require("markdown-it")({html: true});
 
 import {
   ZoomableImageViewer,
@@ -64,7 +64,7 @@ const ContentAndMetadata = ({ source }) => {
     <div className={classNames.wrapper}>
       <div className={[classNames.contentAndMetadata, container].join(" ")}>
         <h2
-          dangerouslySetInnerHTML={{ __html: markdown.toHTML(source.name) }}
+          dangerouslySetInnerHTML={{ __html: markdownit.render(source.name) }}
           className={classNames.contentHeader}
         />
         <div className={classNames.flexWrapper}>
@@ -75,8 +75,7 @@ const ContentAndMetadata = ({ source }) => {
             {source.text &&
               <div
                 dangerouslySetInnerHTML={{
-                  __html: markdown
-                    .toHTML(source.text)
+                  __html: markdownit.render(source.text)
                     .replace(/&lt;br&gt;/g, "<br>")
                 }}
                 className={classNames.description}
@@ -93,7 +92,7 @@ const ContentAndMetadata = ({ source }) => {
                 <div
                   className={classNames.courtesyOf}
                   dangerouslySetInnerHTML={{
-                    __html: markdown.toHTML(
+                    __html: markdownit.render(
                       source.mainEntity[0]["dct:provenance"].name
                     )
                   }}
@@ -104,7 +103,7 @@ const ContentAndMetadata = ({ source }) => {
                   <p
                     className={classNames.copyrightText}
                     dangerouslySetInnerHTML={{
-                      __html: markdown.toHTML(source.copyright)
+                      __html: markdownit.render(source.copyright)
                     }}
                   />
                 </div>}

--- a/components/PrimarySourceSetsComponents/Source/components/SourceCarousel/CarouselSlider.js
+++ b/components/PrimarySourceSetsComponents/Source/components/SourceCarousel/CarouselSlider.js
@@ -1,7 +1,7 @@
 import React from "react";
 import Slider from "react-slick";
 import Link from "next/link";
-import { markdown } from "markdown";
+const markdownit = require("markdown-it")({html: true});
 
 import NextArrow from "./NextArrow";
 import PrevArrow from "./PrevArrow";
@@ -70,7 +70,7 @@ const CarouselSlider = ({ currentSourceIdx, sources, route }) =>
             </div>
             <div
               className={classNames.itemText}
-              dangerouslySetInnerHTML={{ __html: markdown.toHTML(name) }}
+              dangerouslySetInnerHTML={{ __html: markdownit.render(name) }}
             />
           </a>
         </Link>

--- a/components/PrimarySourceSetsComponents/Source/components/SourceCarousel/index.js
+++ b/components/PrimarySourceSetsComponents/Source/components/SourceCarousel/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 import Link from "next/link";
-import { markdown } from "markdown";
+const markdownit = require("markdown-it")({html: true});
 
 import CarouselSlider from "./CarouselSlider";
 import extractSourceId from "/utilFunctions/extractSourceId";
@@ -33,7 +33,7 @@ const SourceCarousel = ({ sources, set, currentSourceIdx, route }) =>
             }}
           >
             <a
-              dangerouslySetInnerHTML={{ __html: markdown.toHTML(set.name) }}
+              dangerouslySetInnerHTML={{ __html: markdownit.render(set.name) }}
               className={classNames.linkToSourceSet}
             />
           </Link>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "express": "^4.15.4",
     "express-http-proxy": "^1.0.6",
     "lru-cache": "^4.1.1",
-    "markdown": "^0.5.0",
+    "markdown-it": "^8.4.0",
     "next": "^3.0.3",
     "openseadragon": "2.2.1",
     "react": "^15.6.1",

--- a/pages/primary-source-sets/set/additional-resources.js
+++ b/pages/primary-source-sets/set/additional-resources.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { markdown } from "markdown";
+const markdownit = require("markdown-it")({html: true});
 import fetch from "isomorphic-fetch";
 
 import MainLayout from "/components/MainLayout";
@@ -36,7 +36,7 @@ const SingleSet = ({ url, set }) =>
       <div
         className={`${classNames.markdownWrapper} ${container}`}
         dangerouslySetInnerHTML={{
-          __html: markdown.toHTML(
+          __html: markdownit.render(
             set.hasPart.find(item => item.name === "Resources").text
           )
         }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4497,6 +4497,12 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+linkify-it@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.0.3.tgz#d94a4648f9b1c179d64fa97291268bdb6ce9434f"
+  dependencies:
+    uc.micro "^1.0.1"
+
 lint-staged@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-4.0.0.tgz#c15669f598614a6e68090303e175a799d48e0d85"
@@ -4729,11 +4735,15 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
-markdown@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/markdown/-/markdown-0.5.0.tgz#28205b565a8ae7592de207463d6637dc182722b2"
+markdown-it@^8.4.0:
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-8.4.0.tgz#e2400881bf171f7018ed1bd9da441dac8af6306d"
   dependencies:
-    nopt "~2.1.1"
+    argparse "^1.0.7"
+    entities "~1.1.1"
+    linkify-it "^2.0.0"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.3"
 
 masonry-layout@^4.2.0:
   version "4.2.0"
@@ -4791,6 +4801,10 @@ maximatch@^0.1.0:
 md5-file@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/md5-file/-/md5-file-3.1.1.tgz#db3c92c09bbda5c2de883fa5490dd711fddbbab9"
+
+mdurl@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -5129,12 +5143,6 @@ nopt@^4.0.1:
 nopt@~1.0.10:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
-  dependencies:
-    abbrev "1"
-
-nopt@~2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-2.1.2.tgz#6cccd977b80132a07731d6e8ce58c2c8303cf9af"
   dependencies:
     abbrev "1"
 
@@ -7540,6 +7548,10 @@ typedarray@^0.0.6:
 ua-parser-js@^0.7.9:
   version "0.7.13"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.13.tgz#cd9dd2f86493b3f44dbeeef3780fda74c5ee14be"
+
+uc.micro@^1.0.1, uc.micro@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.3.tgz#7ed50d5e0f9a9fb0a573379259f2a77458d50192"
 
 uglify-js@3.0.x:
   version "3.0.20"


### PR DESCRIPTION
changed the markdown parser to one that is more complete and more active: https://github.com/markdown-it/markdown-it

several issues arise from this change that are unrelated to the change itself but to the CSS from the global design as described in the issue comments and reposted here:

- nested lists display with wrong margins
- the design overrides the html native behavior of the unordered list (a list with no numbers, just bullets) imposing numbers where there should be bullets. this means that unordered lists display as ordered lists even though they are not supposed to
- we run into the same issue as with #175 and #258 where links are not consistent. in this case the links _are_ orange but do not have the underline that other links do 

screenshot:

<img width="1032" alt="image" src="https://user-images.githubusercontent.com/133020/31517612-7bd083c8-af6a-11e7-9766-917a5d3b927d.png">
