### PR TITLE
Fix thumb expires

### DIFF
--- a/lib/thumbp.js
+++ b/lib/thumbp.js
@@ -79,8 +79,7 @@ Connection.prototype.lookUpImage = function() {
 
       // First set short cache-expiration headers so that the client gets an
       // optimized image if it checks back soon.
-      conn.response.setHeader("Cache-Control", "public, max-age=60");
-      conn.response.setHeader("Expires", "");
+      this.setCacheHeaders(60);
 
       var q_url =
         ELASTIC_URL + `/item/_search?q=id:${conn.itemID}&fields=id,object`;
@@ -89,17 +88,20 @@ Connection.prototype.lookUpImage = function() {
       });
     } else {
       // Set longer cache-expiration headers for the nice optimized image
-      var maxAgeSec = 60 * 60 * 24 * 30; // 30 days
-      var gmtExpDate = new Date(
-        new Date().getTime() + 1000 * maxAgeSec // as milliseconds
-      ).toUTCString();
-      conn.response.setHeader("Cache-Control", `public, max-age=${maxAgeSec}`);
-      conn.response.setHeader("Expires", gmtExpDate);
+      this.setCacheHeaders(60 * 60 * 24 * 30); // 30 days
 
       conn.imageURL = s3.getSignedUrl("getObject", params);
       conn.proxyImage();
     }
   });
+};
+
+Connection.prototype.setCacheHeaders = function(seconds) {
+  var gmtExpDate = new Date(
+    new Date().getTime() + 1000 * seconds // as milliseconds
+  ).toUTCString();
+  this.response.setHeader("Cache-Control", `public, max-age=${seconds}`);
+  this.response.setHeader("Expires", gmtExpDate);
 };
 
 /*

--- a/lib/thumbp.js
+++ b/lib/thumbp.js
@@ -79,7 +79,7 @@ Connection.prototype.lookUpImage = function() {
 
       // First set short cache-expiration headers so that the client gets an
       // optimized image if it checks back soon.
-      this.setCacheHeaders(60);
+      conn.setCacheHeaders(60);
 
       var q_url =
         ELASTIC_URL + `/item/_search?q=id:${conn.itemID}&fields=id,object`;
@@ -88,7 +88,7 @@ Connection.prototype.lookUpImage = function() {
       });
     } else {
       // Set longer cache-expiration headers for the nice optimized image
-      this.setCacheHeaders(60 * 60 * 24 * 30); // 30 days
+      conn.setCacheHeaders(60 * 60 * 24 * 30); // 30 days
 
       conn.imageURL = s3.getSignedUrl("getObject", params);
       conn.proxyImage();


### PR DESCRIPTION
Fix empty Expires cache header in `Connection.lookUpImage()`, in `thumbp.js`.
Create new function, `setCacheHeaders()`, to eliminate redundant code.
