### PR TITLE
fixed css for thumbnails in pss

### DIFF
--- a/components/PrimarySourceSetsComponents/SingleSet/SourceSetSources/SourceSetSources.css
+++ b/components/PrimarySourceSetsComponents/SingleSet/SourceSetSources/SourceSetSources.css
@@ -43,18 +43,15 @@
   }
 }
 
-
 .imageWrapper {
   background-color: visualBrown;
-  padding-top: 72%;
   display: flex;
   align-items: center;
   justify-content: center;
   margin-bottom: 9px;
   position: relative;
-  max-height: 110px;
+  height: 180px;
   @media (min-width: smallRem) {
-    max-height: 172px;
   }
 }
 
@@ -66,15 +63,9 @@
 }
 
 .image {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  margin: .5rem;
   max-width: 100%;
   max-height: 100%;
-  height: 100%;
-  margin: auto;
 }
 
 .title {


### PR DESCRIPTION
addresses: https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1693

before:

<img width="1125" alt="image" src="https://user-images.githubusercontent.com/133020/32514768-023d8742-c3cc-11e7-9d26-d1ba6e521fd6.png">


after:

<img width="1094" alt="image" src="https://user-images.githubusercontent.com/133020/32514792-14da112c-c3cc-11e7-965a-98a65cd220a1.png">
