### PR TITLE
Fix ECR build for user frontend

### DIFF
--- a/.github/workflows/user-production.yml
+++ b/.github/workflows/user-production.yml
@@ -28,7 +28,6 @@ jobs:
 
       - name: Read .nvmrc
         run: echo "{NODE_VERSION}={cat .nvmrc}" >> $GITHUB_OUTPUT
-	run: cat .nvmrc
         id: nvm
       
       - name: Set up QEMU

--- a/.github/workflows/user-production.yml
+++ b/.github/workflows/user-production.yml
@@ -42,7 +42,7 @@ jobs:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
       
       - name: Install npm 
-        run: npm install 
+        run: npm install --legacy-peer-deps 
         
       - name: Install Yarn
         run: npm install -g yarn

--- a/.github/workflows/user-production.yml
+++ b/.github/workflows/user-production.yml
@@ -24,10 +24,11 @@ jobs:
           authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Read .nvmrc
         run: echo "{NODE_VERSION}={cat .nvmrc}" >> $GITHUB_OUTPUT
+	run: cat .nvmrc
         id: nvm
       
       - name: Set up QEMU

--- a/.github/workflows/user-staging.yml
+++ b/.github/workflows/user-staging.yml
@@ -24,7 +24,7 @@ jobs:
           authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Read .nvmrc
         run: echo "{NODE_VERSION}={cat .nvmrc}" >> $GITHUB_OUTPUT
@@ -42,7 +42,7 @@ jobs:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
       
       - name: Install npm 
-        run: npm install 
+        run: npm install --legacy-peer-deps
         
       - name: Install Yarn
         run: npm install -g yarn


### PR DESCRIPTION
Update actions/checkout to v3
Use `--legacy-per-deps` for npm install to work around dependency tree conflicts between `react@^17.0.2` and  `react-markdown@^4.0.1` 