### PR TITLE
Fix browse event - partner and ID

### DIFF
--- a/components/shared/ListView/GaListViewWrapper.js
+++ b/components/shared/ListView/GaListViewWrapper.js
@@ -72,9 +72,9 @@ export default WrappedComponent =>
           if (item) {
             const gaEvent = {
               type: "Browse Item",
-              itemId: item.dplaItemId,
+              itemId: item.id,
               title: joinIfArray(item.title),
-              partner: joinIfArray(item.partner),
+              partner: joinIfArray(item.provider),
               contributor: joinIfArray(item.dataProvider)
             };
 


### PR DESCRIPTION
This fixes some variable names so that the "Browse Item" event tracks the correct data.  This has been tested locally.  It addresses https://github.com/dpla/dpla-frontend/issues/653