### PR TITLE
applying focus in body after page change

### DIFF
--- a/pages/exhibitions/exhibition/index.js
+++ b/pages/exhibitions/exhibition/index.js
@@ -21,30 +21,40 @@ import removeQueryParams from "utilFunctions/removeQueryParams";
 
 import { getDplaItemIdFromExhibit } from "utilFunctions";
 
-const Exhibition = ({ url, exhibition, currentFullUrl }) =>
-  <MainLayout route={url} pageTitle={exhibition.title} seoType={SEO_TYPE}>
-    <BreadcrumbsModule
-      breadcrumbs={[
-        {
-          title: "Exhibitions",
-          url: {
-            pathname: "/exhibitions",
-            query: removeQueryParams(url.query, ["exhibition"])
-          }
-        },
-        { title: exhibition.title, search: "" }
-      ]}
-      route={url}
-    />
-    <div id="main" role="main">
-      <ImageAndCaption exhibition={exhibition} route={url} />
-      <Details
-        exhibition={exhibition}
-        route={url}
-        currentFullUrl={currentFullUrl}
-      />
-    </div>
-  </MainLayout>;
+class Exhibition extends React.Component {
+  componentDidMount() {
+    window.scrollTo(0, 0);
+  }
+
+  render() {
+    const { url, exhibition, currentFullUrl } = this.props;
+    return (
+      <MainLayout route={url} pageTitle={exhibition.title} seoType={SEO_TYPE}>
+        <BreadcrumbsModule
+          breadcrumbs={[
+            {
+              title: "Exhibitions",
+              url: {
+                pathname: "/exhibitions",
+                query: removeQueryParams(url.query, ["exhibition"])
+              }
+            },
+            { title: exhibition.title, search: "" }
+          ]}
+          route={url}
+        />
+        <div id="main" role="main">
+          <ImageAndCaption exhibition={exhibition} route={url} />
+          <Details
+            exhibition={exhibition}
+            route={url}
+            currentFullUrl={currentFullUrl}
+          />
+        </div>
+      </MainLayout>
+    );
+  }
+}
 
 Exhibition.getInitialProps = async ({ query, req }) => {
   const currentFullUrl = getCurrentFullUrl(req);

--- a/pages/exhibitions/exhibition/index.js
+++ b/pages/exhibitions/exhibition/index.js
@@ -24,6 +24,7 @@ import { getDplaItemIdFromExhibit } from "utilFunctions";
 class Exhibition extends React.Component {
   componentDidMount() {
     window.scrollTo(0, 0);
+    document.body.focus();
   }
 
   render() {


### PR DESCRIPTION
to the exhibitions section. it seems that this doesnt happen throughout the site so it is not 100% a11y (the screen reader user doesnt know the page changed). apparently the nextjs people are working on this in the next release: https://github.com/zeit/next.js/pull/3545