### PR TITLE
Improve deployment consistency

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
-node_modules
 npm-debug.log
-.next
+yarn-error.log

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/carbon

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,10 @@
-FROM node:alpine
+# Dockerfile to build an image of the dpla-frontend application
+#
+# Expect that `yarn build` has already been run.
 
-# Create app directory
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
 
-# Install app dependencies
-RUN npm install --global yarn
-COPY package.json yarn.lock /usr/src/app/
-RUN yarn
-
-# Bundle app source
-COPY . /usr/src/app
-RUN yarn build
-
+FROM node:carbon-alpine
+WORKDIR /opt/dpla-frontend
+COPY . /opt/dpla-frontend
 EXPOSE 3000
-CMD [ "yarn", "start" ]
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -5,20 +5,63 @@ This is the repository for the Digital Public Library of America's new frontend.
 
 ## Getting Started For Development
 
-- Install [Node v7.8.0](https://nodejs.org/en/)
-- Install [Yarn](https://yarnpkg.com/en/docs/install)
+### Install the Yarn package manager
+
+Supported version: 1.5.1
+
+[Installation instructions](https://yarnpkg.com/en/docs/install)
+
+Use whichever method is best for your environment, but this project expects the
+supported version given above; so check the documentation for your preferred
+installation method to make sure you can determine the version.
+
+The Yarn installation page referenced above recommends against installing Yarn
+from `npm`. For security, the download is supposed to have its cryptographic
+signature checked and an assumption is being made that you want `yarn` to be its
+own standalone utility, decoupled from this project.
+
+If you have other projects that require different versions of Yarn, this may
+not suit your needs. We may recommend a different way of managing Yarn in the
+future.
+
+### Check this project out from GitHub
 
 ```
-git clone https://github.com/dpla/dpla-frontend/
-cd dpla-frontend
-
-# install dependencies
-yarn
-
-# start the local development server
-yarn dev
-open http://localhost:3000/
+$ git clone https://github.com/dpla/dpla-frontend.git
 ```
+
+### Install Node
+
+We are using the current LTS (long-term-support) "Carbon" version of Node.
+
+The easiest way to manage your Node versions is with
+[NVM](https://github.com/creationix/nvm). Follow the instructions on that page
+to set it up. Then, do the following in your shell:
+```
+$ cd /path/to/dpla-frontend  # Checked out above from GitHub
+$ nvm install                # Picks up correct Node version from `.nvmrc`
+$ nvm use                    # Activates correct Node version
+```
+
+### Install dependencies and start the local development server
+
+```
+$ yarn dev
+```
+
+You may now open http://localhost:3000/ in your browser.
+
+### Run with Docker
+
+```
+$ yarn build
+$ yarn docker:build
+$ yarn docker:run
+```
+
+See [the Docker documentation](https://docs.docker.com/) and `docker help` for
+more information on using Docker containers.
+
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ $ yarn docker:run
 ```
 
 See [the Docker documentation](https://docs.docker.com/) and `docker help` for
-more information on using Docker containers.
+more information on using Docker containers. See package.json for more
+Docker-related commands.
 
 
 ## Environment Variables
@@ -103,52 +104,18 @@ to manage a 12-column grid. Review <http://flexboxgrid.com/> for documentation.
 [Mobile Design Prototype](https://invis.io/VGD6W7ZDQ)  
 [Project Task Board](https://github.com/dpla/dpla-frontend/projects/1)
 
-## Scripts
+## Yarn / NPM Scripts
 
-The project includes a number of scripts used for development, testing, and deployment.
+The project includes a number of scripts used for development, testing, and deployment. See package.json for details if you are a developer. They include:
 
-- `yarn run dev` - begins bundling javascript with webpack and starts the server in development mode
-- `yarn run start` - begins bundling javascript with webpack and starts the server in production mode
-- `yarn run build` - builds the project for production
+- `yarn run clean` - Removes local Node modules, `.next` build targets, etc.
+- `yarn run dev` - Builds the project and starts the server in development mode
+- `yarn run build` - Builds the project for production
+- `yarn run start` - Builds the project and starts the server in production mode
 
+## Authors
 
-### Docker
-
-This project uses a Docker container, which can be run locally or deployed to AWS Elastic Beanstalk.
-
-Once you have [Docker](https://www.docker.com/) installed on your computer, you can run the container locally using this command:
-
-```zsh
-# Build and run the container
-> yarn deploy
-```
-
-To deploy the container to AWS Elastic Beanstalk, you'll need to get set up first.
-
-1. Get AWS credentials and [install the eb-cli tool](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/eb-cli3-install-osx.html) (tl;dr ```brew install awsebcli```).
-2. Using the terminal, run ```eb init```.
-3. Choose us-east-1, US East (N. Virginia) as the region.
-4. Enter your aws-access-id and aws-secret-key.
-5. At select an application to use, choose dpla-frontend.
-6. Opt out of CodeCommit.
-
-When you've completed the one-time setup, the following command will deploy the Docker container to AWS.
-
-```zsh
-> eb deploy dpla
-```
-
-A few other useful commands:
-
-```zsh
-# List environments
-> eb list
-
-# Open the app in your browser
-> eb open dpla
-```
-
-| Authors, DPLA |
+| DPLA |
 | ------------- |
 | Audrey Altman |
 | Gretchen Gueguen |

--- a/package.json
+++ b/package.json
@@ -80,16 +80,14 @@
   },
   "scripts": {
     "precommit": "lint-staged",
-    "dev": "node server.js",
-    "build": "NODE_ENV=production next build",
+    "dev": "yarn && node server.js",
+    "clean": "rm -rf .next ./build ./coverage ./node_modules",
+    "build": "yarn && NODE_ENV=production next build",
     "start": "NODE_ENV=production node server.js",
-    "docker:build": "docker build -t dpla .",
-    "docker:clean": "docker rm -f dpla || true",
-    "docker:run": "docker run -p 3000:3000 -d --name dpla dpla",
-    "docker:stop": "docker stop dpla",
-    "docker:start": "docker start dpla && yarn run docker:logs",
-    "docker:logs": "docker logs -f dpla",
-    "deploy": "yarn run docker:build && yarn run docker:clean && yarn run docker:run",
+    "docker:build": "docker build -t dpla-frontend .",
+    "docker:clean": "docker container rm -f dpla-frontend; docker image rm -f dpla-frontend",
+    "docker:run": "docker run -p 3000:3000 -d --name dpla-frontend dpla-frontend:latest",
+    "docker:logs": "docker logs -f dpla-frontend",
     "analyze": "cross-env ANALYZE=1 next build"
   },
   "lint-staged": {


### PR DESCRIPTION
Make builds across development and production environments more repeatable by ensuring the correct version of `yarn` in all environments and ensuring that production builds in Elastic Beanstalk (and other similar platforms) will be consistent across instances. We're also specifying the same version of Node in the `Dockerfile` as in our README file, which we weren't before!

Previously, our `Dockerfile` contained commands to build the app, which results in different Next.js build IDs being generated across instances. These commands are no longer part of the `Dockerfile`. It's now possible to execute the Next build independently of the Docker build.

Various other improvements:
* An unnecessary `mkdir` command has been removed from the `Dockerfile`
* We forego installing Yarn at all on the Docker image. To run the app  in the container, `npm start` works just fine, and Yarn is only used  for package management outside of the Docker container.
* `README.md` has been updated