### PR TITLE
fix: change pss created by label

### DIFF
--- a/components/PrimarySourceSetsComponents/SingleSet/SourceSetInfo/index.js
+++ b/components/PrimarySourceSetsComponents/SingleSet/SourceSetInfo/index.js
@@ -85,7 +85,7 @@ class SourceSetInfo extends React.Component {
             <div className={classNames.sidebar}>
               <div className={classNames.metadata}>
                 <div className={classNames.metadatum}>
-                  <h3 className={classNames.metadataHeader}>Prepared By</h3>
+                  <h3 className={classNames.metadataHeader}>Created By</h3>
                   {set.author.map(author =>
                     <div
                       key={author.name}

--- a/components/PrimarySourceSetsComponents/SingleSet/TeachersGuide/index.js
+++ b/components/PrimarySourceSetsComponents/SingleSet/TeachersGuide/index.js
@@ -78,7 +78,7 @@ const TeachersGuide = ({ route, teachingGuide, setName, currentPath }) =>
             " "
           )}
         >
-          <h3 className={classNames.sidebarHeader}>Prepared By</h3>
+          <h3 className={classNames.sidebarHeader}>Created By</h3>
           {teachingGuide.author.map(author =>
             <div
               className={classNames.sidebarSection}


### PR DESCRIPTION
This changes the authorship label for primary source sets and guides from "Prepared by" to "Created by".  This has been tested locally.  It addresses https://trello.com/c/4Zu7Np8T/165-pss-change-prepared-by-to-created-by-for-set-and-teaching-guide-authors