### PR TITLE
fix(illinois): remove deleted routes; fix empty error pages on local sites

### DIFF
--- a/components/ErrorComponents/ErrorLinks.js
+++ b/components/ErrorComponents/ErrorLinks.js
@@ -8,7 +8,7 @@ function ErrorLinks() {
   if (siteEnv === "user") return <ErrorLinksUser />;
   if (siteEnv === "pro") return <ErrorLinksPro />;
   if (siteEnv === "local") return <ErrorLinksLocal />;
-  return null;
+  return <ErrorLinksUser />;
 }
 
 export default ErrorLinks;

--- a/components/ErrorComponents/ErrorLinks.js
+++ b/components/ErrorComponents/ErrorLinks.js
@@ -1,0 +1,14 @@
+import React from "react";
+import ErrorLinksUser from "components/ErrorComponents/ErrorLinksUser";
+import ErrorLinksPro from "components/ErrorComponents/ErrorLinksPro";
+import ErrorLinksLocal from "components/ErrorComponents/ErrorLinksLocal";
+
+function ErrorLinks() {
+  const siteEnv = process.env.NEXT_PUBLIC_SITE_ENV;
+  if (siteEnv === "user") return <ErrorLinksUser />;
+  if (siteEnv === "pro") return <ErrorLinksPro />;
+  if (siteEnv === "local") return <ErrorLinksLocal />;
+  return null;
+}
+
+export default ErrorLinks;

--- a/components/ErrorComponents/ErrorLinksLocal.js
+++ b/components/ErrorComponents/ErrorLinksLocal.js
@@ -1,0 +1,20 @@
+import React from "react";
+import Link from "next/link";
+
+function ErrorLinksLocal() {
+  return (
+    <ul>
+      <li>
+        <Link href="/">return to the home page</Link>
+      </li>
+      <li>
+        <Link href="/search">search</Link> the collection
+      </li>
+      <li>
+        browse items by <Link href="/browse-by-partner">contributing partner</Link>
+      </li>
+    </ul>
+  );
+}
+
+export default ErrorLinksLocal;

--- a/constants/local.js
+++ b/constants/local.js
@@ -97,26 +97,10 @@ const LOCALS = {
         isTopLevel: true,
         category: "About"
       },
-      "/about/governance": {
-        parentDir: "/about",
-        path: "governance.md",
-        title: "Governance",
-        description: "",
-        isTopLevel: false,
-        category: "About"
-      },
       "/about/usage-terms": {
         parentDir: "/about",
         path: "usage-terms.md",
         title: "Copyright and Usage",
-        description: "",
-        isTopLevel: false,
-        category: "About"
-      },
-      "/about/outreach": {
-        parentDir: "/about",
-        path: "outreach-materials.md",
-        title: "Outreach Materials",
         description: "",
         isTopLevel: false,
         category: "About"

--- a/pages/404.js
+++ b/pages/404.js
@@ -1,13 +1,11 @@
 import utils from "stylesheets/utils.module.scss";
 import contentCss from "stylesheets/content-pages.module.scss";
 import donateCss from "stylesheets/donate.module.scss";
-import ErrorLinksUser from "components/ErrorComponents/ErrorLinksUser";
-import ErrorLinksPro from "components/ErrorComponents/ErrorLinksPro";
+import ErrorLinks from "components/ErrorComponents/ErrorLinks";
 import MainLayout from "components/MainLayout";
 import React from "react";
 
 export default function Custom404() {
-  const siteEnv = process.env.NEXT_PUBLIC_SITE_ENV;
   return (
     <MainLayout>
       <div
@@ -27,10 +25,7 @@ export default function Custom404() {
                 Instead, try one of these:
               </p>
             </div>
-            <div>
-              {siteEnv === "user" && <ErrorLinksUser />}
-              {siteEnv === "pro" && <ErrorLinksPro />}
-            </div>
+            <ErrorLinks />
           </div>
         </div>
       </div>

--- a/pages/500.js
+++ b/pages/500.js
@@ -1,13 +1,11 @@
 import utils from "stylesheets/utils.module.scss";
 import contentCss from "stylesheets/content-pages.module.scss";
 import donateCss from "stylesheets/donate.module.scss";
-import ErrorLinksUser from "components/ErrorComponents/ErrorLinksUser";
-import ErrorLinksPro from "components/ErrorComponents/ErrorLinksPro";
+import ErrorLinks from "components/ErrorComponents/ErrorLinks";
 import MainLayout from "components/MainLayout";
 import React from "react";
 
 export default function Custom500() {
-  const siteEnv = process.env.NEXT_PUBLIC_SITE_ENV;
   return (
     <MainLayout>
       <div
@@ -27,10 +25,7 @@ export default function Custom500() {
                 meantime, try one of these:
               </p>
             </div>
-            <div>
-              {siteEnv === "user" && <ErrorLinksUser />}
-              {siteEnv === "pro" && <ErrorLinksPro />}
-            </div>
+            <ErrorLinks />
           </div>
         </div>
       </div>

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -4,8 +4,7 @@ import React from "react";
 import { withRouter } from "next/router";
 
 import MainLayout from "components/MainLayout";
-import ErrorLinksUser from "components/ErrorComponents/ErrorLinksUser";
-import ErrorLinksPro from "components/ErrorComponents/ErrorLinksPro";
+import ErrorLinks from "components/ErrorComponents/ErrorLinks";
 
 import contentCss from "stylesheets/content-pages.module.scss";
 import donateCss from "stylesheets/donate.module.scss";
@@ -33,7 +32,6 @@ class Error extends React.Component {
   }
 
   render() {
-    const siteEnv = process.env.NEXT_PUBLIC_SITE_ENV;
     return (
       <MainLayout>
         <div
@@ -62,10 +60,7 @@ class Error extends React.Component {
                   </p>
                 </div>
               )}
-              <div>
-                {siteEnv === "user" && <ErrorLinksUser />}
-                {siteEnv === "pro" && <ErrorLinksPro />}
-              </div>
+              <ErrorLinks />
             </main>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- Removes `/about/governance` and `/about/outreach` routes from the Illinois config in `constants/local.js` — the backing files (`governance.md`, `outreach-materials.md`) were deleted in #1434 but the routes were left in place, causing 500 errors on those pages
- Adds `ErrorLinksLocal` component with fallback navigation links (home, search, browse-by-partner) for local hub error pages — previously the "try one of these:" list was always empty on all local sites because no local case existed
- Extracts a shared `ErrorLinks` component to eliminate the repeated `siteEnv` conditional from `404.js`, `500.js`, and `_error.js`, and to ensure all three pages now handle the `"local"` environment

## Test plan

- [ ] Visit a nonexistent page on https://idhh.dp.la (e.g. `/about/governance`) — confirm the 404/error page shows the three fallback links instead of an empty list
- [ ] Confirm https://idhh.dp.la/about/governance and https://idhh.dp.la/about/outreach both show a 404 (not a 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Error pages now use a single, unified component to present the appropriate set of navigation links for the current site variant.

* **Chores**
  * Removed the Governance and Outreach routes from the local site configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->