### PR TITLE
Disable ETag and X-Powered-By headers

### DIFF
--- a/.ebextensions/nginx.config
+++ b/.ebextensions/nginx.config
@@ -34,6 +34,8 @@ files:
                     proxy_set_header      Host       $host;
                     proxy_set_header      X-Real-IP  $remote_addr;
                     proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
+                    proxy_hide_header     ETag;
+                    proxy_hide_header     X-Powered-By;
 
                     #
                     # REDIRECTS


### PR DESCRIPTION
I think that disabling the ETag may keep CloudFront from caching errors.

While we're at it, hide the X-Powered-By header because it's unnecessary bytes and serves little purpose other than to advertise what we're running to bots that are scanning for security vulnerabilities.
