### PR TITLE
Set Link href to correct path for about page

### DIFF
--- a/components/MainLayout/components/shared/NavigationPro.js
+++ b/components/MainLayout/components/shared/NavigationPro.js
@@ -21,7 +21,7 @@ function NavigationPro({ isHome, className, css }) {
       <span className={css.divider} />
       <ul className={`${css.links} ${css.secondaryLinks}`}>
         <li>
-          <Link href="/about">About</Link>
+          <Link href="/about-dpla-pro">About</Link>
         </li>
         <li>
           <Link href="/events">Events</Link>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Corrects the `Link` href for the 'About' page in `NavigationPro.js` to `/about-dpla-pro`.
> 
>   - **Behavior**:
>     - Corrects the `Link` href for the 'About' page in `NavigationPro.js` from `/about` to `/about-dpla-pro`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fdpla-frontend&utm_source=github&utm_medium=referral)<sup> for 60dfcfb3016014f40b5df3f52ebc958b62bddc60. You can [customize](https://app.ellipsis.dev/dpla/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->