### PR TITLE
Fix/parse pss provider

### DIFF
--- a/components/PrimarySourceSetsComponents/Source/components/ContentAndMetadata/index.js
+++ b/components/PrimarySourceSetsComponents/Source/components/ContentAndMetadata/index.js
@@ -39,10 +39,21 @@ const getItemId = source =>
     )[0]["@id"]
   );
 
-const getPartner = source =>
-  source.mainEntity[0]["provider"].filter(
-    ref => ref["disabmiguationDescription"] == "partner"
-  )["name"];
+const getPartner = source => {
+  const provider = source.mainEntity[0]["provider"];
+  var providerName = "";
+
+  if (provider instanceof Array) {
+    // This works with a more recent iteration of the PSS API.
+    providerName = provider.filter(
+      ref => ref["disabmiguationDescription"] == "partner"
+    )["name"];
+  } else {
+    // This works with the original version of the PSS API.
+    providerName = provider.name;
+  }
+  return providerName;
+};
 
 const getViewerComponent = (fileFormat, type, pathToFile) => {
   if (type === "MediaObject") {


### PR DESCRIPTION
This enables the primary source sets ContentAndMetadata component to parse either a string or array value for partner.  The current production version of the PSS API has a string value, but we will need to deploy a new version of the PSS API that has an array value.  This is the change to the PSS API (which has not yet been deployed): https://github.com/dpla/primary-source-sets/pull/200

The plan is to deploy this PR to dpla-frontend first, and then deploy the latest PSS API.  This has been tested locally against the current production PSS API.