### PR TITLE
made pss tabs more a11y

### DIFF
--- a/components/PrimarySourceSetsComponents/SingleSet/ResourcesTabs/ResourcesTabs.css
+++ b/components/PrimarySourceSetsComponents/SingleSet/ResourcesTabs/ResourcesTabs.css
@@ -38,15 +38,20 @@
   text-transform: uppercase;
   font-weight: 600;
   font-size: 0.75rem;
-  padding: 0 18px 16px;
   margin-right: 15px;
-  display: inline-block;
   flex: 1;
-  text-decoration: none;
-  color: black;
-
-  &:hover {
+  display: inline-block;
+  
+  & a {
+    display: block;
+    padding: 0 18px 16px;
     text-decoration: none;
+    color: black;
+  
+    &:hover {
+      text-decoration: none;
+      border-bottom: 0.2rem solid black;
+    }
   }
 
   @media (min-width: smallRem) {
@@ -54,9 +59,9 @@
   }
 }
 
-.activeTab {
+.activeTab a, .activeTab a:hover {
   color: linkColor;
-  border-bottom: 3px solid linkColor;
+  border-bottom: 0.2rem solid linkColor;
 }
 
 .tab:last-child {

--- a/components/PrimarySourceSetsComponents/SingleSet/ResourcesTabs/index.js
+++ b/components/PrimarySourceSetsComponents/SingleSet/ResourcesTabs/index.js
@@ -10,55 +10,76 @@ class ResourcesTabs extends React.Component {
     return (
       <div id="tabs" className={`${classNames.wrapper}`}>
         <div className={`${classNames.tabsWrapper} sourceSetTabsWrapper`}>
-          <div className={`${classNames.tabs} ${utilClassNames.container}`}>
-            <Link
-              prefetch
-              href={`/primary-source-sets/set?set=${route.query.set}#tabs`}
-              as={`/primary-source-sets/${route.query.set}#tabs`}
+          <ul
+            role="tablist"
+            className={`${classNames.tabs} ${utilClassNames.container}`}
+          >
+            <li
+              id="tab-sourceset"
+              role="tab"
+              aria-controls="panel-sourceset"
+              aria-selected={currentTab === "sourceSet"}
+              className={[
+                classNames.tab,
+                currentTab === "sourceSet" && classNames.activeTab
+              ].join(" ")}
             >
-              <a
-                className={[
-                  classNames.tab,
-                  currentTab === "sourceSet" && classNames.activeTab
-                ].join(" ")}
-              >
-                Source Set
-              </a>
-            </Link>
-            <Link
-              prefetch
-              href={`/primary-source-sets/set/additional-resources?set=${route
-                .query.set}#tabs`}
-              as={`/primary-source-sets/${route.query
-                .set}/additional-resources#tabs`}
-            >
-              <a
-                className={[
-                  classNames.tab,
-                  currentTab === "additionalResources" && classNames.activeTab
-                ].join(" ")}
-              >
-                Additional Resources
-              </a>
-            </Link>
-            {!route.query.studentMode &&
               <Link
                 prefetch
-                href={`/primary-source-sets/set/teaching-guide?set=${route.query
-                  .set}#tabs`}
-                as={`/primary-source-sets/${route.query
-                  .set}/teaching-guide#tabs`}
+                href={`/primary-source-sets/set?set=${route.query.set}#tabs`}
+                as={`/primary-source-sets/${route.query.set}#tabs`}
               >
-                <a
-                  className={[
-                    classNames.tab,
-                    currentTab === "teachingGuide" && classNames.activeTab
-                  ].join(" ")}
-                >
-                  Teaching Guide
+                <a>
+                  Source Set
                 </a>
-              </Link>}
-          </div>
+              </Link>
+            </li>
+            <li
+              id="tab-additionalresources"
+              role="tab"
+              aria-controls="panel-additionalresources"
+              aria-selected={currentTab === "additionalResources"}
+              className={[
+                classNames.tab,
+                currentTab === "additionalResources" && classNames.activeTab
+              ].join(" ")}
+            >
+              <Link
+                prefetch
+                href={`/primary-source-sets/set/additional-resources?set=${route
+                  .query.set}#tabs`}
+                as={`/primary-source-sets/${route.query
+                  .set}/additional-resources#tabs`}
+              >
+                <a>
+                  Additional Resources
+                </a>
+              </Link>
+            </li>
+            {!route.query.studentMode &&
+              <li
+                id="tab-teachingguide"
+                role="tab"
+                aria-controls="panel-teachingguide"
+                aria-selected={currentTab === "teachingGuide"}
+                className={[
+                  classNames.tab,
+                  currentTab === "teachingGuide" && classNames.activeTab
+                ].join(" ")}
+              >
+                <Link
+                  prefetch
+                  href={`/primary-source-sets/set/teaching-guide?set=${route
+                    .query.set}#tabs`}
+                  as={`/primary-source-sets/${route.query
+                    .set}/teaching-guide#tabs`}
+                >
+                  <a>
+                    Teaching Guide
+                  </a>
+                </Link>
+              </li>}
+          </ul>
         </div>
         {this.props.children}
         <style dangerouslySetInnerHTML={{ __html: stylesheet }} />

--- a/components/PrimarySourceSetsComponents/SingleSet/SourceSetSources/index.js
+++ b/components/PrimarySourceSetsComponents/SingleSet/SourceSetSources/index.js
@@ -11,47 +11,52 @@ import extractSourceId from "/utilFunctions/extractSourceId";
 const { container } = utilClassNames;
 
 const SourceSetSources = ({ route, sources }) =>
-  <div className={classNames.wrapper}>
-    <h2 className="invisible">Source Set</h2>
-    <div className={[classNames.sourceSetSources, container].join(" ")}>
+  <div
+    role="tabpanel"
+    aria-labelledby="tab-sourceset"
+    className={classNames.wrapper}
+  >
+    <ul className={[classNames.sourceSetSources, container].join(" ")}>
       {sources.map(({ name, thumbnailUrl, useDefaultImage }, i) => {
         const sourceId = extractSourceId(sources[i]["@id"]);
         return (
-          <Link
-            key={name}
-            prefetch
-            as={{
-              pathname: `/primary-source-sets/${route.query
-                .set}/sources/${sourceId}`,
-              query: removeQueryParams(route.query, ["source", "set"])
-            }}
-            href={{
-              pathname: `/primary-source-sets/set/sources`,
-              query: Object.assign({}, route.query, {
-                source: sourceId,
-                set: route.query.set
-              })
-            }}
-          >
-            <a className={classNames.set}>
-              <div
-                className={`${classNames.imageWrapper} ${useDefaultImage
-                  ? classNames.defaultImageWrapper
-                  : ""}`}
-              >
-                <img alt="" src={thumbnailUrl} className={classNames.image} />
-              </div>
-              <div
-                className={classNames.title}
-                dangerouslySetInnerHTML={{
-                  __html: markdownit.renderInline(name)
-                }}
-              />
-            </a>
-          </Link>
+          <li className={classNames.set}>
+            <Link
+              key={name}
+              prefetch
+              as={{
+                pathname: `/primary-source-sets/${route.query
+                  .set}/sources/${sourceId}`,
+                query: removeQueryParams(route.query, ["source", "set"])
+              }}
+              href={{
+                pathname: `/primary-source-sets/set/sources`,
+                query: Object.assign({}, route.query, {
+                  source: sourceId,
+                  set: route.query.set
+                })
+              }}
+            >
+              <a>
+                <div
+                  className={`${classNames.imageWrapper} ${useDefaultImage
+                    ? classNames.defaultImageWrapper
+                    : ""}`}
+                >
+                  <img alt="" src={thumbnailUrl} className={classNames.image} />
+                </div>
+                <div
+                  className={classNames.title}
+                  dangerouslySetInnerHTML={{
+                    __html: markdownit.renderInline(name)
+                  }}
+                />
+              </a>
+            </Link>
+          </li>
         );
       })}
-    </div>
+    </ul>
     <style dangerouslySetInnerHTML={{ __html: stylesheet }} />
   </div>;
 

--- a/components/PrimarySourceSetsComponents/SingleSet/TeachersGuide/index.js
+++ b/components/PrimarySourceSetsComponents/SingleSet/TeachersGuide/index.js
@@ -19,8 +19,11 @@ const googleClassroom = "/static/images/google-classroom.svg";
 const printHandler = () => window.print();
 
 const TeachersGuide = ({ route, teachingGuide, setName, currentPath }) =>
-  <div className={classNames.wrapper}>
-    <h2 className="invisible">Teaching Guide</h2>
+  <div
+    className={classNames.wrapper}
+    role="tabpanel"
+    aria-labelledby="tab-teachingguide"
+  >
     <div className={`${classNames.teachingGuide} ${container}`}>
       <div className="row">
         <div className="col-xs-12 col-md-8">

--- a/pages/primary-source-sets/set/additional-resources.js
+++ b/pages/primary-source-sets/set/additional-resources.js
@@ -39,8 +39,11 @@ const SingleSet = ({ url, set, currentFullUrl }) =>
     <SourceSetInfo set={set} currentFullUrl={currentFullUrl} />
     <ResourcesTabs route={url} currentTab="additionalResources" set={set}>
       <div className={classNames.content}>
-        <div className={container}>
-          <h2 className="invisible">Additional Resources</h2>
+        <div
+          className={container}
+          role="tabpanel"
+          aria-labelledby="tab-teachingguide"
+        >
           <div
             className={`${contentClasses.content} ${container}`}
             dangerouslySetInnerHTML={{


### PR DESCRIPTION
added some roles and other aria stuff to the panels for better keyboard support. this also meant removing some of audrey's hidden headings which became unnecessary

however, this is a partial fix since the tab panels also invoke a url change which means that in firefox and safari the tab panel loses focus and the user now needs to tab all the way down to the panel to read the information. this doesnt happen as much in chrome. we would need to revisit the linking structure for pss if we want to change this behavior

basing off of this example: http://accessibility.athena-ict.com/aria/examples/tabpanel2.shtml

addresses: https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-2074