### PR TITLE
fix heading for topic browse

### DIFF
--- a/components/TopicBrowseComponents/SubtopicItemsList/Sidebar/index.js
+++ b/components/TopicBrowseComponents/SubtopicItemsList/Sidebar/index.js
@@ -18,9 +18,9 @@ const Sidebar = ({ image, title, description }) =>
     <div className={classNames.subtopicInfo}>
       <img src={image} alt={title} className={classNames.image} />
       <div className={classNames.subtopicInfoText}>
-        <h2 className={classNames.title}>
+        <h1 className={classNames.title}>
           {title}
-        </h2>
+        </h1>
         <p className={classNames.description}>
           {description}
         </p>

--- a/components/TopicBrowseComponents/Topic/MainContent/index.js
+++ b/components/TopicBrowseComponents/Topic/MainContent/index.js
@@ -5,16 +5,15 @@ import HeadingRule from "components/shared/HeadingRule";
 import { classNames, stylesheet } from "./MainContent.css";
 import { classNames as utilClassNames } from "css/utils.css";
 
-const MainContent = ({ topic }) => (
+const MainContent = ({ topic }) =>
   <div className={classNames.wrapper}>
     <div className={`${classNames.container} site-max-width`}>
       <h1 className={classNames.header}>{topic.name}</h1>
-      {topic.description && (
-        <p className={classNames.topicDescription}>{topic.description}</p>
-      )}
+      {topic.description &&
+        <p className={classNames.topicDescription}>{topic.description}</p>}
       <HeadingRule color="#F9BA3F" />
       <ul className="row">
-        {topic.subtopics.map((subtopic, index) => (
+        {topic.subtopics.map((subtopic, index) =>
           <li
             className={`${classNames.subtopic} col-xs-12 col-sm-6 col-md-4`}
             key={`${subtopic.name}-${index}`}
@@ -22,9 +21,7 @@ const MainContent = ({ topic }) => (
             <Link
               prefetch
               as={`/browse-by-topic/${topic.slug}/${subtopic.slug}`}
-              href={`/browse-by-topic/topic/subtopic?subtopic=${
-                subtopic.slug
-              }&topic=${topic.slug}`}
+              href={`/browse-by-topic/topic/subtopic?subtopic=${subtopic.slug}&topic=${topic.slug}`}
             >
               <a className={classNames.subtopicAnchor}>
                 <img
@@ -33,7 +30,7 @@ const MainContent = ({ topic }) => (
                   src={subtopic.thumbnailUrl}
                 />
                 <div className={classNames.textWrapper}>
-                  <h3 className={classNames.subtopicTitle}>{subtopic.name}</h3>
+                  <h2 className={classNames.subtopicTitle}>{subtopic.name}</h2>
                   <p className={classNames.subtopicDescription}>
                     {subtopic.description}
                   </p>
@@ -41,11 +38,10 @@ const MainContent = ({ topic }) => (
               </a>
             </Link>
           </li>
-        ))}
+        )}
       </ul>
     </div>
     <style dangerouslySetInnerHTML={{ __html: stylesheet }} />
-  </div>
-);
+  </div>;
 
 export default MainContent;

--- a/components/TopicBrowseComponents/Topic/Suggestions/index.js
+++ b/components/TopicBrowseComponents/Topic/Suggestions/index.js
@@ -23,7 +23,7 @@ const mapTypeToClass = type => {
 const Suggestions = ({ suggestions }) =>
   <div className={classNames.suggestionsWrapper}>
     <div className={[classNames.suggestions, container].join(" ")}>
-      <h3 className={classNames.header}>You might also enjoy</h3>
+      <h2 className={classNames.header}>You might also enjoy</h2>
       {/* this is a little hacky but <Slider /> seems to throw away
         any class names you pass it as props, so we use this global css
         class to target the arrows */}
@@ -73,7 +73,7 @@ const Suggestions = ({ suggestions }) =>
                       <p className={classNames.resourceType}>
                         {suggestion.type}
                       </p>
-                      <h3
+                      <div
                         dangerouslySetInnerHTML={{ __html: suggestion.title }}
                         className={classNames.suggestionTitle}
                       />

--- a/components/shared/ListView/index.js
+++ b/components/shared/ListView/index.js
@@ -37,13 +37,14 @@ const ListView = ({ items, route }) =>
         <div className={classNames.itemInfo}>
           <Link href={item.linkHref} as={item.linkAs}>
             <a className={classNames.listItemLink}>
-              <span className={`hover-underline ${classNames.itemTitle}`}>
+              <h2 className={`hover-underline ${classNames.itemTitle}`}>
                 {route.pathname.indexOf("/search") === 0 && item.title
                   ? truncateString(item.title, 150)
                   : item.title}
-              </span>
+              </h2>
             </a>
           </Link>
+
           {(item.date || item.creator) &&
             <span className={classNames.itemAuthorAndDate}>
               {route.pathname.indexOf("/search") === 0 &&


### PR DESCRIPTION
This fixes semantic headings for topic browse.  There are no tickets for this b/c these pages were not part of the Kitchen audit.  The ListView is shared between topic browse and search, and the headings work semantically in both contexts.