### PR TITLE
Prod build fixes

### DIFF
--- a/.github/workflows/user-production.yml
+++ b/.github/workflows/user-production.yml
@@ -68,7 +68,7 @@ jobs:
           docker buildx build \
           --build-arg SITE_ENV=${{ env.SITE_ENV }} \
           --build-arg LOCAL_ID=${{ env.LOCAL_ID }} \
-          --build-arg SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} \
+          --build-arg SENTRY_AUTH_TOKEN=${{ env.SENTRY_AUTH_TOKEN }} \
           -t $ECR_REGISTRY/$ECR_REPOSITORY:latest \
           -t $ECR_REGISTRY/$ECR_REPOSITORY:$BRANCH_NAME \
           -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \

--- a/.github/workflows/user-production.yml
+++ b/.github/workflows/user-production.yml
@@ -8,6 +8,7 @@ env:
   LOCAL_ID:       "aviation"
   ECR_REPOSITORY: "frontend-user-production"
   GA_TRACKING_ID: "G-1P5QWL64H0"
+  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
 jobs:
   ecr:
@@ -67,6 +68,7 @@ jobs:
           docker buildx build \
           --build-arg SITE_ENV=${{ env.SITE_ENV }} \
           --build-arg LOCAL_ID=${{ env.LOCAL_ID }} \
+          --build-arg SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} \
           -t $ECR_REGISTRY/$ECR_REPOSITORY:latest \
           -t $ECR_REGISTRY/$ECR_REPOSITORY:$BRANCH_NAME \
           -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ COPY .eslintrc.json ./
 RUN yarn install --ignore-scripts --immutable --prod && yarn run build
 
 FROM node:22-slim AS dpla-frontend
-RUN apt update && apt --no-install-recommends install -y tini curl && apt clean
+RUN apt-get update && apt-get --no-install-recommends install -y tini curl && apt clean
 WORKDIR /opt/dpla-frontend/
 COPY components ./components
 COPY constants ./constants


### PR DESCRIPTION
- `apt-get` instead of `apt` in `Dockerfile`
- `SENTRY_AUTH_TOKEN` for prod github action
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update Dockerfile to use `apt-get` and add `SENTRY_AUTH_TOKEN` to GitHub Actions for production builds.
> 
>   - **Dockerfile**:
>     - Replace `apt` with `apt-get` for package installation.
>   - **GitHub Actions**:
>     - Add `SENTRY_AUTH_TOKEN` to `user-production.yml` for production builds.
>     - Pass `SENTRY_AUTH_TOKEN` as a build argument in the Docker build step.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fdpla-frontend&utm_source=github&utm_medium=referral)<sup> for 0e31e8783f7b5a366a2651ecbac5365f591798b1. You can [customize](https://app.ellipsis.dev/dpla/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->