### PR TITLE
One-off redirect for exhibition page

### DIFF
--- a/.ebextensions/nginx.config
+++ b/.ebextensions/nginx.config
@@ -130,6 +130,8 @@ files:
                     }
 
                     # ... Exhibitions Redirects
+                    # one off fix to single omeka page that had reused a slug
+                    rewrite ^/exhibitions/exhibits/show/radio-golden-age/radio-frontlines/radio-homefront /exhibitions/radio-golden-age/radio-frontlines/radio-homefront-wwii permanent;
                     rewrite ^/exhibitions/exhibits/show/([0-9a-z\-/]+) /exhibitions/$1 permanent;
 
                     # ... Primary Source Sets Redirects


### PR DESCRIPTION
One-off redirect for exhibition page that had slug changed to avoid 
two pages having the same slug.