### PR TITLE
Added ContentQA mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The system makes extensive use of environment variables to decouple the differen
   `NODE_ENV=production`.
 
 - `NODE_ENV`: the node environment, `development` or `production`
-- `NEXT_PUBLIC_SITE_ENV`: the environment's type, `user`, `pro`, or `local`.
+- `NEXT_PUBLIC_SITE_ENV`: the environment's type, `user`, `cqa`, `pro`, or `local`.
 - `NEXT_PUBLIC_LOCAL_ID`: ID of the Local partner if this is a Local instance
 - `NEXT_PUBLIC_WORDPRESS_URL`: URL of the wordpress instance for site content.
 - `NEXT_PUBLIC_PRO_BASE_URL`: The base URL for the Pro site for links. Usually https://pro.dp.la.

--- a/components/HomePageComponents/HomeHero/index.js
+++ b/components/HomePageComponents/HomeHero/index.js
@@ -46,7 +46,7 @@ function HomeHero({ headerDescription, feature }) {
         data-cy="dpla-logo"
         className={`${css.header} ${utils.siteMaxWidth}`}
       >
-        {siteEnv !== "local" && (
+        {siteEnv === "user" && (
           <div className={`${css.homeLogo} ${css.dplaLogo}`}>
             <h1>Digital Public Library of America</h1>
           </div>
@@ -62,7 +62,7 @@ function HomeHero({ headerDescription, feature }) {
             <h1 className={css.localText}>{LOCALS[localId].name}</h1>
           </div>
         )}
-        {siteEnv !== "local" && (
+        {siteEnv === "user" && (
           <Button type="primary" size="large" url="/donate">
             Donate
           </Button>
@@ -90,7 +90,7 @@ function HomeHero({ headerDescription, feature }) {
             </button>
           </div>
         </form>
-        {siteEnv !== "local" && (
+        {siteEnv === "user" && (
           <div className={css.links}>
             <Link href="/browse-by-topic">Browse by Topic</Link>
             <Link href="/guides" title="View our Getting Started Guides">

--- a/components/ItemComponents/Content/QA.js
+++ b/components/ItemComponents/Content/QA.js
@@ -1,55 +1,47 @@
-import React from "react";
-import { withRouter } from "next/router";
+import React, { useState } from "react";
 
 import Link from "next/link";
+import css from "stylesheets/qa.module.scss";
 
-class QA extends React.Component {
-  render() {
-    const { item, randomItemId } = this.props;
-    const preStyle = {
-      fontSize: "13px",
-      wordBreak: "break-all",
-      wordWrap: "break-word",
-      whiteSpace: "pre-wrap",
-      border: "1px solid rgba(0, 0, 0, 0.15)",
-      backgroundColor: "#f5f5f5",
-      borderRadius: "4px",
-      padding: "9.5px",
-    };
+function QA({ item, randomItemId }) {
+  const [collapsed, setCollapsed] = useState(false);
 
-    const divStyle = {
-      float: "left",
-      width: "48%",
-      paddingLeft: "20px",
-    };
+  const originalRecord =
+    "stringValue" in item.originalRecord
+      ? item.originalRecord.stringValue
+      : JSON.stringify(item.originalRecord, null, 2);
 
-    const originalRecord =
-      "stringValue" in item.originalRecord
-        ? item.originalRecord.stringValue
-        : JSON.stringify(item.originalRecord, null, 2);
+  const toggleCollapse = () => {
+    setCollapsed((prev) => !prev);
+  };
 
-    const enrichedRecord = JSON.stringify(item.doc, null, 2);
+  const enrichedRecord = JSON.stringify(item.doc, null, 2);
 
-    return (
-      <div style={{ paddingTop: "8px" }}>
+  return (
+    <div style={{ paddingTop: "8px" }}>
+      <div style={{ padding: "8px 20px 20px" }}>
+        <button onClick={() => toggleCollapse()} className={css.btn}>
+          {collapsed ? "+ Show Metadata" : "- Collapse Metadata"}
+        </button>{" "}
         {randomItemId && (
-          <div style={{ padding: "8px 20px 20px" }}>
-            <Link href={`/item/${randomItemId}`}>Fetch Random Item</Link>
-          </div>
+          <Link href={`/item/${randomItemId}`} className={css.btn}>
+            Fetch Random Item &raquo;
+          </Link>
         )}
-
-        <div style={divStyle}>
-          <h3>Enriched Record</h3>
-          <pre style={preStyle}>{enrichedRecord}</pre>
+      </div>
+      <div id={"qa"} style={{ display: collapsed ? "none" : "block" }}>
+        <div className={css.qaDiv}>
+          <h3>Mapped and Enriched Record</h3>
+          <pre className={css.pre}>{enrichedRecord}</pre>
         </div>
-        <div style={divStyle}>
+        <div className={css.qaDiv}>
           <h3>Original Record</h3>
-          <pre style={preStyle}>{originalRecord}</pre>
+          <pre className={css.pre}>{originalRecord}</pre>
         </div>
         <div style={{ clear: "both" }}></div>
       </div>
-    );
-  }
+    </div>
+  );
 }
 
-export default withRouter(QA);
+export default QA;

--- a/components/SearchComponents/FiltersList/index.js
+++ b/components/SearchComponents/FiltersList/index.js
@@ -4,6 +4,7 @@ import { useRouter } from "next/router";
 
 import {
   possibleFacets,
+  qaFacets,
   mapURLPrettifiedFacetsToUgly,
   mapFacetsToURLPrettified,
 } from "constants/search";
@@ -15,13 +16,11 @@ import utils from "stylesheets/utils.module.scss";
 import CloseIcon from "components/svg/Close";
 import ClearFiltersIcon from "components/svg/ClearFiltersIcon";
 
-function clearAllFacets(query) {
+function clearAllFacets(query, facetList) {
   const duped = { ...query };
   delete duped["q"];
   delete duped["page"];
-  possibleFacets.forEach(
-    (facet) => delete duped[mapFacetsToURLPrettified[facet]],
-  );
+  facetList.forEach((facet) => delete duped[mapFacetsToURLPrettified[facet]]);
   return duped;
 }
 
@@ -39,7 +38,7 @@ function clearFacet(query, queryKey, facet) {
   return duped;
 }
 
-function Filter({ name, queryKey }) {
+function Filter({ name, queryKey, facetList }) {
   const router = useRouter();
   const label = queryKey !== "q" ? queryKey : "keywords";
   return (
@@ -63,9 +62,11 @@ function Filter({ name, queryKey }) {
 function FiltersList({ showFilters }) {
   const router = useRouter();
   const { query } = router;
+  const facetList =
+    process.env.NEXT_PUBLIC_SITE_ENV === "cqa" ? qaFacets : possibleFacets;
   const hasFacets = Object.keys(query).some(
     (queryKey) =>
-      possibleFacets.includes(mapURLPrettifiedFacetsToUgly[queryKey]) ||
+      facetList.includes(mapURLPrettifiedFacetsToUgly[queryKey]) ||
       queryKey === "tags",
   );
   if (!hasFacets) {
@@ -74,7 +75,7 @@ function FiltersList({ showFilters }) {
   const filterChildren = Object.keys(query).map((queryKey) => {
     const value = joinIfArray(query[queryKey], "|");
     if (
-      possibleFacets.includes(mapURLPrettifiedFacetsToUgly[queryKey]) ||
+      facetList.includes(mapURLPrettifiedFacetsToUgly[queryKey]) ||
       queryKey === "q" ||
       queryKey === "tags"
     ) {
@@ -110,7 +111,7 @@ function FiltersList({ showFilters }) {
         <Link
           href={{
             pathname: router.pathname,
-            query: { ...clearAllFacets(query) },
+            query: { ...clearAllFacets(query, facetList) },
           }}
           className={css.clearAll}
         >

--- a/components/SearchComponents/FiltersList/index.js
+++ b/components/SearchComponents/FiltersList/index.js
@@ -38,7 +38,7 @@ function clearFacet(query, queryKey, facet) {
   return duped;
 }
 
-function Filter({ name, queryKey, facetList }) {
+function Filter({ name, queryKey }) {
   const router = useRouter();
   const label = queryKey !== "q" ? queryKey : "keywords";
   return (

--- a/components/SearchComponents/MainContent/Sidebar/index.js
+++ b/components/SearchComponents/MainContent/Sidebar/index.js
@@ -19,11 +19,20 @@ import css from "./Sidebar.module.scss";
 
 function FacetLink({ queryKey, termObject, disabled, isTooltip }) {
   const router = useRouter();
+  const termLabel =
+    termObject.term.startsWith("http://rightsstatements") ||
+    termObject.term.startsWith("http://creativecommons")
+      ? termObject.term
+          .replace("http://rightsstatements.org/vocab/", "Rights Statements/")
+          .replace("http://creativecommons.org/licenses/", "Creative Commons/")
+          .replace("http://creativecommons.org/publicdomain/", "Public Domain/")
+          .replaceAll("/", " ")
+      : termObject.term;
   if (disabled) {
     return (
       <span className={css.facet}>
         <span className={`${css.facetName} ${css.activeFacetName}`}>
-          {`${termObject.term} `}
+          {`${termLabel} `}
         </span>
         <span className={css.facetCount}>
           {addCommasToNumber(termObject.count)}
@@ -47,7 +56,7 @@ function FacetLink({ queryKey, termObject, disabled, isTooltip }) {
     <div className={css.facet}>
       <span className={css.facetName}>
         <Link href={href} className={css.facetLink}>
-          {termObject.term}
+          {termLabel}
         </Link>
         {isTooltip && tooltips[termObject.term] != null && (
           <Link

--- a/next.config.js
+++ b/next.config.js
@@ -44,6 +44,8 @@ let config = {
         redirect("/about-us", "/about"),
         redirect("/contact-us", "/contact"),
       ];
+    } else if (siteEnv === "cqa") {
+      return [];
     } else {
       throw new Error("Invalid site environment");
     }
@@ -53,6 +55,7 @@ let config = {
       const local = LOCALS[localId];
       const results = [
         rewrite("/", "/local"),
+        fourOhFour("/qa"),
         fourOhFour("/exhibitions"),
         fourOhFour("/exhibitions/:slugs*"),
         fourOhFour("/browse-by-topic"),
@@ -96,6 +99,7 @@ let config = {
           "/hubs/:subsection",
           "/pro/wp?section=hubs&subsection=:subsection",
         ),
+        fourOhFour("/qa"),
         fourOhFour("/exhibitions"),
         fourOhFour("/exhibitions/:slugs*"),
         fourOhFour("/browse-by-topic"),
@@ -125,11 +129,50 @@ let config = {
     } else if (siteEnv === "user") {
       return {
         beforeFiles: [
+          fourOhFour("/qa"),
           fourOhFour("/pro"),
           fourOhFour("/pro/hubs"),
           fourOhFour("/pro/wp"),
           fourOhFour("/local/"),
           fourOhFour("/local/markdown"),
+        ],
+      };
+    } else if (siteEnv === "cqa") {
+      return {
+        beforeFiles: [
+          rewrite("/", "/qa"),
+          fourOhFour("/about"),
+          fourOhFour("/about/:slugs*"),
+
+          fourOhFour("/browse-by-topic"),
+          fourOhFour("/browse-by-topic/:slugs*"),
+
+          fourOhFour("/contact"),
+          fourOhFour("/contact/:slugs*"),
+
+          fourOhFour("/donate"),
+          fourOhFour("/donate/:slugs*"),
+
+          fourOhFour("/exhibitions"),
+          fourOhFour("/exhibitions/:slugs*"),
+
+          fourOhFour("/guides"),
+          fourOhFour("/guides/:slugs*"),
+
+          fourOhFour("/lists"),
+          fourOhFour("/lists/:slugs*"),
+
+          fourOhFour("/local/"),
+          fourOhFour("/local/:slugs*"),
+
+          fourOhFour("/news"),
+          fourOhFour("/news/:slugs*"),
+
+          fourOhFour("/primary-source-sets"),
+          fourOhFour("/primary-source-sets/:slugs*"),
+
+          fourOhFour("/pro"),
+          fourOhFour("/pro/:slugs*"),
         ],
       };
     } else {

--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -80,7 +80,7 @@ export async function getServerSideProps(context) {
   if (!itemId) {
     return notFound;
   }
-  const isQA = false;
+  const isQA = process.env.NEXT_PUBLIC_SITE_ENV === "cqa";
   const randomItemId = isQA ? await getRandomItemIdAsync() : null;
   if (!DPLA_ITEM_ID_REGEX.test(itemId)) {
     return notFound;

--- a/pages/qa/index.js
+++ b/pages/qa/index.js
@@ -1,0 +1,27 @@
+import React from "react";
+
+import MainLayout from "components/MainLayout";
+
+import HomeHero from "components/HomePageComponents/HomeHero";
+import WebsiteFeature from "shared/WebsiteFeature";
+
+function QA() {
+  const siteEnv = process.env.NEXT_PUBLIC_SITE_ENV;
+  return (
+    <MainLayout hidePageHeader={true} hideSearchBar={true}>
+      <div id="main" role="main">
+        <HomeHero feature={true} headerDescription={"Content QA"} />
+        <WebsiteFeature
+          title={"Notice: QA Environment"}
+          text={
+            "This is an internal interface not meant for end users. For the full experience, please visit DPLA's home page."
+          }
+          buttonText={"Go to DPLA"}
+          buttonUrl={"https://dp.la"}
+        />
+      </div>
+    </MainLayout>
+  );
+}
+
+export default QA;

--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -102,7 +102,7 @@ export async function getServerSideProps(context) {
   const query = context.query;
   const isLocal = siteEnv === "local";
   let local = isLocal ? LOCALS[localId] : {};
-  const isQA = false;
+  const isQA = siteEnv === "cqa";
 
   if (query.q && !isBalanced(query.q)) {
     // User gave us something that will blow up, strip it out.

--- a/stylesheets/qa.module.scss
+++ b/stylesheets/qa.module.scss
@@ -1,0 +1,36 @@
+.btn, .btn:visited {
+  //display: inline-block;
+
+  width: 15rem;
+  background-color: var(--linkColor);
+  color: white;
+  font-family: var(--sansFont), sans-serif;
+  padding: 0.75rem 1.5rem;
+  margin: 1rem auto;
+  text-align: center;
+  border-radius: 0.25rem;
+  transition: background-color 0.15s ease-out;
+
+  &:hover {
+    background-color: var(--linkHoverColor);
+    text-decoration: none;
+  }
+
+}
+
+.qaDiv {
+  float: left;
+  width: 48%;
+  padding-left: 20px;
+}
+
+.pre {
+  font-size: 13px;
+  word-break: break-all;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  background-color: #f5f5f5;
+  border-radius: 4px;
+  padding: 9.5px;
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces ContentQA mode with specific UI and routing logic for QA environment.
> 
>   - **Environment**:
>     - Added `cqa` as a new value for `NEXT_PUBLIC_SITE_ENV` in `README.md`.
>     - Updated `next.config.js` to handle `cqa` environment with specific rewrites and 404 handling.
>   - **UI Components**:
>     - Modified `HomeHero` in `HomePageComponents/HomeHero/index.js` to display elements only for `user` environment.
>     - Added `QA` component in `ItemComponents/Content/QA.js` to toggle metadata display.
>     - Created `qa.module.scss` for styling QA components.
>   - **Routing and Logic**:
>     - Updated `FiltersList` and `Sidebar` components to use `qaFacets` when in `cqa` mode.
>     - Added `pages/qa/index.js` for the QA environment homepage.
>     - Modified `pages/item/[itemId].js` to include `QA` component when in `cqa` mode.
>     - Adjusted `pages/search/index.js` to use `qaFacets` in `cqa` mode.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fdpla-frontend&utm_source=github&utm_medium=referral)<sup> for 8c2b9fb033ca8fae7eef3755d9cf13eea4f29469. You can [customize](https://app.ellipsis.dev/dpla/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->