### PR TITLE
sorting of pss subsections fixed in safari

### DIFF
--- a/utilFunctions/exhibitions/getInitialProps.js
+++ b/utilFunctions/exhibitions/getInitialProps.js
@@ -20,9 +20,7 @@ const getNextOrPreviousQueryParams = (
   if (!subsectInCurrentSect) {
     subsectInNextOrPrevSect =
       nextOrPreviousSect &&
-      nextOrPreviousSect.subsections.sort(
-        (a, b) => nextOrPrevious === a.order - b.order
-      )[
+      nextOrPreviousSect.subsections.sort((a, b) => a.order - b.order)[
         nextOrPrevious === "previous"
           ? nextOrPreviousSect.subsections.length - 1
           : 0


### PR DESCRIPTION
sorting function had a bug that only broke in safari

addresses: https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1716