### PR TITLE
Change route of thumbnail proxy endpoint

### DIFF
--- a/constants/items.js
+++ b/constants/items.js
@@ -1,2 +1,2 @@
 export const API_ENDPOINT = "/api/dpla/items";
-export const THUMBNAIL_ENDPOINT = "/api/assets";
+export const THUMBNAIL_ENDPOINT = "/thumb";

--- a/server.js
+++ b/server.js
@@ -330,10 +330,10 @@ app
     );
 
     server.get(
-      "/api/assets/*",
+      "/thumb/*",
       proxy(process.env.THUMB_SERVER, {
         proxyReqPathResolver: function(req) {
-          return req.url.replace("/api/assets", "/thumb");
+          return req.url;
         }
       })
     );


### PR DESCRIPTION
Change thumbnail endpoint from `/api/assets/*` to `/thumb`. It's not an API endpoint and we will have an easier time hosting the thumbnail proxy in production vs staging if it's named `/thumb`. It will be possible for it to overlay better with our Nginx caching reverse-proxy in a production setting, where the the CDN can hit the Nginx cache more directly. In staging with no CDN out in front it will still work for the `dpla-frontend` endpoint to be named `thumb`.

Just let me know if any of this is unclear.
