### PR TITLE
add static HTML tags for SEO

### DIFF
--- a/components/Head/index.js
+++ b/components/Head/index.js
@@ -12,6 +12,26 @@ export default ({ additionalLinks, pageTitle }) =>
         name="viewport"
         content="width=device-width, initial-scale=1, shrink-to-fit=no"
       />
+      <meta
+        name="referrer"
+        content="origin-when-cross-origin"
+      />
+      <meta 
+        name="og:site_name"
+        content="Digital Pulic Library of America"
+      />
+      <meta
+        name="twitter:card"
+        content="summary"
+      />
+      <meta
+        name="twitter:site"
+        content="@dpla"
+      />
+      <meta
+        name="twitter:creator"
+        content="@dpla"
+      />
       <link
         rel="apple-touch-icon"
         sizes="180x180"
@@ -57,10 +77,9 @@ export default ({ additionalLinks, pageTitle }) =>
       {additionalLinks}
       <title>{pageTitle || "Digital Public Library of America"}</title>
       <meta
-        property="og:title"
+        name="og:title"
         content={pageTitle || "Digital Public Library of America"}
       />
-
       <style>{reset}</style>
       <style>{utilStylesheet}</style>
     </Head>


### PR DESCRIPTION
This adds HTML tags to the `<head>` for SEO.  These tags are the same for every page in the application.  It has been tested locally.  

This addresses [DT-1770](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1770) _in part._  I plan to submit multiple PR's for this ticket, since some parts will be complex enough to warrant their own PR.