### PR TITLE
fix pss partner parse

### DIFF
--- a/components/PrimarySourceSetsComponents/Source/components/ContentAndMetadata/index.js
+++ b/components/PrimarySourceSetsComponents/Source/components/ContentAndMetadata/index.js
@@ -46,8 +46,8 @@ const getPartner = source => {
   if (provider instanceof Array) {
     // This works with a more recent iteration of the PSS API.
     providerName = provider.filter(
-      ref => ref["disabmiguationDescription"] == "partner"
-    )["name"];
+      ref => ref["disambiguationDescription"] == "partner"
+    )[0]["name"];
   } else {
     // This works with the original version of the PSS API.
     providerName = provider.name;

--- a/server.js
+++ b/server.js
@@ -440,9 +440,9 @@ app
         userResDecorator: function(proxyRes, proxyResData, userReq, userRes) {
           const data = JSON.parse(proxyResData.toString("utf8"));
           const file_urls = data[0].file_urls;
-          Object.keys(file_urls).forEach(key => {
-            file_urls[key] = replaceWithProxyEndpoint(file_urls[key], userReq);
-          });
+          // Object.keys(file_urls).forEach(key => {
+          //   file_urls[key] = replaceWithProxyEndpoint(file_urls[key], userReq);
+          // });
           return JSON.stringify(data);
         }
       })


### PR DESCRIPTION
This fixes the way that the partner name is parsed with the most recent version of the PSS API.