### PR TITLE
Enable UglifyJS in Next configuration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -19,10 +19,6 @@ module.exports = {
       );
     }
 
-    config.plugins = config.plugins.filter(
-      plugin => plugin.constructor.name !== "UglifyJsPlugin"
-    );
-
     config.plugins.push(
       new webpack.DefinePlugin({
         "process.env": {


### PR DESCRIPTION
Stop excluding the UglifyJS plugin from the list of Webpack plugins that are used when building Next.js assets.

With this change, Javascript files are minified when running with `NODE_ENV=production` but they are not minified in development mode.
