### PR TITLE
fixed bullets in chrome column lists

### DIFF
--- a/css/pages/content-pages-wysiwyg.css
+++ b/css/pages/content-pages-wysiwyg.css
@@ -314,6 +314,7 @@
 /* columnar lists */
 :global ul.column {
   column-count: 3;
+  column-gap: 2em;
 
   & ul {
     margin-top: 0;


### PR DESCRIPTION
the column-type grid has cut-off bullets in chrome:

<img width="619" alt="image" src="https://user-images.githubusercontent.com/133020/37231697-1c422460-23ba-11e8-875b-39a25b26c111.png">

now:

<img width="591" alt="image" src="https://user-images.githubusercontent.com/133020/37231698-1f0bb710-23ba-11e8-88a7-5bfe1f4ca9ad.png">

no bullets in safari but it is not a critical aspect of the design