### PR TITLE
bullet numbers now show up in chrome

### DIFF
--- a/css/pages/content-pages-wysiwyg.css
+++ b/css/pages/content-pages-wysiwyg.css
@@ -67,7 +67,6 @@
 
   & h4 {
     font-size: 1.125rem;
-    opacity: 0.75;
   }
 
   & h5, & h6 {
@@ -79,7 +78,6 @@
   & p, & ul, & ol {
     margin-bottom: 1.5rem;
     font-weight: normal;
-    opacity: 0.85;
     font-size: 1rem;
 
     @media (min-width: mediumRem) {


### PR DESCRIPTION
was due to opacity in text being less than 1 😐 

addresses: https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1682