### PR TITLE
Adds new application api endpoint for aboutness

### DIFF
--- a/constants/items.js
+++ b/constants/items.js
@@ -1,2 +1,3 @@
 export const API_ENDPOINT = "/api/dpla/items";
 export const THUMBNAIL_ENDPOINT = "/thumb";
+export const LOCAL_ABOUT_ENDPOINT = "/api/dpla/local_about";

--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -188,9 +188,8 @@ Search.getInitialProps = async ({ query, req }) => {
   // get the aboutness links
   let aboutness = {};
   if (isLocal) {
-    const aboutness_page_size = 20;
     const aboutness_max = 4;
-    const aboutnessUrl = `${currentUrl}${API_ENDPOINT}?op=OR&exact_field_match=true&q=${q}&page=1&page_size=${aboutness_page_size}&${originalLocation}&${originalSubject}&${originalFacetQueries}`;
+    const aboutnessUrl = `${currentUrl}${LOCAL_ABOUT_ENDPOINT}&q=${q}`;
     const aboutnessRes = await fetch(aboutnessUrl);
     const aboutnessJson = await aboutnessRes.json();
     // NOTE: since the api does not allow for negated search,

--- a/routesAPI.js
+++ b/routesAPI.js
@@ -1,5 +1,6 @@
 const proxy = require("express-http-proxy");
 const serverFunctions = require("./lib/serverFunctions");
+const locals = require("./constants/local");
 
 module.exports = (app, server) => {
   // API proxy routes
@@ -70,6 +71,36 @@ module.exports = (app, server) => {
         );
 
         return newPath;
+      }
+    })
+  );
+
+  server.get(
+    "/api/dpla/local_about",
+    proxy(process.env.API_URL, {
+      proxyReqPathResolver: function(req) {
+        console.log("aboutttt");
+        if (process.env.SITE_ENV !== "local") {
+          console.log("Got local about request, but site not a local.");
+          return "";
+        }
+        const localId = process.env.LOCAL_ID;
+        const local = locals["LOCALS"][localId];
+        const provider = local["provider"];
+        const location = local["locationFacet"];
+        const subject = local["subjectFacet"];
+        const apiKey = process.env.API_KEY;
+        const apiUrl = process.env.API_URL;
+        const query =
+          `${req.query.q}%20AND%20` +
+          `(sourceResource.spatial.name:${location}` +
+          `%20OR%20sourceResource.subject.name:${subject})` +
+          `%20AND%20NOT%20provider.name:${provider}`;
+        console.log(query);
+        return (
+          `${apiUrl}/items?api_key=${apiKey}` +
+          `&exact_field_match=true?q=${query}`
+        );
       }
     })
   );

--- a/routesAPI.js
+++ b/routesAPI.js
@@ -82,7 +82,7 @@ module.exports = (app, server) => {
         console.log("aboutttt");
         if (process.env.SITE_ENV !== "local") {
           console.log("Got local about request, but site not a local.");
-          return "";
+          return "{}";
         }
         const localId = process.env.LOCAL_ID;
         const local = locals["LOCALS"][localId];
@@ -92,14 +92,13 @@ module.exports = (app, server) => {
         const apiKey = process.env.API_KEY;
         const apiUrl = process.env.API_URL;
         const query =
-          `${req.query.q}%20AND%20` +
+          `${encodeURIComponent(req.query.q)}%20AND%20` +
           `(sourceResource.spatial.name:${location}` +
           `%20OR%20sourceResource.subject.name:${subject})` +
-          `%20AND%20NOT%20provider.name:${provider}`;
-        console.log(query);
+          `%20AND%20NOT%20provider.name:${provider}&`;
         return (
           `${apiUrl}/items?api_key=${apiKey}` +
-          `&exact_field_match=true?q=${query}`
+          `&exact_field_match=true&q=${query}`
         );
       }
     })

--- a/routesAPI.js
+++ b/routesAPI.js
@@ -79,7 +79,6 @@ module.exports = (app, server) => {
     "/api/dpla/local_about",
     proxy(process.env.API_URL, {
       proxyReqPathResolver: function(req) {
-        console.log("aboutttt");
         if (process.env.SITE_ENV !== "local") {
           console.log("Got local about request, but site not a local.");
           return "{}";


### PR DESCRIPTION
Initial implementation of aboutness (links under `Explore related items in DPLA` on this page: http://recollectionwisconsin.dp.la/search?q=food) was returning unexpected results and did filtering of items on the client side. 

Short version of how feature should work:
```It should show things that are subject=Wisconsin OR location Wisconsin and are not provider = Wisconsin, and the search term should be what the search term is for the page```

I built a new internal API endpoint that does this via a Lucene syntax query and pointed the aboutness links at that instead. Removed a bunch of the client side filtering code as a result.