### PR TITLE
fix(analytics): add onLoad gtag fallback for CSP-blocked inline script

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -67,6 +67,14 @@ function App({ Component, pageProps }) {
         strategy="afterInteractive"
         src={`https://www.googletagmanager.com/gtag/js?id=${gaTrackingId}`}
         onLoad={() => {
+          // Fallback: define gtag here in case the inline script above was
+          // blocked by CSP (which requires a matching sha256 hash for inline scripts).
+          window.dataLayer = window.dataLayer || [];
+          window.gtag =
+            window.gtag ||
+            function () {
+              window.dataLayer.push(arguments);
+            };
           window.gtag("js", new Date());
           window.gtag("config", gaTrackingId, {
             page_path: window.location.pathname,


### PR DESCRIPTION
## Summary

- **Root cause of DPLA-FRONTEND-1J3, 1J4, 1J5**: dp.la's CSP uses `sha256-...` hashes to allow inline scripts. The `<script dangerouslySetInnerHTML>` added in #1439 doesn't match any hash, so browsers block it, leaving `window.gtag` undefined. When the external gtag script loads and `onLoad` fires, it calls `window.gtag("js", new Date())` directly — throwing `TypeError: window.gtag is not a function`.
- **Fix**: add a `window.gtag = window.gtag || function(){...}` fallback inside the `onLoad` callback. Since `onLoad` is in the JS bundle (not an inline script), it's never subject to CSP hash restrictions. If the inline script ran, the `||` short-circuits harmlessly. If it was blocked, `onLoad` now defines `gtag` before calling it.
- The `invokeGtag` wrapper in `lib/gtag.js` (added in #1439) also provides safety for any `gtag.event()` / `gtag.pageview()` calls that fire before `onLoad` — those are silently no-op'd rather than crashing.

## Test plan

- [ ] Hard-navigate to an item page — confirm no `TypeError: window.gtag is not a function` in console
- [ ] Confirm Sentry DPLA-FRONTEND-1J3, 1J4, 1J5 stop receiving new events after deploy
- [ ] Confirm `View Item` GA events still fire (Network tab → `google-analytics.com`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced analytics initialization resilience with a fallback mechanism that ensures tracking functionality remains reliable even when certain restrictions prevent standard initialization methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->