### PR TITLE
add tooltips to item metadata link

### DIFF
--- a/components/ItemComponents/Content/OtherMetadata.js
+++ b/components/ItemComponents/Content/OtherMetadata.js
@@ -16,7 +16,7 @@ const FacetLink = ({ facet, value, facetLabel }) =>
     >
       <a
         className="link"
-        title={`Find more items from ${facetLabel || facet} ${value}`}
+        title={`Find more items with ${facetLabel || facet} "${value}"`}
       >
         {value}
       </a>


### PR DESCRIPTION
This adds tooltips to the links on item pages that take users to new search results.  It addresses DT-2016.