### PR TITLE
add seo type

### DIFF
--- a/components/Head/index.js
+++ b/components/Head/index.js
@@ -5,7 +5,7 @@ import { stylesheet as utilStylesheet } from "css/utils.css";
 import { stylesheet as reset } from "css/reset.css";
 import { getMetaPageTitle } from "utilFunctions";
 
-export default ({ additionalLinks, pageTitle }) =>
+export default ({ additionalLinks, pageTitle, seoType }) =>
   <div>
     <Head>
       <meta charSet="utf-8" />
@@ -80,6 +80,10 @@ export default ({ additionalLinks, pageTitle }) =>
       <meta
         name="og:title"
         content={pageTitle || "Digital Public Library of America"}
+      />
+      <meta
+        name="og:type"
+        content={seoType || "website"}
       />
       <style>{reset}</style>
       <style>{utilStylesheet}</style>

--- a/components/MainLayout/index.js
+++ b/components/MainLayout/index.js
@@ -12,10 +12,11 @@ const MainLayout = ({
   hideSearchBar,
   isSearchPage,
   headLinks,
-  pageTitle
+  pageTitle,
+  seoType
 }) =>
   <div>
-    <Head additionalLinks={headLinks} pageTitle={pageTitle} />
+    <Head additionalLinks={headLinks} pageTitle={pageTitle} seoType={seoType} />
     <SmallScreenHeader isSearchPage={isSearchPage} route={route} />
     <GlobalHeader />
     {!hideSearchBar && <PageHeader searchQuery={route.query.q} />}

--- a/constants/content-pages.js
+++ b/constants/content-pages.js
@@ -2,3 +2,4 @@ export const ABOUT_MENU_ENDPOINT =
   "https://dpla.wpengine.com/wp-json/menus/v1/menus/about-us";
 export const GUIDES_ENDPOINT =
   "https://dpla.wpengine.com/wp-json/wp/v2/pages/2394";
+export const SEO_TYPE = "article";

--- a/constants/exhibition.js
+++ b/constants/exhibition.js
@@ -1,0 +1,1 @@
+export const SEO_TYPE = "article";

--- a/pages/about/index.js
+++ b/pages/about/index.js
@@ -8,11 +8,14 @@ import {
   classNames as contentClasses,
   stylesheet as contentStyles
 } from "css/pages/content-pages-wysiwyg.css";
-import { ABOUT_MENU_ENDPOINT, GUIDES_ENDPOINT } from "constants/content-pages";
+import { 
+  ABOUT_MENU_ENDPOINT,
+  GUIDES_ENDPOINT,
+  SEO_TYPE } from "constants/content-pages";
 import { classNames as utilClassNames } from "css/utils.css";
 
 const AboutMenuPage = ({ url, content, items, pageTitle }) =>
-  <MainLayout route={url} pageTitle={pageTitle}>
+  <MainLayout route={url} pageTitle={pageTitle} seoType={SEO_TYPE}>
     <div
       className={`${utilClassNames.container}
       ${contentClasses.sidebarAndContentWrapper}`}

--- a/pages/contact-us/index.js
+++ b/pages/contact-us/index.js
@@ -9,11 +9,13 @@ import MoreWaysToContact from "components/ContactComponents/MoreWaysToContact";
 import { classNames, stylesheet } from "css/pages/content-pages-wysiwyg.css";
 import { classNames as utilClassNames } from "css/utils.css";
 import { TITLE } from "constants/contact";
+import { SEO_TYPE } from "constants/content-pages";
 
 const Contact = ({ url, sidebarItems }) =>
   <MainLayout
     route={url}
     pageTitle={TITLE}
+    seoType={SEO_TYPE}
     headLinks={
       <link
         rel="stylesheet"

--- a/pages/exhibitions/exhibition/index.js
+++ b/pages/exhibitions/exhibition/index.js
@@ -11,11 +11,12 @@ import {
   EXHIBIT_PAGES_ENDPOINT,
   FILES_ENDPOINT
 } from "constants/exhibitions";
+import { SEO_TYPE } from "constants/exhibition";
 
 import removeQueryParams from "/utilFunctions/removeQueryParams";
 
 const Exhibition = ({ url, exhibition, currentFullUrl }) =>
-  <MainLayout route={url} pageTitle={exhibition.title}>
+  <MainLayout route={url} pageTitle={exhibition.title} seoType={SEO_TYPE}>
     <BreadcrumbsModule
       breadcrumbs={[
         {

--- a/pages/exhibitions/exhibition/section/subsection.js
+++ b/pages/exhibitions/exhibition/section/subsection.js
@@ -16,6 +16,8 @@ import {
   ITEMS_ENDPOINT
 } from "constants/exhibitions";
 
+import { SEO_TYPE } from "constants/exhibition";
+
 const Subsection = ({
   url,
   exhibition,
@@ -26,7 +28,7 @@ const Subsection = ({
   previousQueryParams
 }) =>
   <div>
-    <Head pageTitle={section.title} />
+    <Head pageTitle={section.title} seoType={SEO_TYPE} />
     <Content
       route={url}
       previousQueryParams={previousQueryParams}

--- a/pages/guides/guide/index.js
+++ b/pages/guides/guide/index.js
@@ -9,11 +9,11 @@ import {
   classNames as contentClasses,
   stylesheet as contentStyles
 } from "css/pages/content-pages-wysiwyg.css";
-import { ABOUT_MENU_ENDPOINT } from "constants/content-pages";
+import { ABOUT_MENU_ENDPOINT, SEO_TYPE } from "constants/content-pages";
 import { classNames as utilClassNames } from "css/utils.css";
 
 const Guides = ({ url, sidebarItems, guide }) =>
-  <MainLayout route={url} pageTitle={guide.title}>
+  <MainLayout route={url} pageTitle={guide.title} seoType={SEO_TYPE}>
     <div
       className={`
         ${utilClassNames.container}


### PR DESCRIPTION
This adds the `og:type` metadata element to the `<head>`.  The default value is "website" but a few pages are better classified as "article".  

This addresses part of [DT-1770](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1770).  It has been tested locally.