### PR TITLE
addressing the item breadcrumb

### DIFF
--- a/pages/item/index.js
+++ b/pages/item/index.js
@@ -43,10 +43,9 @@ const ItemDetail = ({
         /* paginationInfo={paginationInfo} */
         breadcrumbs={[
           {
-            title: url.query.q ? `Search for: ${url.query.q}` : "Search",
+            title: "All items",
             url: {
-              pathname: "/search",
-              query: removeQueryParams(url.query, ["itemId, next, previous"])
+              pathname: "/search"
             }
           },
           { title: joinIfArray(item.title), search: "" }


### PR DESCRIPTION
as an intermediate solution to #705 i updated the link and text in the item page breadcrumb to say “all items” and link to a blank search... in the future we can address a more elegant solution with a revision of the whole item page

<img width="620" alt="image" src="https://user-images.githubusercontent.com/133020/38262563-8b33cbf0-373b-11e8-8022-6dde4eafaee3.png">

fixes #705