### PR TITLE
Dataprovider object

### DIFF
--- a/lib/parseDplaItemRecord.js
+++ b/lib/parseDplaItemRecord.js
@@ -4,13 +4,10 @@
 const parseDplaItemRecord = dplaItemJson => {
   const doc = dplaItemJson && dplaItemJson.docs && dplaItemJson.docs[0];
   const sourceResource = doc && doc.sourceResource;
-
-  // Try reading dataProvider from object.
-  // If this fails, read dataProvider from string.
-  const dataProviderFromObj = doc && doc.dataProvider.name;
-  const dataProvider = dataProviderFromObj ? 
-    dataProviderFromObj :
-    doc && doc.dataProvider;
+  const dataProviderFromObj = doc && doc.dataProvider && doc.dataProvider.name;
+  const dataProvider = dataProviderFromObj 
+    ? dataProviderFromObj
+    : doc && doc.dataProvider;
 
   return {
     partner: doc && doc.provider && doc.provider.name,

--- a/lib/parseDplaItemRecord.js
+++ b/lib/parseDplaItemRecord.js
@@ -5,9 +5,16 @@ const parseDplaItemRecord = dplaItemJson => {
   const doc = dplaItemJson && dplaItemJson.docs && dplaItemJson.docs[0];
   const sourceResource = doc && doc.sourceResource;
 
+  // Try reading dataProvider from object.
+  // If this fails, read dataProvider from string.
+  const dataProviderFromObj = doc && doc.dataProvider.name;
+  const dataProvider = dataProviderFromObj ? 
+    dataProviderFromObj :
+    doc && doc.dataProvider;
+
   return {
     partner: doc && doc.provider && doc.provider.name,
-    dataProvider: doc && doc.dataProvider,
+    dataProvider: dataProvider,
     title: sourceResource && sourceResource.title
   };
 };

--- a/pages/api/items/[idListString].js
+++ b/pages/api/items/[idListString].js
@@ -21,7 +21,8 @@ export default async function handler(req, res) {
 
     try {
         const url =
-            `http://api.dp.la/v2/items/${validIds.join(",")}` +
+            `${process.env.API_URL}/${process.env.API_VERSION}/items/` +
+            `${validIds.join(",")}` +
             `?api_key=${process.env.API_KEY}`;
 
         const axiosRes = await axios.get(url, {responseType: 'stream'});

--- a/pages/browse-by-topic/topic/subtopic/index.js
+++ b/pages/browse-by-topic/topic/subtopic/index.js
@@ -130,6 +130,14 @@ export const getServerSideProps = async ({query}) => {
                 return null;
             }
             const itemJson = await itemRes.json();
+
+            // Try reading dataProvider from object.
+            // If this fails, read dataProvider from string.
+            const dataProviderFromObj = itemJson.docs[0].dataProvider.name;
+            const dataProvider = dataProviderFromObj ?
+                dataProviderFromObj :
+                itemJson.docs[0].dataProvider;
+
             return Object.assign({}, item, {
                 title: decodeHTMLEntities(item.title.rendered),
                 linkHref: `/item?itemId=${itemDplaId}`,
@@ -140,7 +148,7 @@ export const getServerSideProps = async ({query}) => {
                 date: itemJson.docs[0].sourceResource.date,
                 creator: itemJson.docs[0].sourceResource.creator,
                 description: itemJson.docs[0].sourceResource.description,
-                dataProvider: itemJson.docs[0].dataProvider,
+                dataProvider: dataProvider,
                 useDefaultImage: !itemJson.docs[0].object,
                 itemDplaId: itemDplaId,
                 provider:

--- a/pages/browse-by-topic/topic/subtopic/index.js
+++ b/pages/browse-by-topic/topic/subtopic/index.js
@@ -130,13 +130,9 @@ export const getServerSideProps = async ({query}) => {
                 return null;
             }
             const itemJson = await itemRes.json();
-
-            // Try reading dataProvider from object.
-            // If this fails, read dataProvider from string.
-            const dataProviderFromObj = itemJson.docs[0].dataProvider.name;
-            const dataProvider = dataProviderFromObj ?
-                dataProviderFromObj :
-                itemJson.docs[0].dataProvider;
+            const dataProvider = itemJson.docs[0].dataProvider.name
+                ? itemJson.docs[0].dataProvider.name
+                : itemJson.docs[0].dataProvider;
 
             return Object.assign({}, item, {
                 title: decodeHTMLEntities(item.title.rendered),

--- a/pages/browse-by-topic/topic/subtopic/index.js
+++ b/pages/browse-by-topic/topic/subtopic/index.js
@@ -123,9 +123,9 @@ export const getServerSideProps = async ({query}) => {
     const items = await Promise.all(
         itemsJson.map(async item => {
             const itemDplaId = extractItemId(item.acf.dpla_url);
-            const itemRes = await fetch(
-                `${process.env.API_URL}/items/${itemDplaId}?api_key=${process.env.API_KEY}`
-            );
+            const itemUrl = `${process.env.API_URL}/${process.env.API_VERSION}` +
+                `/items/${itemDplaId}?api_key=${process.env.API_KEY}`
+            const itemRes = await fetch(itemUrl);
             if (!itemRes.ok) {
                 return null;
             }

--- a/pages/item/index.js
+++ b/pages/item/index.js
@@ -96,6 +96,9 @@ export const getServerSideProps = async context => {
                 return lang.name;
             })
             : doc.sourceResource.language;
+        const dataProvider = doc.dataProvider.name
+            ? doc.dataProvider.name
+            : doc.dataProvider;
         const strippedDoc = Object.assign({}, doc, {originalRecord: ""});
         delete strippedDoc.originalRecord;
 
@@ -103,7 +106,7 @@ export const getServerSideProps = async context => {
             item: Object.assign({}, doc.sourceResource, {
                 id: doc.id,
                 thumbnailUrl,
-                contributor: doc.dataProvider,
+                contributor: dataProvider,
                 intermediateProvider: doc.intermediateProvider,
                 date: date,
                 language: language,

--- a/pages/item/index.js
+++ b/pages/item/index.js
@@ -82,7 +82,9 @@ export const getServerSideProps = async context => {
     const randomItemId = isQA ? await getRandomItemIdAsync() : null;
     // check if item is found
     try {
-        const res = await fetch(`${process.env.API_URL}/items/${query.itemId}?api_key=${process.env.API_KEY}`);
+        const itemUrl = `${process.env.API_URL}/${process.env.API_VERSION}` +
+            `/items/${query.itemId}?api_key=${process.env.API_KEY}`
+        const res = await fetch(itemUrl);
         const json = await res.json();
         const doc = json.docs[0];
         const thumbnailUrl = getItemThumbnail(doc);

--- a/pages/item/index.js
+++ b/pages/item/index.js
@@ -82,7 +82,7 @@ export const getServerSideProps = async context => {
     const randomItemId = isQA ? await getRandomItemIdAsync() : null;
     // check if item is found
     try {
-        const res = await fetch(`https://api.dp.la/v2/items/${query.itemId}?api_key=${process.env.API_KEY}`);
+        const res = await fetch(`${process.env.API_URL}/items/${query.itemId}?api_key=${process.env.API_KEY}`);
         const json = await res.json();
         const doc = json.docs[0];
         const thumbnailUrl = getItemThumbnail(doc);

--- a/pages/lists/list.js
+++ b/pages/lists/list.js
@@ -86,14 +86,11 @@ class List extends React.Component {
                 .filter(result => result.error === undefined)
                 .map(result => {
                     const thumbnailUrl = getItemThumbnail(result);
-
-                    // Try reading dataProvider from object.
-                    // If this fails, read dataProvider from string.
                     const dataProviderFromObj = result.dataProvider && 
                         result.dataProvider.name;
-                    const dataProvider = dataProviderFromObj ?
-                        dataProviderFromObj :
-                        result.dataProvider;
+                    const dataProvider = dataProviderFromObj
+                        ? dataProviderFromObj
+                        : result.dataProvider;
 
                     return Object.assign({}, result.sourceResource, {
                         thumbnailUrl,

--- a/pages/lists/list.js
+++ b/pages/lists/list.js
@@ -86,12 +86,21 @@ class List extends React.Component {
                 .filter(result => result.error === undefined)
                 .map(result => {
                     const thumbnailUrl = getItemThumbnail(result);
+
+                    // Try reading dataProvider from object.
+                    // If this fails, read dataProvider from string.
+                    const dataProviderFromObj = result.dataProvider && 
+                        result.dataProvider.name;
+                    const dataProvider = dataProviderFromObj ?
+                        dataProviderFromObj :
+                        result.dataProvider;
+
                     return Object.assign({}, result.sourceResource, {
                         thumbnailUrl,
                         id: result.id ? result.id : result.sourceResource["@id"],
                         sourceUrl: result.isShownAt,
                         provider: result.provider && result.provider.name,
-                        dataProvider: result.dataProvider,
+                        dataProvider: dataProvider,
                         useDefaultImage: !result.object
                     });
                 });

--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -221,7 +221,8 @@ export const getServerSideProps = async context => {
         const facetsParam = `&facets=${theseFacets.join(",")}&${facetQueries}`;
         const filtersParam = filters.map(x => `&filter=${x}`).join("");
         const url =
-            `${process.env.API_URL}/items?api_key=${process.env.API_KEY}` +
+            `${process.env.API_URL}/${process.env.API_VERSION}/items?` +
+            `api_key=${process.env.API_KEY}` +
             `&exact_field_match=true&q=${q}` +
             `&page=${page}&page_size=${page_size}&sort_order=${sort_order}` +
             `&sort_by=${sort_by}${facetsParam}${filtersParam}`;

--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -231,14 +231,11 @@ export const getServerSideProps = async context => {
         let json = await res.json();
         const docs = json.docs.map(result => {
             const thumbnailUrl = getItemThumbnail(result);
-
-            // Try reading dataProvider from object.
-            // If this fails, read dataProvider from string.
             const dataProviderFromObj = result.dataProvider && 
                 result.dataProvider.name;
-            const dataProvider = dataProviderFromObj ?
-                dataProviderFromObj :
-                result.dataProvider;
+            const dataProvider = dataProviderFromObj
+                ? dataProviderFromObj
+                : result.dataProvider;
 
             return Object.assign({}, result.sourceResource, {
                 thumbnailUrl,

--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -221,7 +221,7 @@ export const getServerSideProps = async context => {
         const facetsParam = `&facets=${theseFacets.join(",")}&${facetQueries}`;
         const filtersParam = filters.map(x => `&filter=${x}`).join("");
         const url =
-            `https://api.dp.la/v2/items?api_key=${process.env.API_KEY}` +
+            `${process.env.API_URL}/items?api_key=${process.env.API_KEY}` +
             `&exact_field_match=true&q=${q}` +
             `&page=${page}&page_size=${page_size}&sort_order=${sort_order}` +
             `&sort_by=${sort_by}${facetsParam}${filtersParam}`;

--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -203,7 +203,7 @@ export const getServerSideProps = async context => {
                         id: result.id ? result.id : result.sourceResource["@id"],
                         sourceUrl: result.isShownAt,
                         provider: result.provider && result.provider.name,
-                        dataProvider: result.dataProvider,
+                        dataProvider: result.dataProvider && result.dataProvider.name,
                         useDefaultImage: !result.object
                     });
                 })
@@ -231,12 +231,21 @@ export const getServerSideProps = async context => {
         let json = await res.json();
         const docs = json.docs.map(result => {
             const thumbnailUrl = getItemThumbnail(result);
+
+            // Try reading dataProvider from object.
+            // If this fails, read dataProvider from string.
+            const dataProviderFromObj = result.dataProvider && 
+                result.dataProvider.name;
+            const dataProvider = dataProviderFromObj ?
+                dataProviderFromObj :
+                result.dataProvider;
+
             return Object.assign({}, result.sourceResource, {
                 thumbnailUrl,
                 id: result.id ? result.id : result.sourceResource["@id"],
                 sourceUrl: result.isShownAt,
                 provider: result.provider && result.provider.name,
-                dataProvider: result.dataProvider,
+                dataProvider: dataProvider,
                 useDefaultImage: !result.object
             });
         });


### PR DESCRIPTION
Read dataProvider string or object (old or new metadata schema).
This has been tested locally in the following features:
* Search list
* Item page
* Topic browse list
* Saved list

This has been tested locally against both the production API and the API running off branch https://github.com/dpla/dplaapi/pull/44 
I have not yet verified local.