### PR TITLE
fixed testing requires

### DIFF
--- a/test/thumbp.js
+++ b/test/thumbp.js
@@ -1,9 +1,9 @@
 const assert = require("chai").assert;
-const expect = require("expect");
+const expect = require("expect.js");
 const sinon = require("sinon");
 const http = require("http");
 const libRequest = require("request");
-const thumbp = require("lib/thumbp");
+const thumbp = require("../lib/thumbp.js");
 
 describe("Connection", function() {
   var c, request, response, returnErrorStub, consoleErrorStub, libRequestStub;


### PR DESCRIPTION
`yarn test` was [crashing](https://travis-ci.org/dpla/dpla-frontend/builds/407317156?utm_source=github_status&utm_medium=notification) due to bad requires for `expect.js` and `lib/thumbp.js`