### PR TITLE
hack nil check in “orphan” item

### DIFF
--- a/components/shared/ListView/ListImage.js
+++ b/components/shared/ListView/ListImage.js
@@ -30,18 +30,43 @@ class ListImage extends React.Component {
         className={`${css.imageWrapper}
           ${useDefaultWrapper && css.defaultImageWrapper}`}
       >
-        <Link href={this.state.item.linkHref} as={this.state.item.linkAs}>
-          <a
-            className={`${css.listItemImageLink} internalItemLink`}
-            aria-hidden
-          >
+        {/* see issue #869 for details on this hack */}
+        {this.state.item.id !== "http://dp.la/api/items/#sourceResource" &&
+          <Link href={this.state.item.linkHref} as={this.state.item.linkAs}>
+            <a
+              className={`${css.listItemImageLink} internalItemLink`}
+              aria-hidden
+            >
+              <img
+                src={updateToDefaultImage ? getDefaultThumbnail(type) : url}
+                alt=""
+                className={css.image}
+              />
+            </a>
+          </Link>}
+        {/* see issue #869 for details on this hack */}
+        {this.state.item.id !== "http://dp.la/api/items/#sourceResource" &&
+          <Link href={this.state.item.linkHref} as={this.state.item.linkAs}>
+            <a
+              className={`${css.listItemImageLink} internalItemLink`}
+              aria-hidden
+            >
+              <img
+                src={updateToDefaultImage ? getDefaultThumbnail(type) : url}
+                alt=""
+                className={css.image}
+              />
+            </a>
+          </Link>}
+        {/* see issue #869 for details on this hack */}
+        {this.state.item.id === "http://dp.la/api/items/#sourceResource" &&
+          <span className={css.listItemImageLink} aria-hidden>
             <img
               src={updateToDefaultImage ? getDefaultThumbnail(type) : url}
               alt=""
               className={css.image}
             />
-          </a>
-        </Link>
+          </span>}
       </div>
     );
   }

--- a/components/shared/ListView/index.js
+++ b/components/shared/ListView/index.js
@@ -38,13 +38,22 @@ const ListView = ({ items, route }) =>
         />
         <div className={css.itemInfo}>
           <h2 className={`hover-underline ${css.itemTitle}`}>
-            <Link href={item.linkHref} as={item.linkAs}>
-              <a className={`internalItemLink`}>
+            {/* see issue #869 for details on this hack */}
+            {item.id !== "http://dp.la/api/items/#sourceResource" &&
+              <Link href={item.linkHref} as={item.linkAs}>
+                <a className={`internalItemLink`}>
+                  {route.pathname.indexOf("/search") === 0 && item.title
+                    ? truncateString(item.title, 150)
+                    : item.title ? item.title : UNTITLED_TEXT}
+                </a>
+              </Link>}
+            {/* see issue #869 for details on this hack */}
+            {item.id === "http://dp.la/api/items/#sourceResource" &&
+              <span>
                 {route.pathname.indexOf("/search") === 0 && item.title
                   ? truncateString(item.title, 150)
                   : item.title ? item.title : UNTITLED_TEXT}
-              </a>
-            </Link>
+              </span>}
           </h2>
 
           {(item.date || item.creator) &&


### PR DESCRIPTION
this search returns an item with no id: https://dp.la/search?q=Reimagining+Sitting+Bull%3A+T%C8%9Fat%C8%9F%C3%A1%C5%8Bka+%C3%8Dyotake

which happens to be (as of posting date) the first result in an empty search: https://dp.la/search?q=

but the item _does_ exist in the provider: https://archive.mpr.org/stories/2010/12/05/reimagining-sitting-bull-t%C8%9F%C8%9F%C3%A1%C5%8Bka-%C3%ADyotake

i suppose because having no id, and (i think) id being used to break ties between records with similar relevancy, this item bubbles to the top of the results. i suppose it is also a byproduct of the improved elasticsearch relevancy work. since this is the _only_ item in all the index with this situation and it will show up in any empty search, i added a hardcoded check. 

in the future we might want to remove it if/when this issue is fixed in the item level. i will add an issue to check back on this.

fixes #869