### PR TITLE
search improvements

### DIFF
--- a/components/MainLayout/components/PageHeader/index.js
+++ b/components/MainLayout/components/PageHeader/index.js
@@ -8,49 +8,69 @@ import { LOCALS } from "constants/local";
 
 import css from "./PageHeader.scss";
 
-const PageHeader = ({ searchQuery, hideSearchBar }) =>
-  <div
-    className={`${css.headerSearchBar} ${SITE_ENV === "pro" ? css.pro : ""}`}
-  >
-    <div
-      className={`${css.flexWrapper}  ${SITE_ENV === "pro"
-        ? css.pro
-        : ""} site-max-width`}
-    >
-      {(SITE_ENV === "user" || SITE_ENV === "pro") &&
-        <Link prefetch as="/" href={SITE_ENV === "user" ? "/" : "/pro"}>
-          <a className={css.logo} title="Home Page">
-            <DPLALogoWide className={css.logoImg} />
-          </a>
-        </Link>}
-      {SITE_ENV === "local" &&
-        <Link prefetch href="/search">
-          <a className={`${css.logo} ${css.local}`} title="Home Page">
-            <img
-              className={css.localLogo}
-              alt={`${LOCALS[LOCAL_ID].name} Home`}
-              src={`/static/local/${LOCALS[LOCAL_ID].theme}/logo.jpg`}
-            />
-            <span className={css.localText}>{LOCALS[LOCAL_ID].name}</span>
-          </a>
-        </Link>}
-      {!hideSearchBar &&
-        SITE_ENV !== "pro" &&
-        <form action="/search" className={css.searchBar}>
-          <input
-            className={css.searchInput}
-            name="q"
-            type="search"
-            placeholder="Search the collection"
-            aria-label="Search the collection"
-            autoComplete="off"
-            defaultValue={searchQuery}
-          />
-          <button type="submit" className={css.searchButton}>
-            Search
-          </button>
-        </form>}
-    </div>
-  </div>;
-
+class PageHeader extends React.Component {
+  render() {
+    const { searchQuery, hideSearchBar } = this.props;
+    return (
+      <div
+        className={`${css.headerSearchBar} ${SITE_ENV === "pro"
+          ? css.pro
+          : ""}`}
+      >
+        <div
+          className={`${css.flexWrapper}  ${SITE_ENV === "pro"
+            ? css.pro
+            : ""} site-max-width`}
+        >
+          {(SITE_ENV === "user" || SITE_ENV === "pro") &&
+            <Link prefetch as="/" href={SITE_ENV === "user" ? "/" : "/pro"}>
+              <a className={css.logo} title="Home Page">
+                <DPLALogoWide className={css.logoImg} />
+              </a>
+            </Link>}
+          {SITE_ENV === "local" &&
+            <Link prefetch href="/search">
+              <a className={`${css.logo} ${css.local}`} title="Home Page">
+                <img
+                  className={css.localLogo}
+                  alt={`${LOCALS[LOCAL_ID].name} Home`}
+                  src={`/static/local/${LOCALS[LOCAL_ID].theme}/logo.jpg`}
+                />
+                <span className={css.localText}>{LOCALS[LOCAL_ID].name}</span>
+              </a>
+            </Link>}
+          {!hideSearchBar &&
+            SITE_ENV !== "pro" &&
+            <form action="/search" className={css.searchBar}>
+              <input
+                className={css.searchInput}
+                name="q"
+                type="search"
+                placeholder="Search the collection"
+                aria-label="Search the collection"
+                autoComplete="off"
+                defaultValue={searchQuery}
+              />
+              {this.props.query &&
+                Object.keys(this.props.query).map((key, index) => {
+                  if (key !== "q" && key !== "page") {
+                    return (
+                      <input
+                        type="hidden"
+                        key={`k_${index}`}
+                        name={key}
+                        value={this.props.query[key]}
+                      />
+                    );
+                  }
+                })}
+              <button type="submit" className={css.searchButton}>
+                Search
+              </button>
+            </form>}
+        </div>
+      </div>
+    );
+  }
+}
 export default PageHeader;

--- a/components/MainLayout/index.js
+++ b/components/MainLayout/index.js
@@ -45,6 +45,7 @@ const MainLayout = ({
       <GlobalHeader isHome={isHome} />
       {!hidePageHeader &&
         <PageHeader
+          query={route.query}
           searchQuery={route.query.q}
           hideSearchBar={hideSearchBar}
         />}

--- a/components/SearchComponents/FiltersList/index.js
+++ b/components/SearchComponents/FiltersList/index.js
@@ -15,6 +15,7 @@ const closeIcon = "/static/images/close-white.svg";
 
 const clearAllFacets = query => {
   const duped = Object.assign({}, query);
+  delete duped["page"];
   possibleFacets.forEach(
     facet => delete duped[mapFacetsToURLPrettified[facet]]
   );
@@ -23,6 +24,7 @@ const clearAllFacets = query => {
 
 const clearFacet = (query, queryKey, facet) => {
   const duped = Object.assign({}, query);
+  delete duped["page"];
   const value = joinIfArray(duped[queryKey], "|");
   duped[queryKey] = value
     .split("|")


### PR DESCRIPTION
when submitting new/changed keywords in the search box while having facets active, the facets persist. this allows for better browse-by-partner experience: select a partner -> type desired keywords. 

it is also not destructive in situations when the user will have selected many facets.

when removing a facet, the pagination is reset to 1

fixes #902 #899 
