### PR TITLE
Add env var to force fork in dev mode if desired

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,6 +9,8 @@ const numCPUs = require("os").cpus().length;
 const serverFunctions = require("./utilFunctions/serverFunctions");
 
 const dev = process.env.NODE_ENV !== "production";
+const production = !dev;
+const mustFork = process.env.MUST_FORK == "true" || production;
 const PORT = process.env.PORT || 3000;
 
 if (require.main === module) {
@@ -17,7 +19,7 @@ if (require.main === module) {
     process.exit(1);
   });
 
-  if (cluster.isMaster) {
+  if (cluster.isMaster && mustFork) {
     // Fork workers, 1 for each CPU.
     cluster
       .on("exit", (worker, code, signal) => {


### PR DESCRIPTION
In server.js, add interpretation of an environment variable, `MUST_FORK`, that forces the process to fork as it would in production. As of the current version, this can lead to application behavior that's uncharacteristic of production behavior, so the default is to not fork in development.