### PR TITLE
added ebooks link section to content page sidebar

### DIFF
--- a/components/shared/ContentPagesSidebar/index.js
+++ b/components/shared/ContentPagesSidebar/index.js
@@ -58,6 +58,11 @@ const NestedSidebarLinks = ({
       as: "/hubs",
       href: "/pro/wp/hubs?section=" + item.post_name
     };
+  } else if (item.post_name === "ebooks") {
+    linkObject = {
+      as: "/ebooks",
+      href: "/pro/wp/ebooks?section=" + item.post_name
+    };
   } else if (SITE_ENV === "user") {
     linkObject = {
       as: "/about/" + item.post_name,


### PR DESCRIPTION
the sidebar does not know about the “special” sections such as hubs and ebooks in the pro site so they have to be manually added/hardcoded

fixes #957