### PR TITLE
3-column home pro

### DIFF
--- a/components/HomePageComponents/HomePro.css
+++ b/components/HomePageComponents/HomePro.css
@@ -73,7 +73,7 @@
 
   & ul {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
     grid-auto-rows: 18rem;
     grid-gap: 1rem;
     align-items: stretch;


### PR DESCRIPTION
making the blue boxes in the pro home be three columns instead of four when in desktop. we now see two rows of three instead of one row of four and one of two.