### PR TITLE
Add redirect for bare /primary-source-sets/sets

### DIFF
--- a/.ebextensions/pss1.config
+++ b/.ebextensions/pss1.config
@@ -7,6 +7,7 @@ files:
         group: "root"
         content: |
             rewrite ^/primary-source-sets/sets/([0-9a-z\-]+) /primary-source-sets/$1 permanent;
+            rewrite ^/primary-source-sets/sets/?$ /primary-source-sets permanent;
 
             rewrite ^/primary-source-sets/guides/exploring-the-politics-of-frederick-douglass-and-abraham-lincoln /primary-source-sets/frederick-douglass-and-abraham-lincoln/teaching-guide permanent;
             rewrite ^/primary-source-sets/guides/teaching-guide-examining-the-exploration-of-the-americas /primary-source-sets/exploration-of-the-americas/teaching-guide permanent;


### PR DESCRIPTION
Add redirect for `/primary-source-sets/sets` (with no set ID on the end) to `/primary-source-sets`, because the former results in a routing error.
