### PR TITLE
opening item url in new window

### DIFF
--- a/components/ItemComponents/Content/OtherMetadata.js
+++ b/components/ItemComponents/Content/OtherMetadata.js
@@ -77,7 +77,7 @@ const OtherMetadata = ({ item }) =>
           </Row>}
         {item.sourceUrl &&
           <Row heading="URL">
-            <a className="link" href={item.sourceUrl}>
+            <a className="link" href={item.sourceUrl} target="_blank">
               {item.sourceUrl}
             </a>
           </Row>}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".", // all paths are relative to the baseUrl
+    "target": "ES6",
+    "moduleResolution": "node",
+    "paths": {
+      "utilFunctions/*": [
+        "./utilFunctions/*"
+      ],
+      "constants/*": [
+        "./constants/*"
+      ],
+      "components/*": [
+        "./components/*"
+      ]
+    }
+  },
+  "exclude": [
+    "node_modules",
+    "lib",
+    ".tmp",
+    "build",
+    ".next"
+  ]
+}

--- a/pages/item/index.js
+++ b/pages/item/index.js
@@ -2,10 +2,10 @@ import React from "react";
 import Link from "next/link";
 import fetch from "isomorphic-fetch";
 
-import MainLayout from "../../components/MainLayout";
-import BreadcrumbsModule from "../../components/ItemComponents/BreadcrumbsModule";
-import Content from "../../components/ItemComponents/Content";
-import CiteButton from "../../components/shared/CiteButton";
+import MainLayout from "components/MainLayout";
+import BreadcrumbsModule from "components/ItemComponents/BreadcrumbsModule";
+import Content from "components/ItemComponents/Content";
+import CiteButton from "components/shared/CiteButton";
 import { API_ENDPOINT, THUMBNAIL_ENDPOINT } from "constants/items";
 import { getCurrentUrl, getCurrentFullUrl } from "utilFunctions";
 import { classNames as utilClassNames } from "css/utils.css";
@@ -18,7 +18,7 @@ import {
 import {
   classNames,
   stylesheet
-} from "../../components/ItemComponents/itemComponent.css";
+} from "components/ItemComponents/itemComponent.css";
 import {
   removeQueryParams,
   joinIfArray,


### PR DESCRIPTION
as with “view full item” button

added a `jsconfig` file for visual studio code that adds some nice “intellisense” features like not having to put relative urls to module imports so that option+click takes you to the module