### PR TITLE
a11y carousels / refactored homepage carousels

### DIFF
--- a/components/HomePageComponents/HomePageSlider/index.js
+++ b/components/HomePageComponents/HomePageSlider/index.js
@@ -1,6 +1,9 @@
 import React from "react";
 import Slider from "react-slick";
 import Link from "next/link";
+
+import { NextArrow, PrevArrow } from "components/shared/CarouselNavArrows";
+
 import { stylesheet, classNames } from "./HomePageSlider.css";
 import { classNames as breakpoints } from "css/breakpoints.css";
 
@@ -8,22 +11,6 @@ const markdownit = require("markdown-it")({ html: true });
 const moreLinkChevron = "static/images/chevron-thick-orange.svg";
 const moreLinkChevronBlue = "static/images/chevron-thick-blue.svg";
 const largeChevron = "static/images/chevron-thin.svg";
-
-const NextArrow = ({ onClick, className }) =>
-  <button
-    className={`${classNames.arrow} ${classNames.nextArrow} ${className}`}
-    onClick={onClick}
-  >
-    <img alt="Right-pointing arrow" src={largeChevron} />
-  </button>;
-
-const PrevArrow = ({ onClick, className }) =>
-  <button
-    className={`${classNames.arrow} ${classNames.prevArrow} ${className}`}
-    onClick={onClick}
-  >
-    <img alt="Left-pointing arrow" src={largeChevron} />
-  </button>;
 
 const HomePageSlider = ({
   browseLinkName,
@@ -57,8 +44,16 @@ const HomePageSlider = ({
       <Slider
         slidesToShow={slidesToShow ? slidesToShow : 3}
         infinite={false}
-        nextArrow={<NextArrow />}
-        prevArrow={<PrevArrow />}
+        nextArrow={
+          <NextArrow
+            className={`${classNames.arrow} ${classNames.nextArrow}`}
+          />
+        }
+        prevArrow={
+          <PrevArrow
+            className={`${classNames.arrow} ${classNames.prevArrow}`}
+          />
+        }
         draggable={false}
         slidesToScroll={slidesToShow ? slidesToShow : 3}
         responsive={[

--- a/components/PrimarySourceSetsComponents/SingleSet/RelatedSets/index.js
+++ b/components/PrimarySourceSetsComponents/SingleSet/RelatedSets/index.js
@@ -18,12 +18,12 @@ const RelatedSets = ({ sets }) => {
       <div className={[container, classNames.relatedSets].join(" ")}>
         <h2 className={classNames.header}>Related Primary Source Sets</h2>
         <Slider
-          slidesToShow={5}
+          slidesToShow={4.5}
           infinite={false}
           nextArrow={<NextArrow className={classNames.navArrow} />}
           prevArrow={<PrevArrow className={classNames.navArrow} />}
           draggable={false}
-          slidesToScroll={5}
+          slidesToScroll={4}
           responsive={[
             {
               breakpoint: ~~breakpoints.smallPx,
@@ -32,14 +32,6 @@ const RelatedSets = ({ sets }) => {
                 arrows: false,
                 draggable: true,
                 slidesToScroll: 2
-              }
-            },
-            {
-              breakpoint: ~~breakpoints.mediumPx,
-              settings: {
-                slidesToShow: 4,
-                draggable: true,
-                slidesToScroll: 4
               }
             }
           ]}

--- a/components/TopicBrowseComponents/Topic/Suggestions/index.js
+++ b/components/TopicBrowseComponents/Topic/Suggestions/index.js
@@ -4,8 +4,11 @@ import Slider from "react-slick";
 
 import { classNames, stylesheet } from "./Suggestions.css";
 import { classNames as utilClassNames } from "css/utils.css";
-import { NextArrow, PrevArrow } from "components/shared/CarouselNavArrows";
-import { stylesheet as navArrowStyles } from "components/shared/CarouselNavArrows/CarouselNavArrows.css";
+import {
+  NextArrow,
+  PrevArrow
+} from "../../../../components/shared/CarouselNavArrows";
+import { stylesheet as navArrowStyles } from "../../../../components/shared/CarouselNavArrows/CarouselNavArrows.css";
 import { classNames as breakpoints } from "css/breakpoints.css";
 
 const { container } = utilClassNames;
@@ -27,14 +30,14 @@ const Suggestions = ({ suggestions }) =>
       {/* this is a little hacky but <Slider /> seems to throw away
         any class names you pass it as props, so we use this global css
         class to target the arrows */}
-      <ul className="dpla-related-resources-carousel">
+      <div className="dpla-related-resources-carousel">
         <Slider
-          slidesToShow={5}
+          slidesToShow={4.5}
           infinite={false}
           nextArrow={<NextArrow className={classNames.navArrow} />}
           prevArrow={<PrevArrow className={classNames.navArrow} />}
           draggable={false}
-          slidesToScroll={5}
+          slidesToScroll={4}
           responsive={[
             {
               breakpoint: ~~breakpoints.smallPx,
@@ -44,19 +47,11 @@ const Suggestions = ({ suggestions }) =>
                 draggable: true,
                 slidesToScroll: 2
               }
-            },
-            {
-              breakpoint: ~~breakpoints.mediumPx,
-              settings: {
-                slidesToShow: 4,
-                draggable: true,
-                slidesToScroll: 4
-              }
             }
           ]}
         >
           {suggestions.map(suggestion =>
-            <li
+            <div
               key={suggestion.title}
               className={[
                 classNames.suggestedItem,
@@ -81,10 +76,10 @@ const Suggestions = ({ suggestions }) =>
                   </div>
                 </a>
               </Link>
-            </li>
+            </div>
           )}
         </Slider>
-      </ul>
+      </div>
     </div>
     <style dangerouslySetInnerHTML={{ __html: stylesheet }} />
     <style dangerouslySetInnerHTML={{ __html: navArrowStyles }} />

--- a/components/shared/CarouselNavArrows/index.js
+++ b/components/shared/CarouselNavArrows/index.js
@@ -6,6 +6,8 @@ const largeChevron = "/static/images/chevron-thin.svg";
 const NextArrow = ({ onClick, className }) =>
   <button
     className={`${classNames.arrow} ${classNames.nextArrow} ${className}`}
+    tabIndex={-1}
+    aria-hidden={true}
     onClick={onClick}
   >
     <img alt="Right-pointing arrow" src={largeChevron} />
@@ -14,6 +16,8 @@ const NextArrow = ({ onClick, className }) =>
 const PrevArrow = ({ onClick, className }) =>
   <button
     className={`${classNames.arrow} ${classNames.prevArrow} ${className}`}
+    tabIndex={-1}
+    aria-hidden={true}
     onClick={onClick}
   >
     <img alt="Left-pointing arrow" src={largeChevron} />

--- a/components/shared/FiltersBar/FiltersBar.css
+++ b/components/shared/FiltersBar/FiltersBar.css
@@ -43,11 +43,7 @@
 }
 
 .sortByText {
-  display: none;
+  display: inline-block;
   color: dimmedTextColor;
   margin-right: 0.25rem;
-
-  @media (min-width: mediumRem) {
-    display: inline-block;
-  }
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -27,6 +27,7 @@ import { PSS_BASE_URL } from "constants/site";
 
 import { stylesheet } from "../components/HomePageComponents/HomePageSlider/HomePageSlider.css";
 import { stylesheet as guidesStylesheet } from "../components/shared/GuideLink/GuideLink.css";
+import { stylesheet as arrowStylesheet } from "../components/shared/CarouselNavArrows/CarouselNavArrows.css";
 
 const Home = ({ sourceSets, exhibitions, guides, headerDescription }) =>
   <MainLayout hideSearchBar>
@@ -55,6 +56,7 @@ const Home = ({ sourceSets, exhibitions, guides, headerDescription }) =>
       {/* <SocialMedia /> */}
     </div>
     <style dangerouslySetInnerHTML={{ __html: stylesheet }} />
+    <style dangerouslySetInnerHTML={{ __html: arrowStylesheet }} />
     <style dangerouslySetInnerHTML={{ __html: guidesStylesheet }} />
   </MainLayout>;
 


### PR DESCRIPTION
hiding arrows from keyboard… user has access to full list via keyboard anyway

changed `ul` and `li` to `div` because it is invalid html to have non-`li`s as direct children of `ul`s

addresses: 
https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-2059
https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-2049
https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-2058