### PR TITLE
no bottom marign in list items

### DIFF
--- a/css/pages/content-pages-wysiwyg.css
+++ b/css/pages/content-pages-wysiwyg.css
@@ -161,7 +161,6 @@
     list-style-type: none;
     position: relative;
     counter-increment: start-from;
-    margin-bottom: 1rem;
   }
 
   & li::before {


### PR DESCRIPTION
list items should not have bottom margin. it takes up too much space

before:
<img width="309" alt="image" src="https://user-images.githubusercontent.com/133020/37789643-ddd5413c-2dda-11e8-9f91-40d7ec28d6e6.png">

after:
<img width="307" alt="image" src="https://user-images.githubusercontent.com/133020/37789670-eed5c862-2dda-11e8-9c76-ecddbadbdfc2.png">

