### PR TITLE
joining array queries with pipe

### DIFF
--- a/components/SearchComponents/FiltersList/index.js
+++ b/components/SearchComponents/FiltersList/index.js
@@ -23,7 +23,7 @@ const clearAllFacets = query => {
 
 const clearFacet = (query, queryKey, facet) => {
   const duped = Object.assign({}, query);
-  const value = joinIfArray(duped[queryKey]);
+  const value = joinIfArray(duped[queryKey], "|");
   duped[queryKey] = value
     .split("|")
     .filter(facetPart => facetPart.replace(/"/g, "") !== facet)
@@ -80,7 +80,7 @@ class FiltersList extends React.Component {
               <span className={classNames.labelText}>Filtered by</span>
               <ul className={classNames.filters}>
                 {Object.keys(query).map((queryKey, index) => {
-                  const value = joinIfArray(query[queryKey]);
+                  const value = joinIfArray(query[queryKey], "|");
                   if (
                     possibleFacets.includes(
                       mapURLPrettifiedFacetsToUgly[queryKey]

--- a/constants/search.js
+++ b/constants/search.js
@@ -45,7 +45,7 @@ export const prettifiedFacetMap = {
 import { joinIfArray } from "utilFunctions";
 
 export const splitAndURIEncodeFacet = facet =>
-  joinIfArray(facet)
+  joinIfArray(facet, "|")
     .split("|")
     .map(param => encodeURIComponent(param))
     .join("+AND+");


### PR DESCRIPTION
because search expects that

postlight did a pipe-separated multi-parameter thing instead of using the more common `[]` array access… the [last fix](https://github.com/dpla/dpla-frontend/pull/719) didnt completely address the problem