### PR TITLE
Updated allowlist for domains for pdfjs.

### DIFF
--- a/public/static/pdfjs/web/viewer.js
+++ b/public/static/pdfjs/web/viewer.js
@@ -2515,10 +2515,9 @@
         var HOSTED_VIEWER_ORIGINS = [
           "null",
           "http://localhost:3000",
-          "http://dp.la",
           "https://dp.la",
-          "http://pro.dp.la",
-          "https://pro.dp.la"
+          "https://pro.dp.la",
+            "https://staging.dp.la"
         ];
         validateFileURL = function validateFileURL(file) {
           if (file === undefined) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update domain allowlist in `viewer.js` by removing `http://dp.la` and `http://pro.dp.la`, and adding `https://staging.dp.la`.
> 
>   - **Domains Allowlist**:
>     - Updated `HOSTED_VIEWER_ORIGINS` in `viewer.js`.
>     - Removed `http://dp.la` and `http://pro.dp.la`.
>     - Added `https://staging.dp.la`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fdpla-frontend&utm_source=github&utm_medium=referral)<sup> for 0db91dcc44adc38f683a05d2601bd67eabf1259b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->