### PR TITLE
fix semantics of homepage heading and logo

### DIFF
--- a/components/HomePageComponents/HomeHero/HomeHero.css
+++ b/components/HomePageComponents/HomeHero/HomeHero.css
@@ -29,6 +29,11 @@
 
 .dplaLogo {
   width: 24rem;
+  background: url("static/images/dpla-logo.svg") no-repeat 0 50%;
+
+  & h1 {
+    margin-left: -1000rem;
+  }
 }
 
 .content {

--- a/components/HomePageComponents/HomeHero/index.js
+++ b/components/HomePageComponents/HomeHero/index.js
@@ -6,7 +6,6 @@ import Link from "next/link";
 
 const bgImage = "static/images/home-hero-bg.png";
 const searchIcon = "static/images/search.svg";
-const dplaLogo = "static/images/dpla-logo.svg";
 
 const HomeHero = ({ headerDescription }) =>
   <div
@@ -14,15 +13,14 @@ const HomeHero = ({ headerDescription }) =>
     style={{ backgroundImage: `url(${bgImage})` }}
   >
     <div className={`${classNames.header} site-max-width`}>
-      <div>
-        <img className={classNames.dplaLogo} alt="DPLA" src={dplaLogo} />
+      <div className={classNames.dplaLogo}>
+        <h1>Digital Public Library of America</h1>
       </div>
       <Button type="primary" size="large" url="/donate">
         Donate
       </Button>
     </div>
     <div className={classNames.content}>
-      <h1 className="invisible">Digital Public Library of America</h1>
       <p className={classNames.headline}>{headerDescription}</p>
       <form action="/search">
         <div className={classNames.search}>


### PR DESCRIPTION
This moves the `<h1>` heading on the homepage to the `div` with the DPLA logo.  It makes the logo a background image.  This addresses [DT-2013](https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-2013).