### PR TITLE
DT-2256: VT updates

### DIFF
--- a/static/local/vermont/about.md
+++ b/static/local/vermont/about.md
@@ -23,4 +23,4 @@ The Vermont Green Mountain Digital Archive (GMDA) is a collaborative effort of s
 
 ***Get Involved!*** For information on how to become a contributing member, contact Patrick Wallace, <pwallace@middlebury.edu> 802-443-3017.
 
-***Questions about the content on the GMDA?***  Contact Rachel Onuf, <rachel.onuf@vermont.gov> 802-622-4092
+***Questions about the content on the GMDA?***  Contact Rachel Onuf, <rachel.onuf@vermont.gov> 802-622-4092.

--- a/static/local/vermont/homepage.md
+++ b/static/local/vermont/homepage.md
@@ -26,6 +26,6 @@ Below are some suggested topics to browse.  The search box above can also be use
 
   Vermont was once a place bustling with railroad activity. View Vermont’s early trains, bridges, and other transportation infrastructure – and accidents.
 
-- ### [Military](/search?q=military+history)
+- ### [Military History](/search?q=military)
 
   Images showing military education in the state and campaigns around the world, as well as historical state regimental flags and letters from Vermont soldiers.

--- a/static/local/vermont/homepage.md
+++ b/static/local/vermont/homepage.md
@@ -26,6 +26,6 @@ Below are some suggested topics to browse.  The search box above can also be use
 
   Vermont was once a place bustling with railroad activity. View Vermont’s early trains, bridges, and other transportation infrastructure – and accidents.
 
-- ### [Military History](/search?q=%22military+history%22)
+- ### [Military](/search?q=military+history)
 
   Images showing military education in the state and campaigns around the world, as well as historical state regimental flags and letters from Vermont soldiers.

--- a/stylesheets/content-pages.scss
+++ b/stylesheets/content-pages.scss
@@ -87,8 +87,9 @@ $borderColor: rgba(0, 0, 0, 0.75);
   }
 
   & h3 {
-    font-size: 1.75rem;
+    font-size: 1.25rem;
     font-weight: normal;
+    font-family: $sansFont;
   }
 
   & h4 {
@@ -139,7 +140,7 @@ $borderColor: rgba(0, 0, 0, 0.75);
   }
 
   & ul, & ol {
-    padding-left: 0;
+    padding-left: 1em;
     margin-top: 1rem;
     margin-bottom: 1rem;
     position: relative;
@@ -161,10 +162,6 @@ $borderColor: rgba(0, 0, 0, 0.75);
   }
 
   & li::before {
-    position: absolute;
-    top: 0;
-    left: -3rem;
-    width: 3rem;
     padding-right: 0.25rem;
     text-align: right;
     color: $primaryBulletColor;


### PR DESCRIPTION
- On the About page, the use of different fonts is a little jarring. Could we have "Partners" and "Contributing Libraries" in the same font as "Our Partners..." and in a smaller size?
- The repository names on the About page could also be slightly indented, under the headings.
- On the About page, there should be a period at the end of Rachel Onuf's contact information "Contact Rachel Onuf, rachel.onuf@vermont.gov 802-622-4092"
- The Military History category on the Home page doesn't actually have any items in it. Do you need us to pull together the subject headings for what's included in that so that the algorithm works correctly? 

https://digitalpubliclibraryofamerica.atlassian.net/browse/DT-2256