### PR TITLE
removed nav links in topics

### DIFF
--- a/components/TopicBrowseComponents/BreadcrumbsAndNav/index.js
+++ b/components/TopicBrowseComponents/BreadcrumbsAndNav/index.js
@@ -17,12 +17,6 @@ const BreadcrumbsAndNav = ({
   <div className={classNames.wrapper}>
     <div className={[classNames.breadcrumbsAndNav, container].join(" ")}>
       <Breadcrumbs breadcrumbs={breadcrumbs} />
-      <NavLinks
-        route={route}
-        previousSubtopic={previousSubtopic}
-        nextSubtopic={nextSubtopic}
-        topic={topic}
-      />
     </div>
     <style dangerouslySetInnerHTML={{ __html: stylesheet }} />
   </div>;

--- a/pages/browse-by-topic/topic/subtopic/index.js
+++ b/pages/browse-by-topic/topic/subtopic/index.js
@@ -47,7 +47,6 @@ const SubtopicItemsList = ({
         },
         { title: subtopic.name, url: "" }
       ]}
-      showNavLinks={true}
       previousSubtopic={previousSubtopic}
       nextSubtopic={nextSubtopic}
       topic={topic}


### PR DESCRIPTION
addresses https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1821

no idea why those links were there in the first place... maybe the next/prev pattern was to be used throughout the site?