### PR TITLE
slay seadragon

### DIFF
--- a/cypress/integration/exhibitions.spec.js
+++ b/cypress/integration/exhibitions.spec.js
@@ -3,14 +3,14 @@ describe('Exhibitions', async () => {
 
     beforeEach(() => {
         cy.viewport(1024, 768);
-    });
+    })
 
     it(`home hasn't changed`, () => {
         cy
             .visit('/exhibitions')
             .getDataCy('exhibitions-home')
             .snapshot();
-    });
+    })
 
     for (const exhibit of exhibits) {
 
@@ -18,17 +18,25 @@ describe('Exhibitions', async () => {
             cy
                 .visit(`/exhibitions/${exhibit.slug}`)
                 .getDataCy('exhibition-home')
-                .snapshot();
-        });
+                .snapshot()
+        })
 
         for (const exhibitPage of exhibit.pages) {
             it(`${exhibit.slug}'s page ${exhibitPage} hasn't changed`, () => {
-                cy
-                    .visit(`/exhibitions/${exhibit.slug}/${exhibitPage}`)
-                    .getDataCy('exhibit-page')
-                    .snapshot();
-            });
+                cy.visit(`/exhibitions/${exhibit.slug}/${exhibitPage}`)
+                cy.window().then( window => {                    
+                    // seadragon's opacity and w/h params shift too much to work with 
+                    // snapshots so we're just going to take it out of the picture heh heh
+
+                    // todo switch to typescript to clean this kind of thing up with ?.
+                    const seadragon = window.document.getElementById("openseadragon1")
+                    if (seadragon) {
+                        seadragon.remove()
+                    }
+                    cy.getDataCy('exhibit-page').snapshot()
+                })
+            })
         }
     }
-});
+})
 

--- a/cypress/integration/exhibitions.spec.js
+++ b/cypress/integration/exhibitions.spec.js
@@ -33,8 +33,9 @@ describe('Exhibitions', async () => {
                     if (seadragon) {
                         seadragon.remove()
                     }
-                    cy.getDataCy('exhibit-page').snapshot()
+
                 })
+                cy.getDataCy('exhibit-page').snapshot()
             })
         }
     }


### PR DESCRIPTION
This uses a Cypress api to get access to the window object and trims out the image viewer on exhibitions pages that have images.

The openseadragon viewer has a mouseover control overlay that fades out using an opacity attribute and a js timeout, and it's unpredictable where that process is going to be when Cypress goes to do a snapshot. So I'm just removing it from the DOM for snapshots until I understand better how to deal with that in cypress. Ideally I'd just remove the overlay, but I haven't figured out the selectors yet.