### PR TITLE
zero items for home item number

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -144,7 +144,7 @@ Home.getInitialProps = async ({ req }) => {
   // fetch item count
 
   const itemsRes = await fetch(
-    `${currentUrl}${ITEMS_API_ENDPOINT}?page_size=1`
+    `${currentUrl}${ITEMS_API_ENDPOINT}?page_size=0`
   );
   const itemsJson = await itemsRes.json();
   const itemCount = itemsJson.count;


### PR DESCRIPTION
shaves 1kB from the request because we dont need an item to know the number...