### PR TITLE
fixed analytics

### DIFF
--- a/.ebextensions/nginx.config
+++ b/.ebextensions/nginx.config
@@ -93,9 +93,9 @@ files:
                     # rewrite ^/info/get-involved ...  # Pro Site main page
                     # rewrite ^/apps ...               # Pro Site > Developers > Apps
 
-                    rewrite ^/info/get-involved/follow /contact-us permanent;
+                    rewrite ^/info/get-involved/follow /contact permanent;
                     rewrite ^/info/about/awards / permanent;
-                    rewrite ^/info/contact /contact-us permanent;
+                    rewrite ^/info/contact /contact permanent;
                     # rewrite ^/info/about/leadership-transition ... # [Blog search /info/category/executive-director-search/]
                     rewrite ^/info/about/policies /terms-conditions permanent;
                     rewrite ^/info/donate /donate permanent;

--- a/components/ExhibitionsComponents/Exhibition/Details/index.js
+++ b/components/ExhibitionsComponents/Exhibition/Details/index.js
@@ -28,7 +28,7 @@ const Details = ({ exhibition, route, currentFullUrl }) =>
                     })
                   }}
                   as={{
-                    pathname: `/exhibitions/${exhibition.slug}/${section.slug}/`
+                    pathname: `/exhibitions/${exhibition.slug}/${section.slug}`
                   }}
                 >
                   <a className="hover-underline">

