### PR TITLE
improved show more in some places

### DIFF
--- a/components/ItemComponents/Content/Content.css
+++ b/components/ItemComponents/Content/Content.css
@@ -82,6 +82,10 @@
   border-top: .075rem solid gray;
   font-size: 1rem;
 
+  &.open {
+    display: none;
+  }
+
   @media (max-width: mediumRem) {
     padding: .25rem 1rem 1rem;
   }

--- a/components/ItemComponents/Content/MainMetadata.js
+++ b/components/ItemComponents/Content/MainMetadata.js
@@ -113,9 +113,13 @@ const MainMetadata = ({ item }) => {
                   {joinIfArray(item.description)}
                 </div>
                 {descriptionIsLong &&
-                  <div id="dpla-showmore" aria-hidden="true">
+                  <div
+                    id="dpla-showmore"
+                    aria-hidden="true"
+                    className={classNames.showMore}
+                  >
                     <span
-                      className={`${classNames.showMore} link`}
+                      className={`link`}
                       onClick={() =>
                         showMoreDescription({ className: classNames.open })}
                     >

--- a/components/PrimarySourceSetsComponents/SingleSet/SourceSetInfo/SourceSetInfo.css
+++ b/components/PrimarySourceSetsComponents/SingleSet/SourceSetInfo/SourceSetInfo.css
@@ -114,6 +114,10 @@
   padding: .25rem 0;
   border-top: .075rem solid gray;
 
+  &.open {
+    display: none;
+  }
+
   @media (max-width: mediumRem) {
     padding: .25rem 1rem 1rem;
     font-size: 0.9rem;

--- a/components/PrimarySourceSetsComponents/SingleSet/SourceSetInfo/index.js
+++ b/components/PrimarySourceSetsComponents/SingleSet/SourceSetInfo/index.js
@@ -7,7 +7,6 @@ import {
 } from "constants/primarySourceSets";
 import Button from "components/shared/Button";
 import CiteButton from "components/shared/CiteButton";
-import { showMoreDescription } from "utilFunctions";
 
 import { stylesheet, classNames } from "./SourceSetInfo.css";
 import { classNames as utilClassNames } from "css/utils.css";
@@ -22,6 +21,16 @@ const extractSubjects = tags =>
   tags.filter(tag => !tag.sameAs).map(tag => tag.name);
 
 class SourceSetInfo extends React.Component {
+  state = { isOpen: false };
+
+  componentWillReceiveProps() {
+    this.setState({ isOpen: this.props.openDescription || false });
+  }
+
+  showMoreDescription() {
+    this.setState({ isOpen: true });
+  }
+
   render() {
     const { set, currentFullUrl } = this.props;
     const authorList = set.author.map(author => author.name);
@@ -50,7 +59,10 @@ class SourceSetInfo extends React.Component {
               </div>
               <div
                 id="dpla-description"
-                className={`${classNames.description} sourceSetDescription`}
+                className={`${classNames.description} sourceSetDescription ${classNames.description} ${this
+                  .state.isOpen
+                  ? classNames.open
+                  : ""}`}
                 dangerouslySetInnerHTML={{
                   __html: markdownit.render(
                     set.hasPart
@@ -66,11 +78,16 @@ class SourceSetInfo extends React.Component {
                   )
                 }}
               />
-              <div id="dpla-showmore" aria-hidden="true">
+              <div
+                id="dpla-showmore"
+                aria-hidden="true"
+                className={`${classNames.showMore} ${this.state.isOpen
+                  ? classNames.open
+                  : ""}`}
+              >
                 <span
-                  className={`${classNames.showMore} link`}
-                  onClick={() =>
-                    showMoreDescription({ className: classNames.open })}
+                  className={`link`}
+                  onClick={() => this.showMoreDescription()}
                 >
                   Show full overview
                 </span>

--- a/components/PrimarySourceSetsComponents/Source/components/ContentAndMetadata/ContentAndMetadata.css
+++ b/components/PrimarySourceSetsComponents/Source/components/ContentAndMetadata/ContentAndMetadata.css
@@ -72,6 +72,10 @@
   border-top: .075rem solid gray;
   font-size: 1rem;
 
+  &.open {
+    display: none;
+  }
+
   @media (max-width: mediumRem) {
     padding: .25rem 1rem 1rem;
   }

--- a/components/PrimarySourceSetsComponents/Source/components/ContentAndMetadata/index.js
+++ b/components/PrimarySourceSetsComponents/Source/components/ContentAndMetadata/index.js
@@ -14,7 +14,6 @@ import {
   joinIfArray,
   getItemId,
   getPartner,
-  showMoreDescription,
   getTitle,
   getContributor,
   trackGaEvent
@@ -85,165 +84,189 @@ const trackClickThrough = (e, source, target = "_blank") => {
   }
 };
 
-const ContentAndMetadata = ({ source }) => {
-  const type = source.mainEntity[0]["@type"];
-  const { fileFormat, contentUrl } = source.mainEntity[0].associatedMedia[0];
-  // some file types aren't stored with full domain
-  // so we determine what the full domain is here
+class ContentAndMetadata extends React.Component {
+  state = { isOpen: false };
 
-  const fullContentUrl = source.thumbnailUrl &&
-    !/^(?:https?:)?\/\//.test(contentUrl)
-    ? `https:${getDomainFromThumbnail(source.thumbnailUrl)}${contentUrl}`
-    : contentUrl;
+  componentWillReceiveProps() {
+    this.setState({ isOpen: this.props.openDescription || false });
+  }
 
-  const viewerComponent = getViewerComponent(fileFormat, type, fullContentUrl);
+  showMoreDescription() {
+    this.setState({ isOpen: true });
+  }
 
-  const maxDescriptionLength = 600; //characters
-  const descriptionIsLong = source.text
-    ? source.text.length > maxDescriptionLength
-    : false;
+  render() {
+    const { source } = this.props;
+    const type = source.mainEntity[0]["@type"];
+    const { fileFormat, contentUrl } = source.mainEntity[0].associatedMedia[0];
+    // some file types aren't stored with full domain
+    // so we determine what the full domain is here
 
-  return (
-    <div className={classNames.wrapper}>
-      <div className={[classNames.contentAndMetadata, container].join(" ")}>
-        <h1
-          dangerouslySetInnerHTML={{
-            __html: markdownit.renderInline(source.name)
-          }}
-          className={classNames.contentHeader}
-        />
-        <div className={classNames.flexWrapper}>
-          <div className={classNames.contentWrapper}>
-            <div className={classNames.content}>
-              {viewerComponent}
-            </div>
-            {source.text &&
-              <div
-                id="dpla-description"
-                className={`${classNames.description} ${descriptionIsLong
-                  ? classNames.longDescription
-                  : ""}`}
-                dangerouslySetInnerHTML={{
-                  __html: markdownit
-                    .render(source.text)
-                    .replace(/&lt;br&gt;/g, "<br>")
-                }}
-              />}
-            {descriptionIsLong &&
-              <div id="dpla-showmore" aria-hidden="true">
-                <span
-                  className={`${classNames.showMore} link`}
-                  onClick={() =>
-                    showMoreDescription({ className: classNames.open })}
-                >
-                  Show full description
-                </span>
-              </div>}
+    const fullContentUrl = source.thumbnailUrl &&
+      !/^(?:https?:)?\/\//.test(contentUrl)
+      ? `https:${getDomainFromThumbnail(source.thumbnailUrl)}${contentUrl}`
+      : contentUrl;
 
-          </div>
-          <div className={classNames.metadata}>
-            <div className={classNames.sourceInfo}>
-              <div className={classNames.buttons}>
-                {getSourceCitation(source) &&
-                  <div
-                    className={`${classNames.citeButton} ${classNames.faveAndCiteButtons}`}
-                  >
-                    <CiteButton
-                      toCiteText="item"
-                      freeText={getSourceCitation(source)}
-                      className={""}
-                      title={source.name}
-                    />
-                  </div>}
+    const viewerComponent = getViewerComponent(
+      fileFormat,
+      type,
+      fullContentUrl
+    );
+
+    const maxDescriptionLength = 600; //characters
+    const descriptionIsLong = source.text
+      ? source.text.length > maxDescriptionLength
+      : false;
+
+    return (
+      <div className={classNames.wrapper}>
+        <div className={[classNames.contentAndMetadata, container].join(" ")}>
+          <h1
+            dangerouslySetInnerHTML={{
+              __html: markdownit.renderInline(source.name)
+            }}
+            className={classNames.contentHeader}
+          />
+          <div className={classNames.flexWrapper}>
+            <div className={classNames.contentWrapper}>
+              <div className={classNames.content}>
+                {viewerComponent}
               </div>
-              {/* <a href={fullContentUrl} download className={classNames.button}>
+              {source.text &&
+                <div
+                  id="dpla-description"
+                  className={`${classNames.description} ${descriptionIsLong
+                    ? classNames.longDescription
+                    : ""} ${this.state.isOpen ? classNames.open : ""}`}
+                  dangerouslySetInnerHTML={{
+                    __html: markdownit
+                      .render(source.text)
+                      .replace(/&lt;br&gt;/g, "<br>")
+                  }}
+                />}
+              {descriptionIsLong &&
+                <div
+                  id="dpla-showmore"
+                  aria-hidden="true"
+                  className={`${classNames.showMore} ${this.state.isOpen
+                    ? classNames.open
+                    : ""}`}
+                >
+                  <span
+                    className={`link`}
+                    onClick={() => this.showMoreDescription()}
+                  >
+                    Show full description
+                  </span>
+                </div>}
+
+            </div>
+            <div className={classNames.metadata}>
+              <div className={classNames.sourceInfo}>
+                <div className={classNames.buttons}>
+                  {getSourceCitation(source) &&
+                    <div
+                      className={`${classNames.citeButton} ${classNames.faveAndCiteButtons}`}
+                    >
+                      <CiteButton
+                        toCiteText="item"
+                        freeText={getSourceCitation(source)}
+                        className={""}
+                        title={source.name}
+                      />
+                    </div>}
+                </div>
+                {/* <a href={fullContentUrl} download className={classNames.button}>
                 Download
               </a> */}
-              {getSourceCitation(source, "credits") &&
-                <div
-                  className={classNames.courtesyOf}
-                  dangerouslySetInnerHTML={{
-                    __html: markdownit.renderInline(
-                      joinIfArray(getSourceCitation(source, "credits"))
-                    )
-                  }}
-                />}
-              {source.mainEntity[0]["dct:provenance"] &&
-                <div
-                  className={classNames.courtesyOf}
-                  dangerouslySetInnerHTML={{
-                    __html: markdownit.renderInline(
-                      source.mainEntity[0]["dct:provenance"].name
-                    )
-                  }}
-                />}
-              {source.copyright &&
-                <div className={classNames.copyrightInfo}>
-                  <img src="" alt="" className={classNames.copyrightIcon} />
-                  <p
-                    className={classNames.copyrightText}
+                {getSourceCitation(source, "credits") &&
+                  <div
+                    className={classNames.courtesyOf}
                     dangerouslySetInnerHTML={{
-                      __html: markdownit.renderInline(source.copyright)
+                      __html: markdownit.renderInline(
+                        joinIfArray(getSourceCitation(source, "credits"))
+                      )
                     }}
-                  />
-                </div>}
-              <div className={classNames.divider} />
-              {source.mainEntity[0]["dct:references"] &&
-                <div className={classNames.linkWrapper}>
-                  <a
-                    className={classNames.sourceLink}
-                    href={`/item/${getItemId(source)}`}
-                  >
-                    <img
-                      alt="Link icon"
-                      src={link}
-                      className={classNames.linkIcon}
+                  />}
+                {source.mainEntity[0]["dct:provenance"] &&
+                  <div
+                    className={classNames.courtesyOf}
+                    dangerouslySetInnerHTML={{
+                      __html: markdownit.renderInline(
+                        source.mainEntity[0]["dct:provenance"].name
+                      )
+                    }}
+                  />}
+                {source.copyright &&
+                  <div className={classNames.copyrightInfo}>
+                    <img src="" alt="" className={classNames.copyrightIcon} />
+                    <p
+                      className={classNames.copyrightText}
+                      dangerouslySetInnerHTML={{
+                        __html: markdownit.renderInline(source.copyright)
+                      }}
                     />
-                    <span className={classNames.linkText}>
-                      View item information
-                    </span>
-                  </a>
-                </div>}
-              {source.mainEntity[0]["dct:references"] &&
-                <div className={classNames.linkWrapper}>
-                  <a
-                    href={getSourceLink(source)}
-                    className={`${classNames.sourceLink}`}
-                    onClick={e => trackClickThrough(e, source)}
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    <img
-                      alt="External link icon"
-                      src={external}
-                      className={classNames.externalIcon}
-                    />
-                    <span className={classNames.linkText}>
-                      View in {getPartner(source)}
-                    </span>
-                  </a>
-                </div>}
-            </div>
-            <div className={classNames.tipsForStudents}>
-              <h2 className={classNames.tipsForStudentsHeader}>
-                Tips for Students
-              </h2>
-              <p className={classNames.tipDirections}>
-                For this source, consider:
-              </p>
-              <ul className={classNames.tips}>
-                <li className={classNames.tip}>the author's point of view</li>
-                <li className={classNames.tip}>the author's purpose</li>
-                <li className={classNames.tip}>historical context</li>
-                <li className={classNames.tip}>audience</li>
-              </ul>
+                  </div>}
+                <div className={classNames.divider} />
+                {source.mainEntity[0]["dct:references"] &&
+                  <div className={classNames.linkWrapper}>
+                    <a
+                      className={classNames.sourceLink}
+                      href={`/item/${getItemId(source)}`}
+                    >
+                      <img
+                        alt="Link icon"
+                        src={link}
+                        className={classNames.linkIcon}
+                      />
+                      <span className={classNames.linkText}>
+                        View item information
+                      </span>
+                    </a>
+                  </div>}
+                {source.mainEntity[0]["dct:references"] &&
+                  <div className={classNames.linkWrapper}>
+                    <a
+                      href={getSourceLink(source)}
+                      className={`${classNames.sourceLink}`}
+                      onClick={e => trackClickThrough(e, source)}
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <img
+                        alt="External link icon"
+                        src={external}
+                        className={classNames.externalIcon}
+                      />
+                      <span className={classNames.linkText}>
+                        View in {getPartner(source)}
+                      </span>
+                    </a>
+                  </div>}
+              </div>
+              <div className={classNames.tipsForStudents}>
+                <h2 className={classNames.tipsForStudentsHeader}>
+                  Tips for Students
+                </h2>
+                <p className={classNames.tipDirections}>
+                  For this source, consider:
+                </p>
+                <ul className={classNames.tips}>
+                  <li className={classNames.tip}>
+                    the author's point of view
+                  </li>
+                  <li className={classNames.tip}>the author's purpose</li>
+                  <li className={classNames.tip}>historical context</li>
+                  <li className={classNames.tip}>audience</li>
+                </ul>
+              </div>
             </div>
           </div>
         </div>
+        <style dangerouslySetInnerHTML={{ __html: stylesheet }} />
       </div>
-      <style dangerouslySetInnerHTML={{ __html: stylesheet }} />
-    </div>
-  );
-};
+    );
+  }
+}
 
 export default GaPssWrapper(ContentAndMetadata);

--- a/pages/news/index.js
+++ b/pages/news/index.js
@@ -113,6 +113,7 @@ class NewsPage extends React.Component {
                   <input
                     type="text"
                     name="k"
+                    aria-label="search news"
                     className={classNames.keywordsInput}
                     defaultValue={this.state.keywords}
                   />

--- a/pages/primary-source-sets/set/index.js
+++ b/pages/primary-source-sets/set/index.js
@@ -29,7 +29,11 @@ const SingleSet = ({ set, url, currentFullUrl }) =>
       ]}
       route={url}
     />
-    <SourceSetInfo set={set} currentFullUrl={currentFullUrl} />
+    <SourceSetInfo
+      set={set}
+      currentFullUrl={currentFullUrl}
+      openDescription={false}
+    />
     <ResourcesTabs route={url} currentTab="sourceSet" set={set}>
       <SourceSetSources
         sources={set.hasPart.filter(

--- a/utilFunctions/showMoreDescription.js
+++ b/utilFunctions/showMoreDescription.js
@@ -6,7 +6,7 @@ const showMoreDescription = ({
   const description = document.getElementById(descriptionId);
   const showmore = document.getElementById(showMoreId);
   description.classList.add(className);
-  showmore.remove();
+  showmore.classList.add(className);
 };
 
 export default showMoreDescription;


### PR DESCRIPTION
this improves the behavior of the “show more” links in pss and pss sources by preserving the state of the description while jumping from one pss and pss source to another. the description is collapsed by default. this also happens when moving from tab to tab (eg: to the teaching guide) since the user is likely more interested in that content than the rest of the page.

this approach will also be necessary if/when we decide to have next/previous buttons in items

this fixes #678 