### PR TITLE
Fix /thumb's handling of bad object url

### DIFF
--- a/lib/thumbp.js
+++ b/lib/thumbp.js
@@ -146,7 +146,7 @@ Connection.prototype.checkSearchResponse = function(error, response, body) {
       } else {
         url = false;
       }
-      if (url) {
+      if (this.isProbablyURL(url)) {
         this.imageURL = url;
         this.createS3Derivative();
         this.proxyImage();
@@ -253,4 +253,11 @@ Connection.prototype.handleImageConnectionError = function(error) {
 Connection.prototype.returnError = function(code) {
   this.response.statusCode = code;
   this.response.end();
+};
+
+/*
+ * Perform a cursory check to see whether the given string looks like a URL
+ */
+Connection.prototype.isProbablyURL = function(s) {
+  return s && s.match(/^https?:\/\//) != null;
 };

--- a/test/thumbp.js
+++ b/test/thumbp.js
@@ -336,4 +336,18 @@ describe("Connection", function() {
       assert(returnErrorStub.calledWith(502));
     });
   });
+
+  describe("isProbablyURL()", function() {
+    it("passes a good URL (1)", function() {
+      assert(c.isProbablyURL("https://example.edu/x.jpg") == true);
+    });
+
+    it("flunks a bad string (1)", function() {
+      assert(c.isProbablyURL("AAA-AAA_chasj_3157") == false);
+    });
+
+    it("flunks a value that is not truthy", function() {
+      assert(c.isProbablyURL(false) == false);
+    });
+  });
 });


### PR DESCRIPTION
Fix /thumb's handling of bad provider data, when `object' is not a URL. Stop throwing a 500 error when running into the bad data; instead, return a 404.