### PR TITLE
added formatting to code

### DIFF
--- a/css/pages/content-pages-wysiwyg.css
+++ b/css/pages/content-pages-wysiwyg.css
@@ -1,4 +1,4 @@
-@value warmerBackgroundColor, secondaryColor, linkColor, linkHoverColor, primaryBulletColor, secondaryBulletColor from "../colors.css";
+@value colderBackgroundColor, warmerBackgroundColor, secondaryColor, linkColor, linkHoverColor, primaryBulletColor, secondaryBulletColor from "../colors.css";
 @value smallRem, mediumRem, largeRem from "../breakpoints.css";
 @value sansFont, monoFont, serifFont from "../typography.css";
 
@@ -109,6 +109,20 @@
 
   & p {
     margin-bottom: 1rem;
+  }
+
+  & code, & pre {
+    background-color: colderBackgroundColor;
+    font-family: monoFont;
+    font-size: 0.85rem;
+    padding: 0.125rem 0.25rem;
+  }
+
+  & pre {
+    border-left: 0.1rem solid secondaryColor;
+    padding: 0.5rem;
+    white-space: pre-wrap;
+    word-break: break-all;
   }
 
   & iframe {


### PR DESCRIPTION
added formatting to `code` snippets and `pre` tags for the developer docs:

<img width="600" alt="image" src="https://user-images.githubusercontent.com/133020/37778463-60f5e992-2dc0-11e8-927a-75ebc0ec66be.png">
