### PR TITLE
Add Elastic Beanstalk Nginx www redirect

### DIFF
--- a/.ebextensions/nginx.config
+++ b/.ebextensions/nginx.config
@@ -1,0 +1,47 @@
+---
+
+files:
+    # The stock Elastic Beanstalk Nginx configuration, with modifications
+    "/etc/nginx/sites-available/elasticbeanstalk-nginx-docker-proxy.conf":
+        mode: "0644"
+        owner: "root"
+        group: "root"
+        content: |
+            map $http_upgrade $connection_upgrade {
+                default        "upgrade";
+                ""            "";
+            }
+            server {
+                listen 80 default;    # "default" added by DPLA
+                gzip on;
+                gzip_comp_level 4;
+                gzip_types text/html text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+                if ($time_iso8601 ~ "^(\d{4})-(\d{2})-(\d{2})T(\d{2})") {
+                    set $year $1;
+                    set $month $2;
+                    set $day $3;
+                    set $hour $4;
+                }
+                access_log /var/log/nginx/healthd/application.log.$year-$month-$day-$hour healthd;
+                access_log    /var/log/nginx/access.log;
+                location / {
+                    proxy_pass            http://docker;
+                    proxy_http_version    1.1;
+                    proxy_set_header      Connection $connection_upgrade;
+                    proxy_set_header      Upgrade    $http_upgrade;
+                    proxy_set_header      Host       $host;
+                    proxy_set_header      X-Real-IP  $remote_addr;
+                    proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
+                }
+            }
+
+    "/etc/nginx/sites-enabled/www-redirect.conf":
+        mode: "0644"
+        owner: "root"
+        group: "root"
+        content: |
+            server {
+                listen 80;
+                server_name ~^www\.(?<domain>.+)$;
+                return 301 $http_x_forwarded_proto://$domain$uri;
+            }


### PR DESCRIPTION
Add Elastic Beanstalk .ebextensions directory with nginx.config file that redirects from www to the apex domain.