### PR TITLE
Retry on 503 in safeFetch; show friendly unavailable UI on item pages

### DIFF
--- a/lib/safeFetch.js
+++ b/lib/safeFetch.js
@@ -69,8 +69,9 @@ export async function safeFetch(url, options) {
   const canRetry = (method === "GET" || method === "HEAD") && options?.body == null;
 
   for (let attempt = 0; attempt < 2; attempt++) {
+    let res;
     try {
-      return await fetch(url, options);
+      res = await fetch(url, options);
     } catch (err) {
       if (canRetry && attempt === 0 && RETRYABLE_CODES.has(err.cause?.code)) {
         console.warn(
@@ -86,6 +87,13 @@ export async function safeFetch(url, options) {
       );
       return null;
     }
+    // Retry once on 503 — transient upstream unavailability (e.g. during deploys).
+    if (canRetry && attempt === 0 && res.status === 503) {
+      console.warn(`[safeFetch] Retrying after 503 from ${sanitizeUrl(url)}`);
+      await new Promise((r) => setTimeout(r, 1500));
+      continue;
+    }
+    return res;
   }
   return null;
 }

--- a/lib/safeFetch.js
+++ b/lib/safeFetch.js
@@ -87,7 +87,10 @@ export async function safeFetch(url, options) {
       );
       return null;
     }
-    // Retry once on 503 — transient upstream unavailability (e.g. during deploys).
+    // Retry once on 503 — transient upstream unavailability during deploys.
+    // 1500ms is intentional: it aligns with the ALB slow-start ramp so the
+    // second attempt lands after new tasks have begun warming up. Applies to
+    // all SSR GET/HEAD fetches site-wide (search, news, PSS, etc.).
     if (canRetry && attempt === 0 && res.status === 503) {
       console.warn(`[safeFetch] Retrying after 503 from ${sanitizeUrl(url)}`);
       await new Promise((r) => setTimeout(r, 1500));
@@ -95,6 +98,8 @@ export async function safeFetch(url, options) {
     }
     return res;
   }
+  // Defensive fallback — unreachable: every loop iteration either returns or
+  // continues, so the loop always exits via return.
   return null;
 }
 

