### PR TITLE
Return scheme-relative URL from url functions

### DIFF
--- a/utilFunctions/getCurrentFullUrl.js
+++ b/utilFunctions/getCurrentFullUrl.js
@@ -1,4 +1,4 @@
 const getCurrentFullUrl = req =>
-  req ? `${req.protocol}://${req.get("host")}${req.url}` : window.location.href;
+  req ? `//${req.get("host")}${req.url}` : window.location.href;
 
 export default getCurrentFullUrl;

--- a/utilFunctions/getCurrentUrl.js
+++ b/utilFunctions/getCurrentUrl.js
@@ -1,6 +1,4 @@
 const getCurrentUrl = req =>
-  req
-    ? `${req.protocol}://${req.get("host")}`
-    : `${window.location.protocol}//${window.location.host}`;
+  req ? `//${req.get("host")}` : `//${window.location.host}`;
 
 export default getCurrentUrl;


### PR DESCRIPTION
In the utility functions `getCurrentUrl` and `getCurrentFullUrl` in `utilFunctions/getCurrentUrl.js` and `getCurrentFullUrl.js`, return a scheme-relative URL instead of dereferencing `req.protocol` or `window.location.protocol`. Behind a CDN plus proxy server it's possible for the server's `req.protocol` to be incorrect.