### PR TITLE
fixed undefined exhibit link

### DIFF
--- a/components/ExhibitionsComponents/ExhibitionSection/Viewer.js
+++ b/components/ExhibitionsComponents/ExhibitionSection/Viewer.js
@@ -69,7 +69,9 @@ const ItemLink = ({
       query: Object.assign({}, route.query, { item: itemId })
     }}
     as={`/exhibitions/${route.query.exhibition}/${route.query.section}/${route
-      .query.subsection}?item=${itemId}`}
+      .query.subsection
+      ? route.query.subsection
+      : ""}?item=${itemId}`}
   >
     <a className={[classNames.itemLink, className].join(" ")}>
       <ItemImage


### PR DESCRIPTION
image links in exhibit introductions (first “page” of any section of an exhibit) when arrived-to client-side will have `undefined` in the url. this fixes it