--- a/lib/safeFetch.js
+++ b/lib/safeFetch.js
@@ -93,6 +93,9 @@ export async function safeFetch(url, options) {
     // all SSR GET/HEAD fetches site-wide (search, news, PSS, etc.).
     if (canRetry && attempt === 0 && res.status === 503) {
       console.warn(`[safeFetch] Retrying after 503 from ${sanitizeUrl(url)}`);
+      // Consume the body so the underlying connection is released back to the
+      // Undici pool before we wait and retry.
+      await res.body?.cancel();
       await new Promise((r) => setTimeout(r, 1500));
       continue;
     }

--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -28,13 +28,20 @@ import { DPLA_ITEM_ID_REGEX } from "constants/items";
 export default function ItemDetail({ item, temporarilyUnavailable, randomItemId, isQA, pageDescription, canonicalUrl }) {
   useEffect(() => {
     if (!temporarilyUnavailable) return;
-    const storageKey = `503-reload-attempts:${window.location.pathname}`;
-    const attempts = parseInt(sessionStorage.getItem(storageKey) || "0", 10);
-    if (attempts >= 3) return;
-    const timer = setTimeout(() => {
-      sessionStorage.setItem(storageKey, String(attempts + 1));
-      window.location.reload();
-    }, 10000);
+    // sessionStorage can throw in private-browsing or restricted environments;
+    // fall back to a plain reload rather than crashing the component.
+    let timer;
+    try {
+      const storageKey = `503-reload-attempts:${window.location.pathname}`;
+      const attempts = parseInt(sessionStorage.getItem(storageKey) || "0", 10);
+      if (attempts >= 3) return;
+      timer = setTimeout(() => {
+        sessionStorage.setItem(storageKey, String(attempts + 1));
+        window.location.reload();
+      }, 10000);
+    } catch {
+      timer = setTimeout(() => window.location.reload(), 10000);
+    }
     return () => clearTimeout(timer);
   }, [temporarilyUnavailable]);
 

--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -1,4 +1,5 @@
 import React, { useEffect } from "react";
+import { useRouter } from "next/router";
 
 import MainLayout from "components/MainLayout";
 import CiteButton from "components/shared/CiteButton";
@@ -26,6 +27,7 @@ import { safeFetch, checkResponseForSSRSafe } from "lib/safeFetch";
 import { DPLA_ITEM_ID_REGEX } from "constants/items";
 
 export default function ItemDetail({ item, temporarilyUnavailable, randomItemId, isQA, pageDescription, canonicalUrl }) {
+  const { query } = useRouter();
   useEffect(() => {
     const storageKey = `503-reload-attempts:${window.location.pathname}`;
     if (!temporarilyUnavailable) {
@@ -34,7 +36,7 @@ export default function ItemDetail({ item, temporarilyUnavailable, randomItemId,
       return;
     }
     // sessionStorage can throw in private-browsing or restricted environments;
-    // fall back to a plain reload rather than crashing the component.
+    // skip auto-reload rather than retrying without a cap.
     let timer;
     try {
       const attempts = parseInt(sessionStorage.getItem(storageKey) || "0", 10);
@@ -44,10 +46,10 @@ export default function ItemDetail({ item, temporarilyUnavailable, randomItemId,
         window.location.reload();
       }, 10000);
     } catch {
-      timer = setTimeout(() => window.location.reload(), 10000);
+      // sessionStorage unavailable — auto-reload skipped to avoid an uncapped loop.
     }
     return () => clearTimeout(timer);
-  }, [temporarilyUnavailable]);
+  }, [temporarilyUnavailable, query.itemId]);
 
   if (temporarilyUnavailable) {
     return (

--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -64,8 +64,8 @@ export default function ItemDetail({ item, temporarilyUnavailable, randomItemId,
             >
               <h1>This item is temporarily unavailable.</h1>
               <p>
-                We&rsquo;re having a brief issue loading this item. The page will
-                refresh automatically in a few seconds.
+                We&rsquo;re having a brief issue loading this item. This page may
+                refresh automatically a few times.
               </p>
               <Button type="primary" onClick={() => window.location.reload()}>
                 Try again now
@@ -151,6 +151,7 @@ export async function getServerSideProps(context) {
   const res = await safeFetch(itemUrl);
   if (res?.status === 503) {
     console.warn(`[SSR] Item ${itemId} returned 503 after retry`);
+    await res.body?.cancel();
     context.res.statusCode = 503;
     context.res.setHeader("Retry-After", "10");
     return { props: { temporarilyUnavailable: true } };

--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -20,6 +20,7 @@ import css from "components/ItemComponents/itemComponent.module.scss";
 import utils from "stylesheets/utils.module.scss";
 import contentCss from "stylesheets/content-pages.module.scss";
 import donateCss from "stylesheets/donate.module.scss";
+import Button from "components/shared/Button";
 import { washObject } from "lib/washObject";
 import { safeFetch, checkResponseForSSRSafe } from "lib/safeFetch";
 import { DPLA_ITEM_ID_REGEX } from "constants/items";
@@ -27,7 +28,13 @@ import { DPLA_ITEM_ID_REGEX } from "constants/items";
 export default function ItemDetail({ item, temporarilyUnavailable, randomItemId, isQA, pageDescription, canonicalUrl }) {
   useEffect(() => {
     if (!temporarilyUnavailable) return;
-    const timer = setTimeout(() => window.location.reload(), 10000);
+    const storageKey = `503-reload-attempts:${window.location.pathname}`;
+    const attempts = parseInt(sessionStorage.getItem(storageKey) || "0", 10);
+    if (attempts >= 3) return;
+    const timer = setTimeout(() => {
+      sessionStorage.setItem(storageKey, String(attempts + 1));
+      window.location.reload();
+    }, 10000);
     return () => clearTimeout(timer);
   }, [temporarilyUnavailable]);
 
@@ -45,12 +52,11 @@ export default function ItemDetail({ item, temporarilyUnavailable, randomItemId,
               <h1>This item is temporarily unavailable.</h1>
               <p>
                 We&rsquo;re having a brief issue loading this item. The page will
-                refresh automatically in a few seconds, or you can{" "}
-                <button onClick={() => window.location.reload()}>
-                  try again now
-                </button>
-                .
+                refresh automatically in a few seconds.
               </p>
+              <Button type="primary" onClick={() => window.location.reload()}>
+                Try again now
+              </Button>
             </main>
           </div>
         </div>
@@ -131,6 +137,7 @@ export async function getServerSideProps(context) {
 
   const res = await safeFetch(itemUrl);
   if (res?.status === 503) {
+    console.warn(`[SSR] Item ${itemId} returned 503 after retry`);
     return { props: { temporarilyUnavailable: true } };
   }
   const errorResult = checkResponseForSSRSafe(res, "Item");

--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -27,12 +27,16 @@ import { DPLA_ITEM_ID_REGEX } from "constants/items";
 
 export default function ItemDetail({ item, temporarilyUnavailable, randomItemId, isQA, pageDescription, canonicalUrl }) {
   useEffect(() => {
-    if (!temporarilyUnavailable) return;
+    const storageKey = `503-reload-attempts:${window.location.pathname}`;
+    if (!temporarilyUnavailable) {
+      // Clear the counter so future outages on the same path auto-refresh again.
+      try { sessionStorage.removeItem(storageKey); } catch {}
+      return;
+    }
     // sessionStorage can throw in private-browsing or restricted environments;
     // fall back to a plain reload rather than crashing the component.
     let timer;
     try {
-      const storageKey = `503-reload-attempts:${window.location.pathname}`;
       const attempts = parseInt(sessionStorage.getItem(storageKey) || "0", 10);
       if (attempts >= 3) return;
       timer = setTimeout(() => {
@@ -145,6 +149,8 @@ export async function getServerSideProps(context) {
   const res = await safeFetch(itemUrl);
   if (res?.status === 503) {
     console.warn(`[SSR] Item ${itemId} returned 503 after retry`);
+    context.res.statusCode = 503;
+    context.res.setHeader("Retry-After", "10");
     return { props: { temporarilyUnavailable: true } };
   }
   const errorResult = checkResponseForSSRSafe(res, "Item");

--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 
 import MainLayout from "components/MainLayout";
 import CiteButton from "components/shared/CiteButton";
@@ -18,11 +18,46 @@ import {
 
 import css from "components/ItemComponents/itemComponent.module.scss";
 import utils from "stylesheets/utils.module.scss";
+import contentCss from "stylesheets/content-pages.module.scss";
+import donateCss from "stylesheets/donate.module.scss";
 import { washObject } from "lib/washObject";
 import { safeFetch, checkResponseForSSRSafe } from "lib/safeFetch";
 import { DPLA_ITEM_ID_REGEX } from "constants/items";
 
-export default function ItemDetail({ item, randomItemId, isQA, pageDescription, canonicalUrl }) {
+export default function ItemDetail({ item, temporarilyUnavailable, randomItemId, isQA, pageDescription, canonicalUrl }) {
+  useEffect(() => {
+    if (!temporarilyUnavailable) return;
+    const timer = setTimeout(() => window.location.reload(), 10000);
+    return () => clearTimeout(timer);
+  }, [temporarilyUnavailable]);
+
+  if (temporarilyUnavailable) {
+    return (
+      <MainLayout>
+        <div className={`${utils.container} ${contentCss.sidebarAndContentWrapper}`}>
+          <div className="row">
+            <div className={`${utils.colMd2} ${utils.colXs12}`} />
+            <main
+              id="main"
+              role="main"
+              className={`${contentCss.content} ${donateCss.thankYou} ${utils.colMd8} ${utils.colXs12}`}
+            >
+              <h1>This item is temporarily unavailable.</h1>
+              <p>
+                We&rsquo;re having a brief issue loading this item. The page will
+                refresh automatically in a few seconds, or you can{" "}
+                <button onClick={() => window.location.reload()}>
+                  try again now
+                </button>
+                .
+              </p>
+            </main>
+          </div>
+        </div>
+      </MainLayout>
+    );
+  }
+
   if (!item) return null;
   return (
     <MainLayout pageTitle={item.title} pageImage={item.thumbnailUrl} pageDescription={pageDescription} canonicalUrl={canonicalUrl}>
@@ -95,6 +130,9 @@ export async function getServerSideProps(context) {
   itemUrl.searchParams.set("api_key", process.env.API_KEY);
 
   const res = await safeFetch(itemUrl);
+  if (res?.status === 503) {
+    return { props: { temporarilyUnavailable: true } };
+  }
   const errorResult = checkResponseForSSRSafe(res, "Item");
   if (errorResult) return errorResult;
   let data;


### PR DESCRIPTION
## Summary

- **`safeFetch` now retries once on HTTP 503** (1.5s delay, GET/HEAD only) — the same mechanism already used for network-level `UND_ERR_CONNECT_TIMEOUT`/`UND_ERR_SOCKET` errors. This handles brief API unavailability during deploys: by the time the retry fires, the ALB slow-start ramp is underway and the second attempt typically succeeds.
- **Item pages show a friendly "temporarily unavailable" UI** if both attempts return 503, instead of silently converting it to a 404. The new UI auto-refreshes after 10 seconds and includes a manual "try again" button.

## Background

During API maintenance on 2026-04-07, a deploy caused 28 item page loads across 4 local hub frontends to return 503. `checkResponseForSSRSafe` was catching those 503s and returning `{ notFound: true }`, so users saw "Page not found" — misleading since the item exists but the API was momentarily unavailable. The 503 window was ~5 minutes; a 1.5s retry would have recovered most requests.

## Test plan

- [ ] Verify happy-path item pages still load normally (retry only fires on 503, no delay on 200)
- [ ] Simulate a 503 from `API_URL` (e.g. point at a mock or use a staging env) — confirm the retry fires and logs `[safeFetch] Retrying after 503`
- [ ] If the retry also 503s, confirm the item page renders the "temporarily unavailable" message with auto-refresh (not a 404)
- [ ] Confirm the auto-refresh fires after ~10s and the manual button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Temporarily unavailable item page: users see a clear “temporarily unavailable” message, a manual "Try again now" button, and automatic reload attempts every 10s with a per-page retry limit and safe fallback if reload tracking fails.

* **Bug Fixes**
  * Improved fetch behavior: transient 503 responses now trigger one brief automatic retry on first attempt; server 503 responses return a 503 status with Retry-After for clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->