### PR TITLE
Set Cache-Control header

### DIFF
--- a/server.js
+++ b/server.js
@@ -407,6 +407,7 @@ function renderAndCache(req, res, pagePath, queryParams) {
       // Let's cache this page
       console.log(`CACHE MISS: ${req.url}`);
       ssrCache.set(req.url, html);
+      res.header("Cache-Control", "no-cache, must-revalidate");
       res.send(html);
     })
     .catch(err => {


### PR DESCRIPTION
In server.js, set a Cache-Control response header with the must-revalidate and no-cache pragmas, to get our CloudFront CDN to revalidate dynamic resources with the origin server.

This fixes a problem I was seeing with CloudFront hanging on to HTML pages after code changes were made to them. It used to be that, even though there was an ETag header, CloudFront was not revalidating the resource. After putting in a header `Cache-Control: no-cache, must-revalidate`, requests after the first one now result in a 304 response with a response header `X-Cache: RefreshHit from cloudfront`. It used to be that it was "Hit from cloudfront" no matter what, even after a deployment.

By the way, to check the app on localhost I've found that it's useful to do `yarn run build` and then `yarn start` to get the production version of the app, with the Express webserver. This gives you a better simulation of the ETag and other behavior that you're going to see in production.
