### PR TITLE
properly nest about menu ul

### DIFF
--- a/components/shared/ContentPagesSidebar/Sidebar.css
+++ b/components/shared/ContentPagesSidebar/Sidebar.css
@@ -5,8 +5,16 @@
   background-color: warmerBackgroundColor;
   padding: 1rem 1.5rem;
 
-  & a {
+  & .link {
+    display: inline-block;
     color: rgba(0, 0, 0, 0.65);
+    margin-bottom: .55rem;
+  }
+
+  & .link.selected {
+    color: rgba(0, 0, 0, 1);
+    font-weight: bold;
+    position: relative;
   }
 
   @media (min-width: mediumRem) {
@@ -15,6 +23,10 @@
     /* inline-block to prevent the divider from spanning the full width */
     display: inline-block;
   }
+}
+
+.sidebar ul:first-child > li:last-child .link:last-child {
+  margin-bottom: 0;
 }
 
 .sidebar ul ul {
@@ -31,15 +43,10 @@
       top: .6rem;
     }
   }
-
-  & .link {
-    margin-bottom: .35rem;
-  }
 }
 
 .link {
   font-size: 1rem;
-  margin-bottom: .55rem;
 
   &:hover {
     text-decoration: underline;
@@ -59,15 +66,6 @@
 
   @media (min-width: mediumRem) {
     margin: 1.25rem 0;
-  }
-}
-
-.selected {
-  font-weight: bold;
-  position: relative;
-
-  & a {
-    color: rgba(0, 0, 0, 1);
   }
 }
 

--- a/components/shared/ContentPagesSidebar/index.js
+++ b/components/shared/ContentPagesSidebar/index.js
@@ -13,27 +13,64 @@ const SidebarLink = ({
   subsection
 }) => {
   return (
-    <li
-      className={`${classNames.link} ${isCurrentLink && classNames.selected}`}
+    <Link
+      as={
+        linkObject && linkObject.as
+          ? linkObject.as
+          : `/${section}/${subsection ? subsection : ""}`
+      }
+      href={
+        linkObject && linkObject.href
+          ? linkObject.href
+          : `/about?section=${section}${subsection
+              ? `&subsection=${subsection}`
+              : ""}`
+      }
     >
-      <Link
-        as={
-          linkObject && linkObject.as
-            ? linkObject.as
-            : `/${section}/${subsection ? subsection : ""}`
-        }
-        href={
-          linkObject && linkObject.href
-            ? linkObject.href
-            : `/about?section=${section}${subsection
-                ? `&subsection=${subsection}`
-                : ""}`
-        }
+      <a
+        className={`${classNames.link} ${isCurrentLink && classNames.selected}`}
       >
-        <a>
-          {title}
-        </a>
-      </Link>
+        {title}
+      </a>
+    </Link>
+  );
+};
+
+const NestedSidebarLinks = ({
+  key,
+  isCurrentLink,
+  linkObject,
+  title,
+  section,
+  subsection,
+  activeItemId,
+  children
+}) => {
+  return (
+    <li>
+      <SidebarLink
+        linkObject={linkObject}
+        title={title}
+        section={section}
+        subsection={subsection}
+        isCurrentLink={isCurrentLink}
+      />
+      {children.length
+        ? <ul>
+            {children.map(child =>
+              <li key={child.id}>
+                <SidebarLink
+                  title={decodeHTMLEntities(child.title)}
+                  section={section}
+                  subsection={child.post_name}
+                  isCurrentLink={child.url.match(
+                    new RegExp(activeItemId + "$")
+                  )}
+                />
+              </li>
+            )}
+          </ul>
+        : null}
     </li>
   );
 };
@@ -46,37 +83,21 @@ const Sidebar = ({ activeItemId, items, route }) =>
           const children = items.filter(
             child => child.menu_item_parent === item.object_id
           );
-          return children.length
-            ? <div key={item.ID}>
-                <SidebarLink
-                  key={item.ID}
-                  title={decodeHTMLEntities(item.title)}
-                  url={item.url}
-                  section={item.post_name}
-                  isCurrentLink={item.url.match(new RegExp(activeItemId + "$"))}
-                />
-                <ul>
-                  {children.map(child =>
-                    <SidebarLink
-                      key={child.ID}
-                      title={decodeHTMLEntities(child.title)}
-                      section={item.post_name}
-                      subsection={child.post_name}
-                      isCurrentLink={child.url.match(
-                        new RegExp(activeItemId + "$")
-                      )}
-                    />
-                  )}
-                </ul>
-              </div>
-            : <SidebarLink
-                key={item.ID}
-                title={decodeHTMLEntities(item.title)}
-                section={item.post_name}
-                isCurrentLink={item.url.match(new RegExp(activeItemId + "$"))}
-              />;
+          return (
+            <NestedSidebarLinks
+              key={item.ID}
+              title={decodeHTMLEntities(item.title)}
+              url={item.url}
+              section={item.post_name}
+              isCurrentLink={item.url.match(new RegExp(activeItemId + "$"))}
+              children={children}
+              activeItemId={activeItemId}
+            />
+          );
         })}
-        <div className={classNames.divider} />
+      </ul>
+      <div className={classNames.divider} />
+      <ul>
         <SidebarLink
           title="Contact Us"
           section="contact-us"


### PR DESCRIPTION
This properly nests `<ul>` elements in the "about" sidebar menu.  Before, the `<ul>` and `<li>` items were not properly nested, and there were `<div>` elements that were direct children of `<ul>`.  This was both semantically incorrect and indecipherable to screen readers.  There are not changes to the style for sighted users.  I have tested this locally on a few browsers, but it would be good for someone else to confirm that the styling is still working correctly.  This addresses [DT-2054](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-2054).