### PR TITLE
use subsection only in exhibit title

### DIFF
--- a/components/ExhibitionsComponents/ExhibitionSection/ExhibitionSection.css
+++ b/components/ExhibitionsComponents/ExhibitionSection/ExhibitionSection.css
@@ -378,16 +378,12 @@
   }
 }
 
-.titleSection {
+.titleSubsection {
   font-weight: 600;
 
   @media (min-width: smallRem) {
     margin-right: .5rem;
   }
-}
-
-.titleSubsection {
-  color: dimmedTextColor;
 }
 
 .viewerContent {

--- a/components/ExhibitionsComponents/ExhibitionSection/Subheader.js
+++ b/components/ExhibitionsComponents/ExhibitionSection/Subheader.js
@@ -28,7 +28,6 @@ const Subheader = ({ section, subsection, onClickMenuButton, isMenuOpen }) =>
         />
       </button>
       <h2 className={classNames.title}>
-        <span className={classNames.titleSection}>{section.title}</span>
         <span className={classNames.titleSubsection}>{subsection.title}</span>
       </h2>
     </div>


### PR DESCRIPTION
In the exhibit page, use only the subsection for the title.  Before, it was both the section and the subsection.  This addresses [DT-1952](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1952).