### PR TITLE
fix(safeFetch): retry once on ConnectTimeoutError for transient WP Engine outages

### DIFF
--- a/lib/safeFetch.js
+++ b/lib/safeFetch.js
@@ -60,15 +60,34 @@ function sanitizeUrl(url) {
  * Using optional chaining on the return value (`res?.ok`) covers both the
  * null (network failure) and non-ok (HTTP error) cases in a single check.
  */
+// Transient undici error codes that are worth retrying once (e.g. WP Engine
+// briefly refusing new connections during hourly maintenance tasks).
+const RETRYABLE_CODES = new Set(["UND_ERR_CONNECT_TIMEOUT", "UND_ERR_SOCKET"]);
+
 export async function safeFetch(url, options) {
-  try {
-    return await fetch(url, options);
-  } catch (err) {
-    // Log the original network-level error (e.g. ConnectTimeoutError) so it
-    // appears in Sentry/CloudWatch before being swallowed.
-    console.error(`[safeFetch] Network error fetching ${sanitizeUrl(url)}:`, err);
-    return null;
+  const method = (options?.method ?? "GET").toUpperCase();
+  const canRetry = (method === "GET" || method === "HEAD") && options?.body == null;
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      return await fetch(url, options);
+    } catch (err) {
+      if (canRetry && attempt === 0 && RETRYABLE_CODES.has(err.cause?.code)) {
+        console.warn(
+          `[safeFetch] Retrying after ${err.cause?.code} fetching ${sanitizeUrl(url)}`,
+        );
+        await new Promise((r) => setTimeout(r, 500));
+        continue;
+      }
+      // Log the original network-level error so it appears in Sentry/CloudWatch.
+      console.error(
+        `[safeFetch] Network error fetching ${sanitizeUrl(url)}:`,
+        err,
+      );
+      return null;
+    }
   }
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- `dpla.wpengine.com` has brief connection outages roughly once per hour (likely hourly maintenance tasks), causing `ConnectTimeoutError` in `getServerSideProps` on Pro and news pages (Sentry DPLA-FRONTEND-1F5, 1F6, 1FQ)
- Add a single retry with 500ms delay in `safeFetch` for `UND_ERR_CONNECT_TIMEOUT` and `UND_ERR_SOCKET` — the undici error codes for transient connection failures
- Add explicit `return null` after the loop to avoid implicit `undefined` return if both attempts fail
- No changes to callers — retry is transparent to all existing `safeFetch` users

## Root cause

`#1380` changed `checkResponseForSSR(null)` from `{ notFound: true }` to throwing, which correctly fixed the hard-nav loop bug (DPLA-FRONTEND-1DV/1DW) but made pre-existing WP Engine timeouts visible as 500 errors. The underlying cause is WP Engine briefly refusing new TCP connections ~once/hour.

## Test plan

- [ ] Pro site (`/pro`, `/pro/wp/*`) renders correctly
- [ ] News slug pages (`/news/[slug]`) render correctly
- [ ] Confirm DPLA-FRONTEND-1F5, 1F6, 1FQ volume drops after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
* **Bug Fix — safeFetch retry for transient WP Engine outages**
  * Adds a single automatic retry inside lib/safeFetch.js for transient undici errors (UND_ERR_CONNECT_TIMEOUT, UND_ERR_SOCKET). On a retryable failure for safe, non-body GET/HEAD requests the code logs a warning, waits 500ms, and retries once. If the retry (or non-retryable error) fails, the error is logged and safeFetch returns null.
  * Ensures an explicit return null after the retry loop to avoid implicit undefined if both attempts fail.
  * Behavior is transparent to callers (no signature changes); callers still receive Response or null and existing checkResponseForSSR/checkResponseForSSRSafe semantics remain in place.
  * Root cause: a prior change made checkResponseForSSR(null) throw instead of returning { notFound: true }, which surfaced pre-existing WP Engine connection timeouts as 500 errors. Those WP Engine timeouts occur briefly ~once/hour (Sentry: DPLA-FRONTEND-1F5, 1F6, 1FQ).
  * Test plan: verify Pro pages (/pro, /pro/wp/*) and news slug pages (/news/[slug]) render correctly and confirm Sentry volume drops for DPLA-FRONTEND-1F5, 1F6, 1FQ after deploy.

Operational notes (explicit checks requested)
  * No manual pipeline trigger or ECS redeploy instructions are added; change is code-only and will take effect when the application is redeployed as normal.
  * No environment variables or AWS Secrets Manager keys added/removed/renamed.
  * No database migrations.
  * No changes to shared infra (CodePipeline/CodeBuild/ECS task definitions/IAM).
  * No public API response shape or endpoint changes.
  * No security-sensitive changes (no new credential handling or auth behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->