### PR TITLE
fix: pss header text overflows

### DIFF
--- a/components/PrimarySourceSetsComponents/SingleSet/ResourcesTabs/ResourcesTabs.css
+++ b/components/PrimarySourceSetsComponents/SingleSet/ResourcesTabs/ResourcesTabs.css
@@ -14,7 +14,7 @@
   background-color: visualBrown;
   width: 100%;
   border-bottom: 1px solid rgba(53, 53, 53, 0.1);
-  margin-bottom: 2rem;
+  margin-bottom: 1rem;
 }
 
 .tabs {

--- a/components/PrimarySourceSetsComponents/SingleSet/ResourcesTabs/index.js
+++ b/components/PrimarySourceSetsComponents/SingleSet/ResourcesTabs/index.js
@@ -22,7 +22,10 @@ class ResourcesTabs extends React.Component {
                   currentTab === "sourceSet" && classNames.activeTab
                 ].join(" ")}
               >
-                <span className={classNames.hideOnSmallScreen}>Source </span>{" "}Set
+                <span className={classNames.hideOnSmallScreen}>
+                  Source{" "}
+                </span>{" "}
+                Set
               </a>
             </Link>
             <Link
@@ -40,10 +43,11 @@ class ResourcesTabs extends React.Component {
               >
                 <span className={classNames.hideOnSmallScreen}>
                   Additional
-                </span>{" "}Resources
+                </span>{" "}
+                Resources
               </a>
             </Link>
-            {!route.query.studentMode &&
+            {!route.query.studentMode && (
               <Link
                 prefetch
                 href={`/primary-source-sets/set/teaching-guide?set=${route.query
@@ -58,7 +62,8 @@ class ResourcesTabs extends React.Component {
                 >
                   Teaching Guide
                 </a>
-              </Link>}
+              </Link>
+            )}
           </div>
         </div>
         {this.props.children}

--- a/components/PrimarySourceSetsComponents/SingleSet/SourceSetInfo/SourceSetInfo.css
+++ b/components/PrimarySourceSetsComponents/SingleSet/SourceSetInfo/SourceSetInfo.css
@@ -1,5 +1,5 @@
 @value visualBrown, bambooOrange, cranberry, softPeach, iceBlue, curiousBlue, cascadeBlue from "../../../../css/colors.css";
-@value smallRem, mediumRem from "../../../../css/breakpoints.css";
+@value smallRem, mediumRem, largeRem from "../../../../css/breakpoints.css";
 
 .wrapper {
   width: 100%;
@@ -7,27 +7,15 @@
 }
 
 .sourceSetInfo {
-  padding-top: 0;
-  padding-right: 0;
-  padding-left: 0;
-  padding-bottom: 0.75rem;
-  display: flex;
-  flex-direction: column;
-  @media (min-width: smallRem) {
-    padding-bottom: 82px;
-    padding-top: 23px;
-    padding-left: 1rem;
-    padding-right: 1rem;
-  }
-  @media (min-width: mediumRem) {
-    flex-direction: row;
-  }
-}
+  padding: 0 0 2rem 0;
 
-.bannerAndDescription {
-  flex-basis: 70%;
   @media (min-width: smallRem) {
-    padding-right: 18px;
+    padding: 1.5rem 1rem 3rem;
+  }
+
+  @media (min-width: largeRem) {
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -42,10 +30,11 @@
 
 .bannerImage {
   width: 100%;
-  padding-top: 32%;
+  padding-top: 42%;
   opacity: 0.95;
   background-size: cover;
   background-repeat: no-repeat;
+
   @media (min-width: smallRem) {
     border-radius: 3px;
   }
@@ -53,27 +42,23 @@
 
 .bannerTextWrapper {
   background: linear-gradient(180deg, rgba(54, 44, 36, 0) 0%, #312921 100%);
-  position: absolute;
-  bottom: 0;
-  width: 100%;
   color: white;
-  padding: 0 0 11px 1rem;
-  @media (min-width: smallRem) {
-    padding: 0 0 11px 22px;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  justify-content: flex-end;
+  padding: 1rem;
+  position: absolute;
+  top: 0;
+
+  @media (min-width: mediumRem) {
+    padding: 1.5rem;
     border-radius: 3px;
   }
-}
 
-.bannerResourceType {
-  text-transform: uppercase;
-  padding-right: 18px;
-  font-size: 0.875rem;
-  font-weight: bold;
-  opacity: 0.85;
-  margin-bottom: 1px;
-  color: white;
-  @media (min-width: smallRem) {
-    font-size: 1rem;
+  @media (min-width: largeRem) {
+    padding: 2rem;
   }
 }
 
@@ -82,11 +67,14 @@
   font-weight: normal;
   font-size: 1.5rem;
   color: white;
+  line-height: 1.1;
+
   @media (min-width: smallRem) {
     font-size: 2rem;
   }
-  @media (min-width: mediumRem) {
-    font-size: 2.875rem;
+
+  @media (min-width: largeRem) {
+    font-size: 2.5rem;
   }
 }
 
@@ -115,21 +103,17 @@
   margin-bottom: 0;
 }
 
-.sidebarWrapper {
-  padding: 0 1rem;
-  @media (min-width: smallRem) {
-    padding: 0;
-  }
-}
-
 .sidebar {
-  width: 100%;
   border: 1px solid #E7E7E7;
   background-color: white;
-  padding: 19px 20px 26px;
-  flex: 1;
+  padding: 1rem 1rem 1.5rem;
+  margin: 0 1rem;
   border-radius: 3px;
   align-self: baseline;
+
+  @media (min-width: smallRem) {
+    margin: 0;
+  }
 }
 
 .metadata {
@@ -154,18 +138,8 @@
   width: 100%;
 }
 
-.shareButton {
-
-}
-
 .citeButton {
   margin-bottom: 0.5rem;
-}
-
-.favoritesButton {
-  background-color: softPeach;
-  color: cranberry;
-  margin-bottom: 15px;
 }
 
 .link p {
@@ -174,52 +148,4 @@
 
 .comma {
   color: bambooOrange;
-}
-
-.heart {
-  width: 16px;
-  height: 14px;
-  margin-right: 9px;
-  position: relative;
-  top: 1px;
-}
-
-.hideDetailsWrapper {
-  padding-top: 0.5rem;
-  margin-top: 1rem;
-  border-top: 1px solid rgba(0, 0, 0, 0.1);
-  width: 100%;
-  margin-bottom: 1.25rem;
-  @media (min-width: smallRem) {
-    display: none;
-    visibility: hidden;
-  }
-}
-
-.hideDetailsButton {
-  color: cascadeBlue;
-  font-size: 0.875rem;
-  font-weight: 600;
-  margin: auto;
-  display: flex;
-  align-items: center;
-}
-
-.hiddenOnSmallScreens {
-  display: none;
-  visibility: hidden;
-  @media (min-width: smallRem) {
-    display: inherit;
-    visibility: visible;
-  }
-  & ~ .hideDetailsWrapper .chevron {
-    transform: rotate(90deg);
-  }
-}
-
-.chevron {
-  transform: rotate(-90deg);
-  width: 7px;
-  height: 12px;
-  margin-left: 0.5rem;
 }

--- a/components/PrimarySourceSetsComponents/SingleSet/SourceSetInfo/index.js
+++ b/components/PrimarySourceSetsComponents/SingleSet/SourceSetInfo/index.js
@@ -10,167 +10,129 @@ import {
 import ShareButton from "components/shared/ShareButton";
 import Button from "components/shared/Button";
 
-const chevron = "/static/images/chevron-thick-cascade-blue.svg";
 const markdownit = require("markdown-it")({ html: true });
 const { container } = utilClassNames;
 
-// only the time period has a sameAs field
+// Only the time period has a sameAs field
 const extractTimePeriod = tags =>
   tags.filter(tag => tag.sameAs).map(tag => tag.name);
 const extractSubjects = tags =>
   tags.filter(tag => !tag.sameAs).map(tag => tag.name);
 
 class SourceSetInfo extends React.Component {
-  state = {
-    hideDetailsOnSmallScreens: true
-  };
-
-  toggleHideDetails = () => {
-    this.setState(
-      {
-        hideDetailsOnSmallScreens: !this.state.hideDetailsOnSmallScreens
-      },
-      () => {
-        if (this.state.hideDetailsOnSmallScreens) {
-          document.documentElement.scrollTop = 0;
-        }
-      }
-    );
-  };
-
   render() {
     const { set, currentFullUrl } = this.props;
     return (
       <div className={classNames.wrapper}>
         <div className={[classNames.sourceSetInfo, container].join(" ")}>
-          <div className={classNames.bannerAndDescription}>
-            <div className={classNames.banner}>
+          <div className="row">
+            <div className="col-xs-12 col-md-8">
+              <div className={classNames.banner}>
+                <div
+                  className={classNames.bannerImage}
+                  style={{
+                    backgroundImage: `url(${set.repImageUrl ||
+                      set.thumbnailUrl})`
+                  }}
+                />
+                <div className={classNames.bannerTextWrapper}>
+                  <h1
+                    dangerouslySetInnerHTML={{
+                      __html: markdownit.render(set.name)
+                    }}
+                    className={classNames.bannerTitle}
+                  />
+                </div>
+              </div>
+              {/* TODO: shouldn't have to get rid of the extra text with split */}
               <div
-                className={classNames.bannerImage}
-                style={{
-                  backgroundImage: `url(${set.thumbnailUrl})`
+                className={classNames.description}
+                dangerouslySetInnerHTML={{
+                  __html: markdownit.render(
+                    set.hasPart.find(item => item.name === "Overview").text
+                  )
                 }}
               />
-              <div className={classNames.bannerTextWrapper}>
-                <h3 className={classNames.bannerResourceType}>
-                  Primary Source Set
-                </h3>
-                <h1
-                  dangerouslySetInnerHTML={{
-                    __html: markdownit.render(set.name)
-                  }}
-                  className={classNames.bannerTitle}
+            </div>
+            <div className="col-xs-12 col-md-4">
+              <div className={classNames.sidebar}>
+                <div className={classNames.metadata}>
+                  <div className={classNames.metadatum}>
+                    <h3 className={classNames.metadataHeader}>Created By</h3>
+                    {set.author.map(author => (
+                      <div
+                        key={author.name}
+                        dangerouslySetInnerHTML={{
+                          __html: markdownit.render(
+                            author.name + ", " + author.affiliation.name
+                          )
+                        }}
+                      />
+                    ))}
+                  </div>
+                  <div className={classNames.metadatum}>
+                    <h3 className={classNames.metadataHeader}>Time Period</h3>
+                    {extractTimePeriod(set.about).map((period, i, periods) => (
+                      <span key={period}>
+                        <Link
+                          prefetch
+                          href={{
+                            pathname: "/primary-source-sets",
+                            query: {
+                              timePeriod: mapTimePeriodNameToSlug(period)
+                            }
+                          }}
+                        >
+                          <a
+                            className={`link ${classNames.link}`}
+                            dangerouslySetInnerHTML={{
+                              __html: markdownit.render(period)
+                            }}
+                          />
+                        </Link>
+                        {i < periods.length - 1 && <br />}
+                      </span>
+                    ))}
+                  </div>
+                  <div className={classNames.metadatum}>
+                    <h3 className={classNames.metadataHeader}>Subjects</h3>
+                    {extractSubjects(set.about).map((subject, i, subjects) => (
+                      <span key={subject}>
+                        <Link
+                          prefetch
+                          href={{
+                            pathname: "/primary-source-sets",
+                            query: {
+                              subject: mapSubjectNameToSlug(subject)
+                            }
+                          }}
+                        >
+                          <a
+                            className={`link ${classNames.link}`}
+                            dangerouslySetInnerHTML={{
+                              __html: markdownit.render(subject)
+                            }}
+                          />
+                        </Link>
+                        {i < subjects.length - 1 && <br />}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+                <Button
+                  type="ghost"
+                  className={`${classNames.button} ${classNames.citeButton}`}
+                >
+                  Cite this set
+                </Button>
+                <ShareButton
+                  toShareText="set"
+                  title={set.name}
+                  currentFullUrl={currentFullUrl}
+                  className={`${classNames.button} ${classNames.shareButton}`}
                 />
               </div>
             </div>
-            {/* TODO: shouldn't have to get rid of the extra text with split */}
-            <div
-              className={`${classNames.description} ${this.state
-                .hideDetailsOnSmallScreens
-                ? classNames.hiddenOnSmallScreens
-                : ""}`}
-              dangerouslySetInnerHTML={{
-                __html: markdownit.render(
-                  set.hasPart.find(item => item.name === "Overview").text
-                )
-              }}
-            />
-          </div>
-          <div
-            className={`${classNames.sidebarWrapper} ${this.state
-              .hideDetailsOnSmallScreens
-              ? classNames.hiddenOnSmallScreens
-              : ""}`}
-          >
-            <div className={classNames.sidebar}>
-              <div className={classNames.metadata}>
-                <div className={classNames.metadatum}>
-                  <h3 className={classNames.metadataHeader}>Created By</h3>
-                  {set.author.map(author =>
-                    <div
-                      key={author.name}
-                      dangerouslySetInnerHTML={{
-                        __html: markdownit.render(
-                          author.name + ", " + author.affiliation.name
-                        )
-                      }}
-                    />
-                  )}
-                </div>
-                <div className={classNames.metadatum}>
-                  <h3 className={classNames.metadataHeader}>Time Period</h3>
-                  {extractTimePeriod(set.about).map((period, i, periods) =>
-                    <span key={period}>
-                      <Link
-                        prefetch
-                        href={{
-                          pathname: "/primary-source-sets",
-                          query: {
-                            timePeriod: mapTimePeriodNameToSlug(period)
-                          }
-                        }}
-                      >
-                        <a
-                          className={`link ${classNames.link}`}
-                          dangerouslySetInnerHTML={{
-                            __html: markdownit.render(period)
-                          }}
-                        />
-                      </Link>
-                      {i < periods.length - 1 && <br />}
-                    </span>
-                  )}
-                </div>
-                <div className={classNames.metadatum}>
-                  <h3 className={classNames.metadataHeader}>Subjects</h3>
-                  {extractSubjects(set.about).map((subject, i, subjects) =>
-                    <span key={subject}>
-                      <Link
-                        prefetch
-                        href={{
-                          pathname: "/primary-source-sets",
-                          query: {
-                            subject: mapSubjectNameToSlug(subject)
-                          }
-                        }}
-                      >
-                        <a
-                          className={`link ${classNames.link}`}
-                          dangerouslySetInnerHTML={{
-                            __html: markdownit.render(subject)
-                          }}
-                        />
-                      </Link>
-                      {i < subjects.length - 1 && <br />}
-                    </span>
-                  )}
-                </div>
-              </div>
-              <Button
-                type="ghost"
-                className={`${classNames.button} ${classNames.citeButton}`}
-              >
-                Cite this set
-              </Button>
-              <ShareButton
-                toShareText="set"
-                title={set.name}
-                currentFullUrl={currentFullUrl}
-                className={`${classNames.button} ${classNames.shareButton}`}
-              />
-            </div>
-          </div>
-          <div className={classNames.hideDetailsWrapper}>
-            <button
-              onClick={() => this.toggleHideDetails()}
-              className={classNames.hideDetailsButton}
-            >
-              <span>
-                {this.state.hideDetailsOnSmallScreens ? "Show" : "Hide"} Full
-                Description and Details
-              </span>
-              <img src={chevron} alt="" className={classNames.chevron} />
-            </button>
           </div>
         </div>
         <style dangerouslySetInnerHTML={{ __html: stylesheet }} />

--- a/components/PrimarySourceSetsComponents/SingleSet/SourceSetSources/SourceSetSources.css
+++ b/components/PrimarySourceSetsComponents/SingleSet/SourceSetSources/SourceSetSources.css
@@ -1,11 +1,14 @@
 @value visualBrown from "../../../../css/colors.css";
-@value xSmallRem, smallRem from "../../../../css/breakpoints.css";
+@value xSmallRem, smallRem, largeRem from "../../../../css/breakpoints.css";
 
 .sourceSetSources {
   display: flex;
   flex-wrap: wrap;
   margin-bottom: 4rem;
-  margin-top: 3rem;
+
+  @media (min-width: largeRem) {
+    margin-top: 3rem;
+  }
 }
 
 .set {

--- a/components/PrimarySourceSetsComponents/SingleSet/TeachersGuide/TeachersGuide.css
+++ b/components/PrimarySourceSetsComponents/SingleSet/TeachersGuide/TeachersGuide.css
@@ -1,29 +1,37 @@
 @value elephantBlue, hippieBlue, curiousBlue, visualBrown, bambooOrange from "../../../../css/colors.css";;
-@value mediumRem from "../../../../css/breakpoints.css";;
+@value mediumRem, smallRem, largeRem from "../../../../css/breakpoints.css";;
 
 .wrapper {
   width: 100%;
 }
 
 .teachingGuide {
-  display: flex;
-  flex-direction: column-reverse;
+  /*flex-direction: column-reverse;
+
   @media (min-width: mediumRem) {
     flex-direction: row;
-  }
+  }*/
 }
 
 .content {
   @media (min-width: mediumRem) {
-    margin-right: 73px;
+    margin-bottom: 2rem;
+  }
+
+  @media (min-width: largeRem) {
+    margin-top: 2rem;
+    margin-bottom: 4rem;
   }
 }
 
 .sidebar {
   font-size: 0.875rem;
   line-height: 1.125rem;
-  width: 295px;
-  flex-shrink: 0;
+  margin-top: 1rem;
+
+  @media (min-width: smallRem) {
+    margin-top: 2rem;
+  }
 }
 
 .sidebarHeader {
@@ -34,11 +42,11 @@
 }
 
 .sidebarSection {
-  margin-bottom: 22px;
+  margin-bottom: 1.5rem;
 }
 
 .teacherTools {
-  padding-bottom: 22px;
+  padding-bottom: 1.5rem;
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
 }
 

--- a/components/PrimarySourceSetsComponents/SingleSet/TeachersGuide/index.js
+++ b/components/PrimarySourceSetsComponents/SingleSet/TeachersGuide/index.js
@@ -1,6 +1,5 @@
 import React from "react";
 import Link from "next/link";
-const markdownit = require("markdown-it")({ html: true });
 
 import removeQueryParams from "utilFunctions/removeQueryParams";
 import { GOOGLE_CLASSROOMS_SHARE_URL } from "constants/site";
@@ -11,180 +10,186 @@ import {
 } from "css/pages/content-pages-wysiwyg.css";
 import { classNames as utilClassNames } from "css/utils.css";
 
+const markdownit = require("markdown-it")({ html: true });
 const { container } = utilClassNames;
 const printer = "/static/images/printer.svg";
 const link = "/static/images/link.svg";
 const googleClassroom = "/static/images/google-classroom.svg";
 
-const TeachersGuide = ({ route, teachingGuide, setName, currentPath }) =>
+const TeachersGuide = ({ route, teachingGuide, setName, currentPath }) => (
   <div className={classNames.wrapper}>
-    <div className={[classNames.teachingGuide, container].join(" ")}>
-      <div className={classNames.content}>
-        <div className={contentClasses.content}>
-          <h3>Discussion questions</h3>
-          <div
-            dangerouslySetInnerHTML={{
-              __html: markdownit.render(
-                teachingGuide.hasPart
-                  .find(item => item.name === "Questions")
-                  .text.replace(
-                    /(http|https):\/\/dp.la\/primary-source-sets\//,
-                    ""
+    <div className={`${classNames.teachingGuide} ${container}`}>
+      <div className="row">
+        <div className="col-xs-12 col-md-8">
+          <div className={classNames.content}>
+            <div className={contentClasses.content}>
+              <h3>Discussion questions</h3>
+              <div
+                dangerouslySetInnerHTML={{
+                  __html: markdownit.render(
+                    teachingGuide.hasPart
+                      .find(item => item.name === "Questions")
+                      .text.replace(
+                        /(http|https):\/\/dp.la\/primary-source-sets\//,
+                        ""
+                      )
                   )
-              )
-            }}
-          />
-          <h3>Classroom activities</h3>
-          <div
-            dangerouslySetInnerHTML={{
-              __html: markdownit.render(
-                teachingGuide.hasPart.find(item => item.name === "Activity")
-                  .text
-              )
-            }}
-          />
-        </div>
-        <div className={classNames.aboutThis}>
-          <h3 className={classNames.aboutThisHeader}>About This Guide</h3>
-          <div>
-            This teaching guide helps instructors use a specific primary source
-            set,{" "}
-            <Link
-              prefetch
-              href={{ pathname: route.pathname, query: route.query }}
-              as={{
-                pathname: `/primary-source-sets/${route.query.set}`,
-                query: removeQueryParams(route.query, ["set"])
-              }}
-            >
-              <a className={`link ${classNames.aboutThisLink}`}>
-                <span
-                  dangerouslySetInnerHTML={{
-                    __html: markdownit.render(teachingGuide.isPartOf.name)
+                }}
+              />
+              <h3>Classroom activities</h3>
+              <div
+                dangerouslySetInnerHTML={{
+                  __html: markdownit.render(
+                    teachingGuide.hasPart.find(item => item.name === "Activity")
+                      .text
+                  )
+                }}
+              />
+            </div>
+            <div className={classNames.aboutThis}>
+              <h3 className={classNames.aboutThisHeader}>About This Guide</h3>
+              <div>
+                This teaching guide helps instructors use a specific primary source
+                set,{" "}
+                <Link
+                  prefetch
+                  href={{ pathname: route.pathname, query: route.query }}
+                  as={{
+                    pathname: `/primary-source-sets/${route.query.set}`,
+                    query: removeQueryParams(route.query, ["set"])
                   }}
-                />
-              </a>
-            </Link>, in the classroom. It offers discussion questions, classroom
-            activities, and primary source analysis tools. It is intended to
-            spark pedagogical creativity by giving a sample approach to the
-            material. Please feel free to share, reuse, and adapt the resources
-            in this guide for your teaching purposes.
+                >
+                  <a className={`link ${classNames.aboutThisLink}`}>
+                    <span
+                      dangerouslySetInnerHTML={{
+                        __html: markdownit.render(teachingGuide.isPartOf.name)
+                      }}
+                    />
+                  </a>
+                </Link>, in the classroom. It offers discussion questions, classroom
+                activities, and primary source analysis tools. It is intended to
+                spark pedagogical creativity by giving a sample approach to the
+                material. Please feel free to share, reuse, and adapt the resources
+                in this guide for your teaching purposes.
+              </div>
+            </div>
           </div>
         </div>
-      </div>
-      <div className={classNames.sidebar}>
-        <div
-          className={[classNames.teacherTools, classNames.sidebarSection].join(
-            " "
-          )}
-        >
-          <h3 className={classNames.sidebarHeader}>Created By</h3>
-          {teachingGuide.author.map(author =>
-            <div
-              className={classNames.sidebarSection}
-              dangerouslySetInnerHTML={{
-                __html: markdownit.render(
-                  author.name + ", " + author.affiliation.name
-                )
-              }}
-            />
-          )}
-          <h3 className={classNames.sidebarHeader}>Teacher Tools</h3>
-          <div className={classNames.toolLinkAndIcon}>
-            <img src={googleClassroom} alt="" className={classNames.toolIcon} />
-            <a
-              href={`${GOOGLE_CLASSROOMS_SHARE_URL}?url=${currentPath
-                ? currentPath
-                : window.location.href.replace("teaching-guide", "")}`}
-              className={classNames.toolLink}
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Share to Google Classroom
-            </a>
-          </div>
-          <div className={classNames.toolLinkAndIcon}>
-            <img src={printer} alt="" className={classNames.toolIcon} />
-            <Link prefetch href="">
-              <a className={classNames.toolLink}>Print this Guide</a>
-            </Link>
-          </div>
-          <div className={classNames.toolLinkAndIcon}>
-            <img src={link} alt="" className={classNames.toolIcon} />
-            <Link
-              prefetch
-              href={{
-                pathname: `/primary-source-sets/set`,
-                query: Object.assign({}, route.query, { studentMode: true })
-              }}
-              as={{
-                pathname: `/primary-source-sets/${route.query.set}`,
-                query: Object.assign(
-                  {},
-                  removeQueryParams(route.query, ["set"]),
-                  { studentMode: true }
-                )
-              }}
-            >
-              <a className={classNames.toolLink}>Link to Student View</a>
-            </Link>
-          </div>
-          <p className={classNames.studentViewNote}>
-            <span className={classNames.semibold}>Student View</span> is a link
-            to this Primary Source Set with the Teaching Guide hidden.
-          </p>
-        </div>
-        <div className={classNames.sidebarSection}>
-          <h3 className={classNames.sidebarHeader}>Primary source analysis</h3>
-          <p>For each source, ask students to indicate:</p>
-          <ul className={classNames.ul}>
-            <li>the author's point of view</li>
-            <li>the author's purpose</li>
-            <li>historical context</li>
-            <li>audience</li>
-          </ul>
-          <p>For inquiry-based learning, ask students to:</p>
-          <ul className={classNames.ul}>
-            <li>
-              explain how a source tells its story and/or makes its argument
-            </li>
-            <li>explain the relationships between sources</li>
-            <li>
-              compare and contrast sources in terms of point of view and method
-            </li>
-            <li>support conclusions and interpretations with evidence</li>
-            <li>identify questions for further investigation</li>
-          </ul>
-        </div>
-        <div className={classNames.sidebarSection}>
-          <h3 className={classNames.sidebarHeader}>Additional tools</h3>
-          <ul className={classNames.ul}>
-            <li className={classNames.additionalToolWrapper}>
+        <div className={`col-xs-12 col-md-4 ${classNames.sidebar}`}>
+          <div
+            className={[classNames.teacherTools, classNames.sidebarSection].join(
+              " "
+            )}
+          >
+            <h3 className={classNames.sidebarHeader}>Created By</h3>
+            {teachingGuide.author.map(author => (
+              <div
+                className={classNames.sidebarSection}
+                dangerouslySetInnerHTML={{
+                  __html: markdownit.render(
+                    author.name + ", " + author.affiliation.name
+                  )
+                }}
+              />
+            ))}
+            <h3 className={classNames.sidebarHeader}>Teacher Tools</h3>
+            <div className={classNames.toolLinkAndIcon}>
+              <img src={googleClassroom} alt="" className={classNames.toolIcon} />
               <a
-                className="link"
-                href="https://www.archives.gov/education/lessons/worksheets"
-                target="_blank"
+                href={`${GOOGLE_CLASSROOMS_SHARE_URL}?url=${currentPath
+                  ? currentPath
+                  : window.location.href.replace("teaching-guide", "")}`}
+                className={classNames.toolLink}
                 rel="noopener noreferrer"
-              >
-                Document Analysis Worksheets from the National Archives
-              </a>
-            </li>
-            <li className={classNames.additionalToolWrapper}>
-              <a
-                className="link"
-                href="https://www.loc.gov/teachers/usingprimarysources/"
                 target="_blank"
-                rel="noopener noreferrer"
               >
-                Using Primary Sources from the Library of Congress
+                Share to Google Classroom
               </a>
-            </li>
-          </ul>
+            </div>
+            <div className={classNames.toolLinkAndIcon}>
+              <img src={printer} alt="" className={classNames.toolIcon} />
+              <Link prefetch href="">
+                <a className={classNames.toolLink}>Print this Guide</a>
+              </Link>
+            </div>
+            <div className={classNames.toolLinkAndIcon}>
+              <img src={link} alt="" className={classNames.toolIcon} />
+              <Link
+                prefetch
+                href={{
+                  pathname: `/primary-source-sets/set`,
+                  query: Object.assign({}, route.query, { studentMode: true })
+                }}
+                as={{
+                  pathname: `/primary-source-sets/${route.query.set}`,
+                  query: Object.assign(
+                    {},
+                    removeQueryParams(route.query, ["set"]),
+                    { studentMode: true }
+                  )
+                }}
+              >
+                <a className={classNames.toolLink}>Link to Student View</a>
+              </Link>
+            </div>
+            <p className={classNames.studentViewNote}>
+              <span className={classNames.semibold}>Student View</span> is a link
+              to this Primary Source Set with the Teaching Guide hidden.
+            </p>
+          </div>
+          <div className={classNames.sidebarSection}>
+            <h3 className={classNames.sidebarHeader}>Primary source analysis</h3>
+            <p>For each source, ask students to indicate:</p>
+            <ul className={classNames.ul}>
+              <li>the author's point of view</li>
+              <li>the author's purpose</li>
+              <li>historical context</li>
+              <li>audience</li>
+            </ul>
+            <p>For inquiry-based learning, ask students to:</p>
+            <ul className={classNames.ul}>
+              <li>
+                explain how a source tells its story and/or makes its argument
+              </li>
+              <li>explain the relationships between sources</li>
+              <li>
+                compare and contrast sources in terms of point of view and method
+              </li>
+              <li>support conclusions and interpretations with evidence</li>
+              <li>identify questions for further investigation</li>
+            </ul>
+          </div>
+          <div className={classNames.sidebarSection}>
+            <h3 className={classNames.sidebarHeader}>Additional tools</h3>
+            <ul className={classNames.ul}>
+              <li className={classNames.additionalToolWrapper}>
+                <a
+                  className="link"
+                  href="https://www.archives.gov/education/lessons/worksheets"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Document Analysis Worksheets from the National Archives
+                </a>
+              </li>
+              <li className={classNames.additionalToolWrapper}>
+                <a
+                  className="link"
+                  href="https://www.loc.gov/teachers/usingprimarysources/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Using Primary Sources from the Library of Congress
+                </a>
+              </li>
+            </ul>
+          </div>
         </div>
       </div>
     </div>
     <style dangerouslySetInnerHTML={{ __html: stylesheet }} />
     <style dangerouslySetInnerHTML={{ __html: contentStyles }} />
-  </div>;
+  </div>
+);
 
 export default TeachersGuide;

--- a/css/pages/content-pages-wysiwyg.css
+++ b/css/pages/content-pages-wysiwyg.css
@@ -85,16 +85,25 @@
   & ul,
   & ol {
     margin-bottom: 1.5rem;
-    font-size: 1.125rem;
     font-weight: normal;
     opacity: 0.85;
+    font-size: 1rem;
+
+    @media (min-width: mediumRem) {
+      font-size: 1.125rem;
+    }
 
     @media (min-width: largeRem) {
       margin-bottom: 1.75rem;
     }
   }
 
-  & ol li {
+  & ul, & ol {
+    padding-left: 1.125rem;
+  }
+
+  & ol li,
+  & ul li {
     position: relative;
     padding-left: 0.75rem;
   }
@@ -105,15 +114,6 @@
 
   & ul {
     list-style-type: disc;
-  }
-
-  & ul, & ol {
-    padding-left: 1.125rem;
-  }
-
-  & ul li {
-    position: relative;
-    padding-left: 0.75rem;
   }
 
   & table {

--- a/pages/primary-source-sets/set/additional-resources.js
+++ b/pages/primary-source-sets/set/additional-resources.js
@@ -1,5 +1,4 @@
 import React from "react";
-const markdownit = require("markdown-it")({ html: true });
 import fetch from "isomorphic-fetch";
 
 import MainLayout from "/components/MainLayout";
@@ -18,6 +17,8 @@ import {
   stylesheet as contentStyles
 } from "css/pages/content-pages-wysiwyg.css";
 import { classNames as utilClassNames } from "css/utils.css";
+
+const markdownit = require("markdown-it")({ html: true });
 const { container } = utilClassNames;
 
 const SingleSet = ({ url, set }) =>
@@ -37,14 +38,18 @@ const SingleSet = ({ url, set }) =>
     />
     <SourceSetInfo set={set} />
     <ResourcesTabs route={url} currentTab="additionalResources" set={set}>
-      <div
-        className={`${contentClasses.content} ${container}`}
-        dangerouslySetInnerHTML={{
-          __html: markdownit.render(
-            set.hasPart.find(item => item.name === "Resources").text
-          )
-        }}
-      />
+      <div className={classNames.content}>
+        <div className={container}>
+          <div
+            className={`${contentClasses.content} ${container}`}
+            dangerouslySetInnerHTML={{
+              __html: markdownit.render(
+                set.hasPart.find(item => item.name === "Resources").text
+              )
+            }}
+          />
+        </div>
+      </div>
     </ResourcesTabs>
     <PSSFooter />
     <style dangerouslySetInnerHTML={{ __html: stylesheet }} />


### PR DESCRIPTION
Fixes overflows of long text for PSS headers. Also cleans up typography on the Teacher's Guides.

<img width="1090" alt="screen shot 2017-10-24 at 5 15 29 pm" src="https://user-images.githubusercontent.com/1767309/31968405-ff79fb28-b8de-11e7-8cb3-1b4da7b96a0e.png">

---

<img width="1099" alt="screen shot 2017-10-24 at 5 16 51 pm" src="https://user-images.githubusercontent.com/1767309/31968461-2ec0af76-b8df-11e7-98b0-e9b038cd6054.png">


fixes https://github.com/postlight/dpla-frontend/issues/50