### PR TITLE
fixed array-based search params

### DIFF
--- a/components/SearchComponents/FiltersList/index.js
+++ b/components/SearchComponents/FiltersList/index.js
@@ -6,7 +6,7 @@ import {
   mapURLPrettifiedFacetsToUgly,
   mapFacetsToURLPrettified
 } from "constants/search";
-import { removeQueryParams } from "utilFunctions";
+import { removeQueryParams, joinIfArray } from "utilFunctions";
 
 import { classNames, stylesheet } from "./FiltersList.css";
 import { classNames as utilClassNames } from "css/utils.css";
@@ -23,7 +23,8 @@ const clearAllFacets = query => {
 
 const clearFacet = (query, queryKey, facet) => {
   const duped = Object.assign({}, query);
-  duped[queryKey] = duped[queryKey]
+  const value = joinIfArray(duped[queryKey]);
+  duped[queryKey] = value
     .split("|")
     .filter(facetPart => facetPart.replace(/"/g, "") !== facet)
     .join("|");
@@ -79,14 +80,15 @@ class FiltersList extends React.Component {
               <span className={classNames.labelText}>Filtered by</span>
               <ul className={classNames.filters}>
                 {Object.keys(query).map((queryKey, index) => {
+                  const value = joinIfArray(query[queryKey]);
                   if (
                     possibleFacets.includes(
                       mapURLPrettifiedFacetsToUgly[queryKey]
                     )
                   ) {
                     return (
-                      query[queryKey] &&
-                      query[queryKey].split("|").map((paramValue, idx) => {
+                      value &&
+                      value.split("|").map((paramValue, idx) => {
                         const name = queryKey !== "after" &&
                           queryKey !== "before"
                           ? paramValue.replace(/"/g, "")

--- a/constants/search.js
+++ b/constants/search.js
@@ -42,7 +42,12 @@ export const prettifiedFacetMap = {
   "provider.name": "Partner"
 };
 
+import { joinIfArray } from "utilFunctions";
+
 export const splitAndURIEncodeFacet = facet =>
-  facet.split("|").map(param => encodeURIComponent(param)).join("+AND+");
+  joinIfArray(facet)
+    .split("|")
+    .map(param => encodeURIComponent(param))
+    .join("+AND+");
 
 export const DEFAULT_PAGE_SIZE = "20";


### PR DESCRIPTION
old dpla had array-based parameters (eg: `search?partner[]=value`) and new one doesnt (eg: `search?partner=value`). this breaks the site when using old links that exist throughout the news content like this one: https://dp.la/news/ohio-digital-network-brings-the-buckeye-state-to-dpla

this fix addresses that issue, “flattening” query parameters