### PR TITLE
added image/alt to item/topic/exhibits/pss

### DIFF
--- a/components/DPLAHead/index.js
+++ b/components/DPLAHead/index.js
@@ -24,6 +24,7 @@ class DPLAHead extends React.Component {
       seoType,
       pageTitle,
       pageImage,
+      pageImageCaption,
       pageDescription
     } = this.props;
     const defaultDescription =
@@ -54,6 +55,10 @@ class DPLAHead extends React.Component {
           <meta name="twitter:site" content="@dpla" />
           <meta name="twitter:creator" content="@dpla" />
           <meta name="twitter:image" content={pageImage || defaultImageUrl} />
+          <meta
+            name="twitter:image:alt"
+            content={pageImageCaption || defaultDescription}
+          />
           <meta name="og:image" content={pageImage || defaultImageUrl} />
           <meta
             name="og:title"

--- a/components/DPLAHead/index.js
+++ b/components/DPLAHead/index.js
@@ -55,10 +55,7 @@ class DPLAHead extends React.Component {
           <meta name="twitter:site" content="@dpla" />
           <meta name="twitter:creator" content="@dpla" />
           <meta name="twitter:image" content={pageImage || defaultImageUrl} />
-          <meta
-            name="twitter:image:alt"
-            content={pageImageCaption || defaultDescription}
-          />
+          <meta name="twitter:image:alt" content={pageImageCaption} />
           <meta name="og:image" content={pageImage || defaultImageUrl} />
           <meta
             name="og:title"

--- a/components/MainLayout/index.js
+++ b/components/MainLayout/index.js
@@ -18,6 +18,8 @@ const MainLayout = ({
   hidePageHeader,
   isSearchPage,
   headLinks,
+  pageImage,
+  pageImageCaption,
   pageTitle,
   pageDescription,
   seoType
@@ -34,6 +36,8 @@ const MainLayout = ({
         pageTitle={pageTitle}
         seoType={seoType}
         pageDescription={pageDescription}
+        pageImage={pageImage}
+        pageImageCaption={pageImageCaption}
       />
       <SkipToContent />
       <SmallScreenHeader

--- a/pages/browse-by-topic/topic/subtopic/index.js
+++ b/pages/browse-by-topic/topic/subtopic/index.js
@@ -33,7 +33,11 @@ const SubtopicItemsList = ({
   nextSubtopic,
   items
 }) =>
-  <MainLayout route={url} pageTitle={subtopic.name}>
+  <MainLayout
+    route={url}
+    pageTitle={subtopic.name}
+    pageImage={subtopic.thumbnailUrl}
+  >
     <BreadcrumbsAndNav
       breadcrumbs={[
         { title: "Browse by Topic", url: "/browse-by-topic" },

--- a/pages/exhibitions/exhibition/index.js
+++ b/pages/exhibitions/exhibition/index.js
@@ -34,6 +34,7 @@ class Exhibition extends React.Component {
     return (
       <MainLayout
         route={router}
+        pageImage={exhibition.thumbnailUrl}
         pageTitle={exhibition.title.replace(/\*/g, "")}
         seoType={SEO_TYPE}
       >

--- a/pages/exhibitions/exhibition/section/subsection.js
+++ b/pages/exhibitions/exhibition/section/subsection.js
@@ -39,7 +39,11 @@ const Subsection = ({
   }
   return (
     <div>
-      <DPLAHead pageTitle={section.title} seoType={SEO_TYPE} />
+      <DPLAHead
+        pageTitle={section.title}
+        seoType={SEO_TYPE}
+        pageImage={exhibition.thumbnailUrl}
+      />
       <SkipToContent />
       <Content
         route={url}
@@ -172,8 +176,28 @@ Subsection.getInitialProps = async ({ query, req, res }) => {
           });
         })
     );
+    // Get homepage item file
+    const sortedExhibitPages = exhibitPageJson
+      .filter(exhibition => !exhibition.parent)
+      .sort((a, b) => a.order - b.order);
+
+    // just in case order isn't consistent, try checking the slug first
+    const homePage =
+      sortedExhibitPages.find(
+        exhibit => exhibit.slug === "home-page" || exhibit.slug === "homepage"
+      ) || sortedExhibitPages[0];
+
+    const { item } = homePage.page_blocks[0].attachments[0];
+    const filesRes = await fetch(
+      `${currentUrl}${FILES_ENDPOINT}?item=${item.id}`
+    );
+    const filesJson = await filesRes.json();
+    const thumbnailUrl = filesJson[0].file_urls.fullsize;
     return {
-      exhibition: Object.assign({}, exhibition, { sections }),
+      exhibition: Object.assign({}, exhibition, {
+        sections,
+        thumbnailUrl
+      }),
       section,
       nextQueryParams: nextQueryParamsAndTitle.queryParams,
       nextSubsectionTitle: nextQueryParamsAndTitle.title,

--- a/pages/item/index.js
+++ b/pages/item/index.js
@@ -42,7 +42,6 @@ const ItemDetail = ({
       route={url}
       pageTitle={item.title}
       pageImage={item.thumbnailUrl}
-      pageDescription={item.title}
     >
       <BreadcrumbsModule /* searchItemCount={searchItemCount} */
         /* paginationInfo={paginationInfo} */

--- a/pages/item/index.js
+++ b/pages/item/index.js
@@ -38,7 +38,12 @@ const ItemDetail = ({
     return <Error statusCode={error.statusCode} />;
   }
   return (
-    <MainLayout route={url} pageTitle={item.title}>
+    <MainLayout
+      route={url}
+      pageTitle={item.title}
+      pageImage={item.thumbnailUrl}
+      pageDescription={item.title}
+    >
       <BreadcrumbsModule /* searchItemCount={searchItemCount} */
         /* paginationInfo={paginationInfo} */
         breadcrumbs={[

--- a/pages/primary-source-sets/set/additional-resources.js
+++ b/pages/primary-source-sets/set/additional-resources.js
@@ -17,7 +17,11 @@ import contentCss from "stylesheets/content-pages.scss";
 import css from "components/PrimarySourceSetsComponents/SingleSet/TeachersGuide/TeachersGuide.scss";
 
 const SingleSet = ({ url, set, currentFullUrl }) =>
-  <MainLayout route={url} pageTitle={set.name.replace(/\*/g, "")}>
+  <MainLayout
+    route={url}
+    pageTitle={set.name.replace(/\*/g, "")}
+    pageImage={set.repImageUrl || set.thumbnailUrl}
+  >
     <BreadcrumbsModule
       breadcrumbs={[
         {

--- a/pages/primary-source-sets/set/index.js
+++ b/pages/primary-source-sets/set/index.js
@@ -16,7 +16,11 @@ const videoIcon = "/static/placeholderImages/Video.svg";
 const audioIcon = "/static/placeholderImages/Sound.svg";
 
 const SingleSet = ({ set, url, currentFullUrl }) =>
-  <MainLayout route={url} pageTitle={set.name.replace(/\*/g, "")}>
+  <MainLayout
+    route={url}
+    pageTitle={set.name.replace(/\*/g, "")}
+    pageImage={set.repImageUrl || set.thumbnailUrl}
+  >
     <BreadcrumbsModule
       breadcrumbs={[
         {

--- a/pages/primary-source-sets/set/sources/index.js
+++ b/pages/primary-source-sets/set/sources/index.js
@@ -15,7 +15,11 @@ const videoIcon = "/static/placeholderImages/Video.svg";
 const audioIcon = "/static/placeholderImages/Sound.svg";
 
 const Source = ({ url, source, set, currentSourceIdx }) =>
-  <MainLayout route={url} pageTitle={source.name}>
+  <MainLayout
+    route={url}
+    pageTitle={source.name}
+    pageImage={source.thumbnailUrl}
+  >
     <BreadcrumbsModule
       breadcrumbs={[
         {

--- a/pages/primary-source-sets/set/teaching-guide.js
+++ b/pages/primary-source-sets/set/teaching-guide.js
@@ -13,7 +13,11 @@ import { PSS_BASE_URL } from "constants/env";
 import { removeQueryParams, getCurrentFullUrl } from "lib";
 
 const SingleSet = ({ url, set, teachingGuide, currentPath, currentFullUrl }) =>
-  <MainLayout route={url} pageTitle={set.name.replace(/\*/g, "")}>
+  <MainLayout
+    route={url}
+    pageTitle={set.name.replace(/\*/g, "")}
+    pageImage={set.repImageUrl || set.thumbnailUrl}
+  >
     <BreadcrumbsModule
       breadcrumbs={[
         {


### PR DESCRIPTION
addressing #471 where not all pages across the site have images. this does not address the lack of an image in news, because there is currently no field to populate this in wordpress. there are still some areas of the site without unique `og:image` but this still falls back to the generic DPLA site description

note that `pageImageCaption` is _not_ the description of the page but the alt information for screen readers describing the contents of the image used. right now there is no field for this either but i added it for future use