### PR TITLE
add collection to item page

### DIFF
--- a/components/ItemComponents/Content/OtherMetadata.js
+++ b/components/ItemComponents/Content/OtherMetadata.js
@@ -24,6 +24,15 @@ const OtherMetadata = ({ item }) =>
         <ItemTermValuePair heading="Supporting Institution">
           <FacetLink facet="provider" value={item.intermediateProvider} />
         </ItemTermValuePair>}
+      {item.collection &&
+        <ItemTermValuePair heading="Collection">
+          {!Array.isArray(item.collection)
+            ? <div>{item.collection.title}</div>
+            : item.collection.map((collection, i, collections) =>
+              <div key={i}>{collection.title}</div>
+            )}
+
+        </ItemTermValuePair>}
       {item.publisher &&
         <ItemTermValuePair heading="Publisher">
           {joinIfArray(item.publisher)}


### PR DESCRIPTION
This adds the collection name to the item metadata page.  Collection is not linked, it's just pain text.
This has been tested locally with items with 0, 1, and many collections.

![Screen Shot 2021-05-05 at 11 09 51 AM](https://user-images.githubusercontent.com/3615206/117164516-afba8880-ad92-11eb-8bf1-8e94d4478468.png)
