### PR TITLE
right-aligned send button in feedback

### DIFF
--- a/components/FeedbackForm/FeedbackForm.scss
+++ b/components/FeedbackForm/FeedbackForm.scss
@@ -32,6 +32,7 @@
   box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
 
   .sendCancelButtons {
+    align-items: center;
     display: flex;
   }
 
@@ -41,6 +42,7 @@
 
   .cancelButton {
     flex-grow: 1;
+    margin-right: 0.5rem;
   }
 
   @media (max-width: $mediumRem) {

--- a/components/FeedbackForm/index.js
+++ b/components/FeedbackForm/index.js
@@ -279,6 +279,15 @@ class FeedbackForm extends React.Component {
               </p>}
 
             <div className={css.sendCancelButtons}>
+              <Button
+                className={css.cancelButton}
+                type="ghost"
+                id="deactivate-feedback"
+                onClick={this.closeForm}
+                name="close_button"
+              >
+                {step === 1 ? "Cancel" : "Close"}
+              </Button>
               {!isSending &&
                 step === 1 &&
                 <Button
@@ -296,16 +305,6 @@ class FeedbackForm extends React.Component {
                 >
                   Sending…
                 </Button>}
-
-              <Button
-                className={css.cancelButton}
-                type="ghost"
-                id="deactivate-feedback"
-                onClick={this.closeForm}
-                name="close_button"
-              >
-                {step === 1 ? "Cancel" : "Close"}
-              </Button>
             </div>
           </form>
         </AriaModal>


### PR DESCRIPTION

<img width="350" alt="image" src="https://user-images.githubusercontent.com/133020/41743626-541eee84-756f-11e8-9468-867413a3a69d.png">


because research: http://uxmovement.com/buttons/why-ok-buttons-in-dialog-boxes-work-best-on-the-right/