### PR TITLE
fixed a typo and added styling to empty results

### DIFF
--- a/components/SearchComponents/MainContent/index.js
+++ b/components/SearchComponents/MainContent/index.js
@@ -8,6 +8,7 @@ import { addLinkInfoToResults } from "lib";
 
 import utils from "stylesheets/utils.scss";
 import css from "./MainContent.scss";
+import contentCss from "stylesheets/content-pages.scss";
 
 const MainContent = ({ results, route, facets, paginationInfo, hideSidebar }) =>
   <div className={[utils.container, css.mainContent].join(" ")}>
@@ -23,9 +24,19 @@ const MainContent = ({ results, route, facets, paginationInfo, hideSidebar }) =>
           viewMode={route.query.list_view}
         />}
       {results.length === 0 &&
-        <div className={css.noResults}>
-          Your search did not match any items. Try different or more general
-          keywords or removing filters.
+        <div className={`${css.noResults} ${contentCss.content}`}>
+          <p>
+            Your search did not match any items.
+          </p>
+          <p>
+            Some suggestions:
+          </p>
+          <ul>
+            <li>make sure spelling is correct</li>
+            <li>try different keywords</li>
+            <li>try more general keywords</li>
+            <li>try removing filters</li>
+          </ul>
         </div>}
       <Pagination
         route={route}

--- a/components/SearchComponents/MaxPageError.js
+++ b/components/SearchComponents/MaxPageError.js
@@ -6,7 +6,7 @@ import css from "./MaxPageError.scss";
 const MaxPageError = ({ maxPage, requestedPage }) =>
   <div className={`${utils.container} ${css.maxPageError}`}>
     Sorry, DPLA does not serve more than {maxPage} pages of results for any
-    query. (You asked for results starting from {requestedPage}.).
+    query. (You asked for results starting from {requestedPage})
   </div>;
 
 export default MaxPageError;


### PR DESCRIPTION
there was a typo in the 100+ message. added some styling to empty search: 

<img width="352" alt="image" src="https://user-images.githubusercontent.com/133020/45040898-0812b880-b035-11e8-8916-0e06eaf5b0a1.png">
