### PR TITLE
not caching errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,11 +97,6 @@
       "git add"
     ]
   },
-  "babel": {
-    "presets": [
-      "react-app"
-    ]
-  },
   "eslintConfig": {
     "extends": "react-app"
   }

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -1,5 +1,4 @@
 import React from "react";
-import Link from "next/link";
 
 import MinimalLayout from "components/MainLayout/components/MinimalLayout";
 import ErrorLinksUser from "components/ErrorComponents/ErrorLinksUser";
@@ -14,6 +13,10 @@ import donateCss from "stylesheets/donate.scss";
 export default class Error extends React.Component {
   static getInitialProps({ res, err }) {
     const statusCode = res ? res.statusCode : err ? err.statusCode : null;
+    res.setHeader(
+      "Cache-Control",
+      "max-age=0, private, no-cache, no-store, must-revalidate"
+    );
     return { statusCode };
   }
 

--- a/pages/item/index.js
+++ b/pages/item/index.js
@@ -8,13 +8,14 @@ import Content from "components/ItemComponents/Content";
 import CiteButton from "components/shared/CiteButton";
 
 import { API_ENDPOINT, THUMBNAIL_ENDPOINT } from "constants/items";
+
 import {
   getCurrentUrl,
   getCurrentFullUrl,
-  removeQueryParams,
   joinIfArray,
   getDefaultThumbnail
 } from "lib";
+
 import {
   DEFAULT_PAGE_SIZE,
   possibleFacets,


### PR DESCRIPTION
using `res.setHeader("Cache-Control", "max-age=0, private, no-cache, no-store, must-revalidate");` in the custom `_error.js` file:

<img width="913" alt="image" src="https://user-images.githubusercontent.com/133020/41990480-843d43fe-7a10-11e8-860f-b8897177d9a4.png">

and minor cleanup

nextjs 6 has a [native fix](https://github.com/zeit/next.js/pull/4111) for this but i can't upgrade the whole thing right now

fixes #886