### PR TITLE
fix: do not force type to lowercase in schema.org mapping

### DIFF
--- a/components/ItemComponents/Content/JsonLdMarkup.js
+++ b/components/ItemComponents/Content/JsonLdMarkup.js
@@ -29,7 +29,7 @@ const JsonLdMarkup = ({ item, url }) => {
     if (Array.isArray(item.type)) {
       return "CreativeWork"
     } else {
-      switch (item.type.toLowerCase()) {
+      switch (item.type) {
         case "text" : return "TextDigitalDocument"
         case "image" : return "ImageObject"
         case "moving image" : return "VideoObject"
@@ -71,7 +71,7 @@ const JsonLdMarkup = ({ item, url }) => {
     */
   const potentialAction = () => {
     const action = () => {
-      switch (item.type.toLowerCase()) {
+      switch (item.type) {
         case "text" : return "ReadAction";
         case "image" : return "ViewAction";
         case "moving image" : return "WatchAction";


### PR DESCRIPTION
This removes the step that forces the type value to lowercase in the schema.org mapping.  The value should be lowercase anyway, assuming the ingestion is correct.  And this way it won't blow up if we try to call `toLowerCase()` on an undefined `item.type`.