### PR TITLE
fixed icon in default image in search results

### DIFF
--- a/components/shared/ListView/ListView.scss
+++ b/components/shared/ListView/ListView.scss
@@ -18,6 +18,7 @@
 .itemTitle {
   font-size: 0.875rem;
   font-weight: 600;
+
   @media (min-width: $smallRem) {
     font-weight: normal;
     color: $linkColor;
@@ -38,15 +39,11 @@
 
 .defaultImageWrapper {
   background-color: $warmerBackgroundColor;
-  padding-bottom: 20%;
-  padding-top: 20%;
-
-  @media (min-width: $largeRem) {
-    padding-bottom: 0;
-    padding-top: 0;
-  }
+  padding-bottom: 0;
+  padding-top: 0;
 
   & img {
+    opacity: 0.25;
   }
 }
 


### PR DESCRIPTION
the default image icon was not being displayed in intermediate screens (bigger than mobile smaller than big desktop)

also made icon less visible since it is just decoration

see: https://dp.la/search?q=&page=3 and try in localhost: http://localhost:3000/search?q=&page=3