### PR TITLE
improving pss list in homepage

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -143,7 +143,9 @@ Home.getInitialProps = async ({ req }) => {
 
   // fetch item count
 
-  const itemsRes = await fetch(`${currentUrl}${ITEMS_API_ENDPOINT}`);
+  const itemsRes = await fetch(
+    `${currentUrl}${ITEMS_API_ENDPOINT}?page_size=1`
+  );
   const itemsJson = await itemsRes.json();
   const itemCount = itemsJson.count;
   const headerDescription = homepageJson.acf.header_description.replace(

--- a/pages/index.js
+++ b/pages/index.js
@@ -126,26 +126,16 @@ Home.getInitialProps = async ({ req }) => {
 
   // fetch featured primary source sets data
 
-  const pssRes = await fetch(`${PSS_BASE_URL}/sets.json`);
-  const pssJson = await pssRes.json();
-
   const featuredPrimarySourceSets =
     homepageJson.acf.featured_primary_source_sets;
-  const featuredPrimarySourceSetIds = featuredPrimarySourceSets.map(
-    set => set.primary_source_set_id
-  );
 
   const sourceSets = [];
-  featuredPrimarySourceSetIds.forEach(setId => {
-    const featuredSet = pssJson.itemListElement.find(
-      item => item["@id"] === setId
-    );
+  featuredPrimarySourceSets.forEach(featuredSet => {
     if (featuredSet) {
       const setWithLinkInfo = Object.assign({}, featuredSet, {
-        href: `/primary-source-sets/set?set=${extractSourceSetSlug(
-          featuredSet["@id"]
-        )}`,
-        as: `/primary-source-sets/${extractSourceSetSlug(featuredSet["@id"])}`
+        href: `/primary-source-sets/set?set=${featuredSet.primary_source_set_id}`,
+        as: `/primary-source-sets/${featuredSet.primary_source_set_id}`,
+        repImageUrl: featuredSet.image_url
       });
       sourceSets.push(setWithLinkInfo);
     }


### PR DESCRIPTION
this is to address #745 which happens client-side (when clicking home from some other page in the site). this also requires some changes in the wordpress admin which are [visible in staging](https://dpla.staging.wpengine.com/wp-json/wp/v2/pages/3777) which require the admin to add the image url and pss name. ideally the entire pss would live in wordpress.

what this means is that the pss entire info in the homepage is obtained with only 1, very compact, api call.

an alternative would be to amend the pss api to accept a list of slugs and return only those requested (as opposed to the full list of pss)