### PR TITLE
handle missing dataProvider in item page render

### DIFF
--- a/pages/item/index.js
+++ b/pages/item/index.js
@@ -98,7 +98,7 @@ export const getServerSideProps = async context => {
                 return lang.name;
             })
             : doc.sourceResource.language;
-        const dataProvider = doc.dataProvider.name
+        const dataProvider = doc.dataProvider && doc.dataProvider.name
             ? doc.dataProvider.name
             : doc.dataProvider;
         const strippedDoc = Object.assign({}, doc, {originalRecord: ""});


### PR DESCRIPTION
The HathiTrust records were failing to render b/c they are missing `dataProvider`. 
Would you advise writing test coverage around this issue?
