### PR TITLE
"Re-enabled" QA mode

### DIFF
--- a/components/ItemComponents/Content/QA.js
+++ b/components/ItemComponents/Content/QA.js
@@ -26,8 +26,7 @@ class QA extends React.Component {
     const divStyle = {
       float: "left",
       width: "48%",
-      paddingLeft: "20px",
-      display: "none"
+      paddingLeft: "20px"
     };
     let originalRecord = "";
     if ("stringValue" in item.originalRecord) {


### PR DESCRIPTION
This was "disabled" when we were trying to build BWS in this project. 

"Reenabling" this to help Dominic see actual metadata records.

This only shows up in the UI if you have a special cookie set and view the frontend directly from the app server rather than the CDN, so it's not user-facing.