### PR TITLE
get results count ES7 style

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -147,7 +147,14 @@ Home.getInitialProps = async ({ req }) => {
     `${currentUrl}${ITEMS_API_ENDPOINT}?page_size=0`
   );
   const itemsJson = await itemsRes.json();
-  const itemCount = itemsJson.count;
+  var itemCount = 0 // default handles unexpected error
+  if ("count" in itemsJson) {
+    if (itemsJson.count.value != undefined) {
+      itemCount = itemsJson.count.value // ElasticSearch 7
+    } else {
+      itemCount = itemsJson.count // ElasticSearch 6
+    }
+  }
   const headerDescription = homepageJson.acf.header_description.replace(
     HEADER_DESCRIPTION_TOKEN,
     addCommasToNumber(itemCount)

--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -54,6 +54,16 @@ class Search extends React.Component {
       pageSize,
       aboutness
     } = this.props;
+
+    var itemCount = 0 // default handles unexpected error
+    if ("count" in results) {
+      if (results.count.value != undefined) {
+        itemCount = results.count.value // ElasticSearch 7
+      } else {
+        itemCount = results.count // ElasticSearch 6
+      }
+    }
+
     return (
       <MainLayout
         isSearchPage={true}
@@ -64,7 +74,7 @@ class Search extends React.Component {
           showFilters={this.state.showSidebar}
           currentPage={currentPage}
           route={router}
-          itemCount={results.count || 0}
+          itemCount={itemCount}
           onClickToggleFilters={this.toggleFilters}
           numberOfActiveFacets={numberOfActiveFacets}
         />


### PR DESCRIPTION
This handles a change in ES7 in which counts are represented as a hash instead of a number.  It is backward compatible with ES6.  This has been tested locally against the production API and a local instance of the API running ES7.