### PR TITLE
uri encoding of free text param

### DIFF
--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -69,7 +69,10 @@ class Search extends React.Component {
 
 Search.getInitialProps = async ({ query, req }) => {
   const currentUrl = getCurrentUrl(req);
-  const q = query.q || "";
+  const q =
+    encodeURIComponent(query.q)
+      .replace(/'/g, "%27")
+      .replace(/"/g, "%22") || "";
   const page_size = query.page_size || DEFAULT_PAGE_SIZE;
   const page = query.page || 1;
   let sort_by = "";
@@ -93,7 +96,9 @@ Search.getInitialProps = async ({ query, req }) => {
     .join("&");
 
   const res = await fetch(
-    `${currentUrl}${API_ENDPOINT}?q=${q}&page=${page}&page_size=${page_size}&sort_order=${sort_order}&sort_by=${sort_by}&facets=${possibleFacets.join(
+    `${currentUrl}${API_ENDPOINT}?q=${q}&page=${page}&page_size=${
+      page_size
+    }&sort_order=${sort_order}&sort_by=${sort_by}&facets=${possibleFacets.join(
       ","
     )}&${facetQueries}`
   );


### PR DESCRIPTION
fixes https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1872 !!!!!!1!

passing the keywords as-is killed the server for some reason

a lot of hair-pulling for this one-line fix although now kind of obvious in retrospect