### PR TITLE
breaking facets in words

### DIFF
--- a/components/SearchComponents/MainContent/Sidebar/Sidebar.scss
+++ b/components/SearchComponents/MainContent/Sidebar/Sidebar.scss
@@ -33,7 +33,7 @@
   color: black;
   flex-basis: 80%;
   font-size: 0.8125rem;
-  word-break: break-all;
+  word-break: break-word;
 }
 
 .activeFacetName {


### PR DESCRIPTION
this 

<img width="307" alt="image" src="https://user-images.githubusercontent.com/133020/41550963-5b80e71e-72f8-11e8-9c37-5ceeb1b06867.png">

looks better than this

<img width="310" alt="image" src="https://user-images.githubusercontent.com/133020/41550974-6059c1e8-72f8-11e8-94ce-50b895b85c5b.png">

(related to #773)