### PR TITLE
fix(analytics): initialize window.gtag synchronously to prevent dropped View Item events

### DIFF
--- a/lib/gtag.js
+++ b/lib/gtag.js
@@ -1,6 +1,11 @@
+const invokeGtag = (...args) => {
+  if (typeof window === "undefined" || typeof window.gtag !== "function") return;
+  window.gtag(...args);
+};
+
 // https://developers.google.com/analytics/devguides/collection/gtagjs/pages
 export const pageview = ({ url, title }) => {
-  window.gtag("config", process.env.NEXT_PUBLIC_GA_TRACKING_ID, {
+  invokeGtag("config", process.env.NEXT_PUBLIC_GA_TRACKING_ID, {
     page_title: title,
     page_location: url,
   });
@@ -9,7 +14,7 @@ export const pageview = ({ url, title }) => {
 // https://developers.google.com/analytics/devguides/collection/gtagjs/events
 export const event = (gaEvent) => {
   const action = gaEvent.contributor ? gaEvent.contributor : "Broken ID";
-  window.gtag("event", action, {
+  invokeGtag("event", action, {
     event_category: `${gaEvent.type} : ${gaEvent.partner}`,
     event_label: `${gaEvent.itemId} : ${gaEvent.title}`,
   });

--- a/lib/gtag.js
+++ b/lib/gtag.js
@@ -1,26 +1,18 @@
 // https://developers.google.com/analytics/devguides/collection/gtagjs/pages
 export const pageview = ({ url, title }) => {
-  if (window.gtag) {
-    window.gtag("config", process.env.NEXT_PUBLIC_GA_TRACKING_ID, {
-      page_title: title,
-      page_location: url,
-    });
-  } else {
-    console.log("WARNING: gtag not loaded.");
-  }
+  window.gtag("config", process.env.NEXT_PUBLIC_GA_TRACKING_ID, {
+    page_title: title,
+    page_location: url,
+  });
 };
 
 // https://developers.google.com/analytics/devguides/collection/gtagjs/events
 export const event = (gaEvent) => {
-  if (window.gtag) {
-    const action = gaEvent.contributor ? gaEvent.contributor : "Broken ID";
-    window.gtag("event", action, {
-      event_category: `${gaEvent.type} : ${gaEvent.partner}`,
-      event_label: `${gaEvent.itemId} : ${gaEvent.title}`,
-    });
-  } else {
-    console.log("WARNING: gtag not loaded.");
-  }
+  const action = gaEvent.contributor ? gaEvent.contributor : "Broken ID";
+  window.gtag("event", action, {
+    event_category: `${gaEvent.type} : ${gaEvent.partner}`,
+    event_label: `${gaEvent.itemId} : ${gaEvent.title}`,
+  });
 };
 
 const gtag = { event, pageview };

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -53,27 +53,25 @@ function App({ Component, pageProps }) {
       window.removeEventListener("unhandledrejection", handleStaleChunkError);
   }, []);
 
-  function gaLoad() {
-    window.dataLayer = window.dataLayer || [];
-
-    function gtag() {
-      dataLayer.push(arguments);
-    }
-
-    window.gtag = gtag;
-    gtag("js", new Date());
-    gtag("config", gaTrackingId, {
-      page_path: window.location.pathname,
-    });
-  }
-
   return (
     <>
-      {/* Global Site Tag (gtag.js) - Google Analytics */}
+      {/* Define window.gtag synchronously so calls during hydration are queued,
+          not dropped. The external script below processes the queue on load. */}
+      <script
+        id="gtag-init"
+        dangerouslySetInnerHTML={{
+          __html: `window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}`,
+        }}
+      />
       <Script
         strategy="afterInteractive"
         src={`https://www.googletagmanager.com/gtag/js?id=${gaTrackingId}`}
-        onLoad={() => gaLoad()}
+        onLoad={() => {
+          window.gtag("js", new Date());
+          window.gtag("config", gaTrackingId, {
+            page_path: window.location.pathname,
+          });
+        }}
       />
       <Component {...pageProps} />
     </>


### PR DESCRIPTION
## Summary

- `View Item` GA events were silently dropped for users who landed on item pages via a direct/hard load (from Google, external links, bookmarks, new-tab search results)
- Root cause: `componentDidMount` fires during React hydration, before the `afterInteractive` gtag script loads, so `window.gtag` was undefined and the `event()` call hit the warning branch and did nothing
- Fix: add a synchronous inline `<script>` that defines `window.dataLayer` and `window.gtag` in the initial HTML, before any React code runs — the [standard Google-recommended pattern](https://developers.google.com/tag-platform/gtagjs/install). Calls during hydration queue in `dataLayer` and are processed when the external script loads
- Pageview tracking was never affected; only the custom `View Item` (and `View Exhibition Item` / PSS source view) events were broken on hard loads
- Removes the now-obsolete `if (window.gtag)` guards and `"WARNING: gtag not loaded."` console logs from `lib/gtag.js`

## Test plan

- [ ] Hard-navigate directly to an item page (e.g. `dp.la/item/...`)
- [ ] Open browser DevTools → Network → filter `google-analytics` — confirm a `View Item` event fires
- [ ] Confirm `"WARNING: gtag not loaded."` no longer appears in the console
- [ ] Client-side navigate from search results to an item page — confirm event still fires
- [ ] Confirm pageview tracking is unaffected throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated analytics initialization into the script load path and removed redundant presence checks.

* **Bug Fixes**
  * Made analytics invocation more robust so missing analytics won’t trigger errors or noisy console warnings; calls are now queued and initialized reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->