### PR TITLE
fix: block multimedia downloads

### DIFF
--- a/components/shared/mediaViewers/AudioPlayer.js
+++ b/components/shared/mediaViewers/AudioPlayer.js
@@ -7,6 +7,7 @@ const AudioPlayer = ({ pathToFile, fileFormat }) =>
     <audio
       className={classNames.audioPlayer}
       controls
+      controlsList="nodownload"
       src={pathToFile}
       type={`audio/${fileFormat}`}
     >

--- a/components/shared/mediaViewers/VideoPlayer.js
+++ b/components/shared/mediaViewers/VideoPlayer.js
@@ -7,6 +7,7 @@ const VideoPlayer = ({ pathToFile, fileFormat }) =>
     <video
       className={classNames.videoPlayer}
       controls
+      controlsList="nodownload"
       src={pathToFile}
       type={`video/${fileFormat}`}
     >


### PR DESCRIPTION
fix: added attribute that blocks the download button in the html5 media player in chrome
