### PR TITLE
feat: consistent link hover styles for PSS and next/previous item

### DIFF
--- a/components/ItemComponents/BreadcrumbsModule/index.js
+++ b/components/ItemComponents/BreadcrumbsModule/index.js
@@ -42,9 +42,11 @@ const PreviousItemLink = ({ query, searchItemCount, paginationInfo }) => {
         }
       }}
     >
-      <a className={classNames.previousItemButton}>
+      <a className={`${classNames.previousItemButton} hover-underline`}>
         <img src={chevron} alt="" className={classNames.previousChevron} />
-        <span>Previous <span className={classNames.hideOnSmallScreens}>Item</span></span>
+        <span>
+          Previous <span className={classNames.hideOnSmallScreens}>Item</span>
+        </span>
       </a>
     </Link>
   );
@@ -79,8 +81,10 @@ const NextItemLink = ({ query, searchItemCount, paginationInfo }) => {
         }
       }}
     >
-      <a className={classNames.nextItemButton}>
-        <span>Next <span className={classNames.hideOnSmallScreens}>Item</span></span>
+      <a className={`${classNames.nextItemButton} hover-underline`}>
+        <span>
+          Next <span className={classNames.hideOnSmallScreens}>Item</span>
+        </span>
         <img src={chevron} alt="" className={classNames.nextChevron} />
       </a>
     </Link>
@@ -92,7 +96,7 @@ const BreadcrumbsModule = ({
   breadcrumbs,
   searchItemCount,
   paginationInfo
-}) =>
+}) => (
   <div className={classNames.wrapper}>
     <div className={[container, classNames.breadcrumbsModule].join(" ")}>
       <Breadcrumbs
@@ -102,25 +106,29 @@ const BreadcrumbsModule = ({
           })
         )}
       />
-      {(route.query.previous >= 0 || route.query.next) &&
-        <div className={classNames.navButtonsWrapper}>
-          {route.query.previous &&
-            route.query.previous >= 0 &&
-            <PreviousItemLink
-              query={route.query}
-              searchItemCount={searchItemCount}
-              paginationInfo={paginationInfo}
-            />}
-          {route.query.next &&
-            route.query.next < searchItemCount &&
-            <NextItemLink
-              query={route.query}
-              searchItemCount={searchItemCount}
-              paginationInfo={paginationInfo}
-            />}
-        </div>}
+      {(route.query.previous >= 0 || route.query.next) && (
+          <div className={classNames.navButtonsWrapper}>
+            {route.query.previous &&
+              route.query.previous >= 0 && (
+                <PreviousItemLink
+                  query={route.query}
+                  searchItemCount={searchItemCount}
+                  paginationInfo={paginationInfo}
+                />
+              )}
+            {route.query.next &&
+              route.query.next < searchItemCount && (
+                <NextItemLink
+                  query={route.query}
+                  searchItemCount={searchItemCount}
+                  paginationInfo={paginationInfo}
+                />
+              )}
+          </div>
+        )}
     </div>
     <style dangerouslySetInnerHTML={{ __html: stylesheet }} />
-  </div>;
+  </div>
+);
 
 export default BreadcrumbsModule;

--- a/components/PrimarySourceSetsComponents/Source/components/ContentAndMetadata/ContentAndMetadata.css
+++ b/components/PrimarySourceSetsComponents/Source/components/ContentAndMetadata/ContentAndMetadata.css
@@ -105,7 +105,7 @@
   border-bottom: 1px solid #000000;
   height: 2px;
   opacity: 0.1;
-  margin-bottom: 17px;
+  margin: 1rem 0;
 }
 
 .linkWrapper {
@@ -118,11 +118,7 @@
 
 .sourceLink {
   color: curiousBlue;
-  font-weight: 600;
-}
-
-.linkText {
-  border-bottom: 1px solid curiousBlue;
+  text-decoration: underline;
 }
 
 .linkIcon {
@@ -178,6 +174,6 @@
   width: 100%;
 }
 
-.shareButton, .citeButton {
+.citeButton {
   margin-bottom: 0.5rem;
 }


### PR DESCRIPTION
Links that aren't underlined should get a hover underline, and links that are underlined should use `text-decoration: underline` rather than a bottom border. This PR fixes a couple lingering links where this pattern has not been used.

<img width="384" alt="screen shot 2017-10-24 at 6 19 31 pm" src="https://user-images.githubusercontent.com/1767309/31971198-be8b5e68-b8e8-11e7-9e6f-1d8d9f6d5132.png">
