### PR TITLE
added better empty states to search

### DIFF
--- a/components/SearchComponents/MainContent/MainContent.scss
+++ b/components/SearchComponents/MainContent/MainContent.scss
@@ -28,6 +28,10 @@
   }
 }
 
+.noResults {
+  margin: 0 1rem;
+}
+
 .sidebar {
   flex-basis: 33%;
   overflow: hidden;

--- a/components/SearchComponents/MainContent/index.js
+++ b/components/SearchComponents/MainContent/index.js
@@ -4,33 +4,38 @@ import ListView from "shared/ListView";
 import Pagination from "shared/Pagination";
 import Sidebar from "./Sidebar";
 
-import { addLinkInfoToResults, removeQueryParams, extractItemId } from "lib";
+import { addLinkInfoToResults } from "lib";
 
 import utils from "stylesheets/utils.scss";
 import css from "./MainContent.scss";
 
 const MainContent = ({ results, route, facets, paginationInfo, hideSidebar }) =>
-  <div className={css.wrapper}>
-    <div className={[utils.container, css.mainContent].join(" ")}>
+  <div className={[utils.container, css.mainContent].join(" ")}>
+    {results.length > 0 &&
       <div className={`${!hideSidebar ? css.isOpen : ""} ${css.sidebar}`}>
         <Sidebar route={route} facets={facets} />
-      </div>
-      <div id="main" role="main" className={css.resultsAndPagination}>
+      </div>}
+    <div id="main" role="main" className={css.resultsAndPagination}>
+      {results.length > 0 &&
         <ListView
           route={route}
           items={addLinkInfoToResults(results, route.query)}
           viewMode={route.query.list_view}
-        />
-        <Pagination
-          route={route}
-          itemsPerPage={paginationInfo.pageSize}
-          currentPage={parseInt(paginationInfo.currentPage, 10)}
-          totalItems={paginationInfo.pageCount}
-          pageCount={Math.ceil(
-            paginationInfo.pageCount / paginationInfo.pageSize
-          )}
-        />
-      </div>
+        />}
+      {results.length === 0 &&
+        <div className={css.noResults}>
+          Your search did not match any items. Try different or more general
+          keywords or removing filters.
+        </div>}
+      <Pagination
+        route={route}
+        itemsPerPage={paginationInfo.pageSize}
+        currentPage={parseInt(paginationInfo.currentPage, 10)}
+        totalItems={paginationInfo.pageCount}
+        pageCount={Math.ceil(
+          paginationInfo.pageCount / paginationInfo.pageSize
+        )}
+      />
     </div>
   </div>;
 

--- a/components/SearchComponents/MaxPageError.js
+++ b/components/SearchComponents/MaxPageError.js
@@ -1,0 +1,12 @@
+import React from "react";
+
+import utils from "stylesheets/utils.scss";
+import css from "./MaxPageError.scss";
+
+const MaxPageError = ({ maxPage, requestedPage }) =>
+  <div className={`${utils.container} ${css.maxPageError}`}>
+    Sorry, DPLA does not serve more than {maxPage} pages of results for any
+    query. (You asked for results starting from {requestedPage}.).
+  </div>;
+
+export default MaxPageError;

--- a/components/SearchComponents/MaxPageError.scss
+++ b/components/SearchComponents/MaxPageError.scss
@@ -1,0 +1,4 @@
+.maxPageError {
+  margin-bottom: 10rem;
+  margin-top: 2rem;
+}

--- a/constants/search.js
+++ b/constants/search.js
@@ -101,6 +101,3 @@ export const splitAndURIEncodeFacet = facet =>
 export const DEFAULT_PAGE_SIZE = "20";
 
 export const MAX_PAGE_SIZE = 100;
-
-export const MAX_PAGE_MESSAGE =
-  "Sorry, DPLA does not serve more than 100 pages of results for any query.";

--- a/constants/search.js
+++ b/constants/search.js
@@ -101,3 +101,6 @@ export const splitAndURIEncodeFacet = facet =>
 export const DEFAULT_PAGE_SIZE = "20";
 
 export const MAX_PAGE_SIZE = 100;
+
+export const MAX_PAGE_MESSAGE =
+  "Sorry, DPLA does not serve more than 100 pages of results for any query.";

--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -20,6 +20,7 @@ import { SITE_ENV, LOCAL_ID } from "constants/env";
 import { LOCALS } from "constants/local";
 
 import { getCurrentUrl, getDefaultThumbnail, getSearchPageTitle } from "lib";
+import MaxPageError from "components/SearchComponents/MaxPageError";
 
 class Search extends React.Component {
   state = {
@@ -45,31 +46,39 @@ class Search extends React.Component {
         route={router}
         pageTitle={getSearchPageTitle(router.query.q)}
       >
-        <OptionsBar
-          showFilters={this.state.showSidebar}
-          currentPage={currentPage}
-          route={router}
-          itemCount={results.count}
-          onClickToggleFilters={this.toggleFilters}
-          numberOfActiveFacets={numberOfActiveFacets}
-        />
-        <FiltersList
-          showFilters={this.state.showSidebar}
-          onClickToggleFilters={this.toggleFilters}
-          route={router}
-          facets={results.facets}
-        />
-        <MainContent
-          hideSidebar={!this.state.showSidebar}
-          paginationInfo={{
-            pageCount: pageCount,
-            pageSize: pageSize || DEFAULT_PAGE_SIZE,
-            currentPage: currentPage
-          }}
-          route={router}
-          facets={results.facets}
-          results={results.docs}
-        />
+        <div>
+          <OptionsBar
+            showFilters={this.state.showSidebar}
+            currentPage={currentPage}
+            route={router}
+            itemCount={results.count || 0}
+            onClickToggleFilters={this.toggleFilters}
+            numberOfActiveFacets={numberOfActiveFacets}
+          />
+          <FiltersList
+            showFilters={this.state.showSidebar}
+            onClickToggleFilters={this.toggleFilters}
+            route={router}
+            facets={results.facets}
+          />
+          {currentPage <= MAX_PAGE_SIZE &&
+            <MainContent
+              hideSidebar={!this.state.showSidebar}
+              paginationInfo={{
+                pageCount: pageCount,
+                pageSize: pageSize || DEFAULT_PAGE_SIZE,
+                currentPage: currentPage
+              }}
+              route={router}
+              facets={results.facets}
+              results={results.docs}
+            />}
+          {currentPage > MAX_PAGE_SIZE &&
+            <MaxPageError
+              maxPage={MAX_PAGE_SIZE}
+              requestedPage={currentPage}
+            />}
+        </div>
       </MainLayout>
     );
   }
@@ -81,22 +90,6 @@ Search.getInitialProps = async ({ query, req }) => {
   const q = query.q
     ? encodeURIComponent(query.q).replace(/'/g, "%27").replace(/"/g, "%22")
     : "";
-  let page_size = query.page_size || DEFAULT_PAGE_SIZE;
-  const acceptedPageSizes = pageSizeOptions.map(item => item.value);
-  if (acceptedPageSizes.indexOf(page_size) === -1) {
-    page_size = DEFAULT_PAGE_SIZE;
-  }
-  let page = query.page || 1;
-  if (page > MAX_PAGE_SIZE) {
-    page = MAX_PAGE_SIZE;
-  }
-  let sort_by = "";
-  if (query.sort_by === "title") {
-    sort_by = "sourceResource.title";
-  } else if (query.sort_by === "created") {
-    sort_by = "sourceResource.date.begin";
-  }
-  const sort_order = query.sort_order || "";
 
   let hasDates = false;
 
@@ -141,49 +134,76 @@ Search.getInitialProps = async ({ query, req }) => {
 
   const facetQueries = queryArray.join("&");
 
-  const url = `${currentUrl}${API_ENDPOINT}?exact_field_match=true&q=${q}&page=${page}&page_size=${page_size}&sort_order=${sort_order}&sort_by=${sort_by}&facets=${possibleFacets.join(
-    ","
-  )}&${facetQueries}`;
+  let sort_by = "";
+  if (query.sort_by === "title") {
+    sort_by = "sourceResource.title";
+  } else if (query.sort_by === "created") {
+    sort_by = "sourceResource.date.begin";
+  }
+  const sort_order = query.sort_order || "";
 
-  const res = await fetch(url);
+  let page_size = query.page_size || DEFAULT_PAGE_SIZE;
+  const acceptedPageSizes = pageSizeOptions.map(item => item.value);
+  if (acceptedPageSizes.indexOf(page_size) === -1) {
+    page_size = DEFAULT_PAGE_SIZE;
+  }
 
-  const numberOfActiveFacets = facetQueries
-    .split(/(&|\+AND\+)/)
-    .filter(facet => facet && facet !== "+AND+" && facet !== "&").length;
+  let page = query.page || 1;
 
-  let json = await res.json();
-  const docs = json.docs.map(result => {
-    const thumbnailUrl = result.object
-      ? `${currentUrl}${THUMBNAIL_ENDPOINT}/${result.id}`
-      : getDefaultThumbnail(result.sourceResource.type);
-    return Object.assign({}, result.sourceResource, {
-      thumbnailUrl,
-      id: result.id ? result.id : result.sourceResource["@id"],
-      sourceUrl: result.isShownAt,
-      provider: result.provider && result.provider.name,
-      dataProvider: result.dataProvider,
-      useDefaultImage: !result.object
+  if (page <= MAX_PAGE_SIZE) {
+    const numberOfActiveFacets = facetQueries
+      .split(/(&|\+AND\+)/)
+      .filter(facet => facet && facet !== "+AND+" && facet !== "&").length;
+
+    const url = `${currentUrl}${API_ENDPOINT}?exact_field_match=true&q=${q}&page=${page}&page_size=${page_size}&sort_order=${sort_order}&sort_by=${sort_by}&facets=${possibleFacets.join(
+      ","
+    )}&${facetQueries}`;
+
+    const res = await fetch(url);
+
+    let json = await res.json();
+    const docs = json.docs.map(result => {
+      const thumbnailUrl = result.object
+        ? `${currentUrl}${THUMBNAIL_ENDPOINT}/${result.id}`
+        : getDefaultThumbnail(result.sourceResource.type);
+      return Object.assign({}, result.sourceResource, {
+        thumbnailUrl,
+        id: result.id ? result.id : result.sourceResource["@id"],
+        sourceUrl: result.isShownAt,
+        provider: result.provider && result.provider.name,
+        dataProvider: result.dataProvider,
+        useDefaultImage: !result.object
+      });
     });
-  });
 
-  // fix facets because ES no longer returns them in the requested order
-  // TODO: remove this hack once fixed in ES
-  let newFacets = {};
-  possibleFacets.forEach(facet => {
-    if (json.facets[facet]) newFacets[facet] = json.facets[facet];
-  });
-  json.facets = newFacets;
-  // end of hack
+    // fix facets because ES no longer returns them in the requested order
+    // TODO: remove this hack once fixed in ES
+    let newFacets = {};
+    possibleFacets.forEach(facet => {
+      if (json.facets[facet]) newFacets[facet] = json.facets[facet];
+    });
+    json.facets = newFacets;
+    // end of hack
 
-  const maxResults = MAX_PAGE_SIZE * page_size;
-  const pageCount = json.count > maxResults ? maxResults : json.count;
+    const maxResults = MAX_PAGE_SIZE * page_size;
+    const pageCount = json.count > maxResults ? maxResults : json.count;
 
-  return {
-    results: Object.assign({}, json, { docs }),
-    numberOfActiveFacets,
-    currentPage: page,
-    pageCount,
-    pageSize: page_size
-  };
+    return {
+      results: Object.assign({}, json, { docs }),
+      numberOfActiveFacets,
+      currentPage: page,
+      pageCount,
+      pageSize: page_size
+    };
+  } else {
+    // we skip the whole thing and present the error message
+    return {
+      results: {},
+      numberOfActiveFacets: 0,
+      currentPage: page,
+      pageCount: 0,
+      pageSize: page_size
+    };
+  }
 };
 export default withRouter(Search);

--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -46,39 +46,34 @@ class Search extends React.Component {
         route={router}
         pageTitle={getSearchPageTitle(router.query.q)}
       >
-        <div>
-          <OptionsBar
-            showFilters={this.state.showSidebar}
-            currentPage={currentPage}
-            route={router}
-            itemCount={results.count || 0}
-            onClickToggleFilters={this.toggleFilters}
-            numberOfActiveFacets={numberOfActiveFacets}
-          />
-          <FiltersList
-            showFilters={this.state.showSidebar}
-            onClickToggleFilters={this.toggleFilters}
+        <OptionsBar
+          showFilters={this.state.showSidebar}
+          currentPage={currentPage}
+          route={router}
+          itemCount={results.count || 0}
+          onClickToggleFilters={this.toggleFilters}
+          numberOfActiveFacets={numberOfActiveFacets}
+        />
+        <FiltersList
+          showFilters={this.state.showSidebar}
+          onClickToggleFilters={this.toggleFilters}
+          route={router}
+          facets={results.facets}
+        />
+        {currentPage <= MAX_PAGE_SIZE &&
+          <MainContent
+            hideSidebar={!this.state.showSidebar}
+            paginationInfo={{
+              pageCount: pageCount,
+              pageSize: pageSize || DEFAULT_PAGE_SIZE,
+              currentPage: currentPage
+            }}
             route={router}
             facets={results.facets}
-          />
-          {currentPage <= MAX_PAGE_SIZE &&
-            <MainContent
-              hideSidebar={!this.state.showSidebar}
-              paginationInfo={{
-                pageCount: pageCount,
-                pageSize: pageSize || DEFAULT_PAGE_SIZE,
-                currentPage: currentPage
-              }}
-              route={router}
-              facets={results.facets}
-              results={results.docs}
-            />}
-          {currentPage > MAX_PAGE_SIZE &&
-            <MaxPageError
-              maxPage={MAX_PAGE_SIZE}
-              requestedPage={currentPage}
-            />}
-        </div>
+            results={results.docs}
+          />}
+        {currentPage > MAX_PAGE_SIZE &&
+          <MaxPageError maxPage={MAX_PAGE_SIZE} requestedPage={currentPage} />}
       </MainLayout>
     );
   }


### PR DESCRIPTION
when a patron provides keywords with no results, we just show an empty page with very few indicators: only the “0 results” in the top. added a more instructive message:

<img width="2336" alt="image" src="https://user-images.githubusercontent.com/133020/44937037-50845a80-ad45-11e8-9b85-03494dbdd152.png">

also when a patron alters the querystring to get an unaccepted page number (beyond 100) we are currently showing the 100th page. added a message to explain what is going on:

<img width="2336" alt="image" src="https://user-images.githubusercontent.com/133020/44937079-888b9d80-ad45-11e8-9c23-02c6c2611186.png">
