### PR TITLE
breadcrumb + markdown fix

### DIFF
--- a/components/Breadcrumbs/Breadcrumbs.css
+++ b/components/Breadcrumbs/Breadcrumbs.css
@@ -10,11 +10,18 @@
 
 .activeBreadcrumb {
   display: inline-block;
-  max-width: 215px;
+  max-width: 30rem;
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
   line-height: 1.2;
+
+  @media (max-width: smallRem) {
+    display: inline;
+    white-space: normal;
+    max-width: none;
+  }
+
   @media (min-width: smallRem) {
     font-size: 1rem;
   }

--- a/components/PrimarySourceSetsComponents/SingleSet/SourceSetInfo/index.js
+++ b/components/PrimarySourceSetsComponents/SingleSet/SourceSetInfo/index.js
@@ -57,7 +57,7 @@ class SourceSetInfo extends React.Component {
                 id="dpla-description"
                 className={`${classNames.description} sourceSetDescription`}
                 dangerouslySetInnerHTML={{
-                  __html: markdownit.renderInline(
+                  __html: markdownit.render(
                     set.hasPart
                       .find(item => item.name === "Overview")
                       .text.replace(


### PR DESCRIPTION
pss overview markdown was not being used

https://dp.la/primary-source-sets/sets/puerto-rican-migration-to-the-us
vs
https://postlight-staging.dp.la/primary-source-sets/puerto-rican-migration-to-the-us

also addresses: https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-1793