### PR TITLE
fixed nil check in news

### DIFF
--- a/pages/news/index.js
+++ b/pages/news/index.js
@@ -230,7 +230,7 @@ NewsPage.getInitialProps = async ({ req, query, res }) => {
     newsItems = await newsRes.json();
     newsCount = newsRes.headers.get("X-WP-Total");
     newsPageCount = newsRes.headers.get("X-WP-TotalPages");
-    error = newsItems.code !== "" ? true : false;
+    error = newsItems.code !== undefined ? true : false;
     if (error) page = 1;
     retries++;
   }


### PR DESCRIPTION
there was a nil check in the news request to prevent people from crashing the page by submitting invalid params but it was wrong, making pagination not work. now it is right.

fixes #820 