### PR TITLE
no titlecase in google analytics tracker

### DIFF
--- a/lib/googleAnalytics/initGa.js
+++ b/lib/googleAnalytics/initGa.js
@@ -5,7 +5,7 @@ import ReactGA from "react-ga";
 // switching between pages of different types.
 const initGa = () => {
   if (!window.GA_INITIALIZED) {
-    ReactGA.initialize(gaTrackingId);
+    ReactGA.initialize(gaTrackingId, { titleCase: false });
     window.GA_INITIALIZED = true;
   }
 };


### PR DESCRIPTION
This fixes a problem wherein the `ReactGA` app was capitalizing the first letter of every event field.  This was causing data inconsistencies, like capitalizing the first letter of an item ID in event tracking. This problem started on March 8 - not quite sure why.  But this code fixes it.  I've tested it on demo.dp.la.