--- a/components/ExhibitionsComponents/Exhibition/ImageAndCaption/index.js
+++ b/components/ExhibitionsComponents/Exhibition/ImageAndCaption/index.js
@@ -41,7 +41,7 @@ const ImageAndCaption = ({ exhibition, route }) =>
               }}
               as={{
                 pathname: `/exhibitions/${exhibition.slug}/${exhibition
-                  .sections[0].slug}/`
+                  .sections[0].slug}`
               }}
             >
               Explore Exhibition

--- a/components/ItemComponents/Content/OtherMetadata.js
+++ b/components/ItemComponents/Content/OtherMetadata.js
@@ -12,7 +12,7 @@ const FacetLink = ({ facet, value, facetLabel }) =>
   <span>
     <Link
       prefetch
-      href={{ pathname: "/search/", query: { [facet]: `"${value}"` } }}
+      href={{ pathname: "/search", query: { [facet]: `"${value}"` } }}
     >
       <a
         className="link"

--- a/components/MainLayout/components/Footer/index.js
+++ b/components/MainLayout/components/Footer/index.js
@@ -52,7 +52,7 @@ const Footer = () =>
               </Link>
             </li>
             <li>
-              <Link href="/contact-us">
+              <Link as="/contact" href="/contact-us">
                 <a>Contact Us</a>
               </Link>
             </li>

--- a/components/PrimarySourceSetsComponents/PSSFooter/index.js
+++ b/components/PrimarySourceSetsComponents/PSSFooter/index.js
@@ -13,7 +13,7 @@ const OtherInfo = () =>
         <span>
           These sets were created and reviewed by the teachers on the&nbsp;
         </span>
-        <Link href="//pro.dp.la/education/education-advisory-committee/">
+        <Link href="//pro.dp.la/education/education-advisory-committee">
           <a className="link">
             DPLA's Education Advisory Committee.
           </a>

--- a/components/shared/ContentPagesSidebar/index.js
+++ b/components/shared/ContentPagesSidebar/index.js
@@ -114,7 +114,7 @@ const Sidebar = ({ activeItemId, items, route }) =>
           section="contact-us"
           isCurrentLink={activeItemId === "contact-us"}
           linkObject={{
-            as: "/contact-us",
+            as: "/contact",
             href: "/contact-us"
           }}
         />

--- a/pages/about/index.js
+++ b/pages/about/index.js
@@ -54,10 +54,10 @@ AboutMenuPage.getInitialProps = async ({ req, query, res }) => {
     return {};
   } else if (pageItem.menu_item_parent === guidesPageItem.object_id) {
     if (res) {
-      res.redirect(`/guides/guide/?guide=${pageItem.post_name}`);
+      res.redirect(`/guides/guide?guide=${pageItem.post_name}`);
     } else {
       Router.push(
-        `/guides/guide/?guide=${pageItem.post_name}`,
+        `/guides/guide?guide=${pageItem.post_name}`,
         `/guides/${pageItem.post_name}`
       );
     }

--- a/pages/browse-by-topic/topic/subtopic/index.js
+++ b/pages/browse-by-topic/topic/subtopic/index.js
@@ -43,7 +43,7 @@ const SubtopicItemsList = ({
         {
           title: topic.name,
           as: `/browse-by-topic/${topic.slug}`,
-          url: `/browse-by-topic/topic/?topic=${topic.slug}`
+          url: `/browse-by-topic/topic?topic=${topic.slug}`
         },
         { title: subtopic.name, url: "" }
       ]}
@@ -69,7 +69,7 @@ const SubtopicItemsList = ({
         {
           title: topic.name,
           as: `/browse-by-topic/${topic.slug}`,
-          url: `/browse-by-topic/topic/?topic=${topic.slug}`
+          url: `/browse-by-topic/topic?topic=${topic.slug}`
         },
         { title: subtopic.name, url: "" }
       ]}

--- a/pages/exhibitions/exhibition/index.js
+++ b/pages/exhibitions/exhibition/index.js
@@ -22,7 +22,7 @@ const Exhibition = ({ url, exhibition, currentFullUrl }) =>
         {
           title: "Exhibitions",
           url: {
-            pathname: "/exhibitions/",
+            pathname: "/exhibitions",
             query: removeQueryParams(url.query, ["exhibition"])
           }
         },

--- a/pages/item/index.js
+++ b/pages/item/index.js
@@ -41,7 +41,7 @@ const ItemDetail = ({
         {
           title: url.query.q ? `Search for “${url.query.q}”` : "Search",
           url: {
-            pathname: "/search/",
+            pathname: "/search",
             query: removeQueryParams(url.query, ["itemId, next, previous"])
           }
         },

--- a/pages/primary-source-sets/set/additional-resources.js
+++ b/pages/primary-source-sets/set/additional-resources.js
@@ -28,7 +28,7 @@ const SingleSet = ({ url, set, currentFullUrl }) =>
         {
           title: "Primary Source Sets",
           url: {
-            pathname: "/primary-source-sets/",
+            pathname: "/primary-source-sets",
             query: removeQueryParams(url.query, ["set"])
           }
         },

--- a/pages/primary-source-sets/set/index.js
+++ b/pages/primary-source-sets/set/index.js
@@ -21,7 +21,7 @@ const SingleSet = ({ set, url, currentFullUrl }) =>
         {
           title: "Primary Source Sets",
           url: {
-            pathname: "/primary-source-sets/",
+            pathname: "/primary-source-sets",
             query: removeQueryParams(url.query, ["set"])
           }
         },

--- a/pages/primary-source-sets/set/sources/index.js
+++ b/pages/primary-source-sets/set/sources/index.js
@@ -30,7 +30,7 @@ const Source = ({ url, source, set, currentSourceIdx }) =>
             query: removeQueryParams(url.query, ["source", "set"])
           },
           url: {
-            pathname: "/primary-source-sets/set/",
+            pathname: "/primary-source-sets/set",
             query: Object.assign({}, removeQueryParams(url.query, ["source"]))
           }
         },

--- a/pages/primary-source-sets/set/teaching-guide.js
+++ b/pages/primary-source-sets/set/teaching-guide.js
@@ -17,7 +17,7 @@ const SingleSet = ({ url, set, teachingGuide, currentPath, currentFullUrl }) =>
         {
           title: "Primary Source Sets",
           url: {
-            pathname: "/primary-source-sets/",
+            pathname: "/primary-source-sets",
             query: removeQueryParams(url.query, ["set"])
           }
         },

--- a/server.js
+++ b/server.js
@@ -199,7 +199,7 @@ app
 
     // contact us routes
 
-    server.get(["/contact-us", "/contact-us"], (req, res) => {
+    server.get("/contact", (req, res) => {
       app.render(req, res, "/contact-us", req.query);
     });
 


### PR DESCRIPTION
turns out the double analytics counts were due to trailing slashes in urls like `/exhibitions/` or `/search/?query=dogs` so i removed (i hope) all of those

renamed `/about-us`to `/about` and `/contact-us` to `/contact`

added mark because changed some nginx redirects

addresses:
https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1907
https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1733