### PR TITLE
fixed widths and line breaks in search sidebar

### DIFF
--- a/components/SearchComponents/MainContent/MainContent.css
+++ b/components/SearchComponents/MainContent/MainContent.css
@@ -50,6 +50,5 @@
   }
 
   @media (min-width: mediumRem) {
-    flex-basis: 25%;
   }
 }

--- a/components/SearchComponents/MainContent/Sidebar/Sidebar.css
+++ b/components/SearchComponents/MainContent/Sidebar/Sidebar.css
@@ -33,7 +33,9 @@
 
 .facetName {
   color: black;
-  flex-basis: 75%;
+  flex-basis: 80%;
+  font-size: 0.8125rem;
+  word-break: break-all;
 }
 
 .activeFacetName {
@@ -42,10 +44,10 @@
 }
 
 .facetCount {
-  font-size: 0.8125rem;
   color: dimmedTextColor;
+  flex-basis: 20%;
+  font-size: 0.8125rem;
   margin-left: .25rem;
-  flex-basis: 25%;
   text-align: right;
 }
 


### PR DESCRIPTION
sometimes facets with long, non-breaking names (eg: “Wheat,Farmers,Diseases,Fort Peck Indian Reservation,Montana,Seeds,Trucks,Farmhouses,Agricultural machinery & implements,Brockton,Roosevelt County”) would make the sidebar wider than desirable

it is now breaking in the max width and not in the next available word, breaking some words in non-syllables, but it is still readable

<img width="310" alt="image" src="https://user-images.githubusercontent.com/133020/37780469-33242420-2dc5-11e8-8198-42ec9eb89f06.png">
