### PR TITLE
Return 503 instead of 404 when upstream API is unreachable

### DIFF
--- a/components/shared/ServiceUnavailable/index.js
+++ b/components/shared/ServiceUnavailable/index.js
@@ -1,0 +1,34 @@
+import React from "react";
+import MainLayout from "components/MainLayout";
+import Button from "components/shared/Button";
+import utils from "stylesheets/utils.module.scss";
+import contentCss from "stylesheets/content-pages.module.scss";
+
+/**
+ * Generic "temporarily unavailable" page rendered when an upstream API call
+ * fails at the network level (connection timeout, DNS failure, etc.).
+ *
+ * The HTTP response is set to 503 + Retry-After in getServerSideProps before
+ * returning { props: { temporarilyUnavailable: true } }, so crawlers know to
+ * retry rather than treating the page as gone.
+ */
+export default function ServiceUnavailable() {
+  return (
+    <MainLayout>
+      <main
+        id="main"
+        role="main"
+        className={`${utils.container} ${contentCss.content}`}
+      >
+        <h1>This page is temporarily unavailable.</h1>
+        <p>
+          We&rsquo;re having a brief issue loading this page. Please try again
+          in a moment.
+        </p>
+        <Button type="primary" onClick={() => window.location.reload()}>
+          Try again now
+        </Button>
+      </main>
+    </MainLayout>
+  );
+}

--- a/lib/safeFetch.js
+++ b/lib/safeFetch.js
@@ -125,6 +125,24 @@ export function checkResponseForSSRSafe(res, label) {
 }
 
 /**
+ * Sets a 503 status code + Retry-After header on the SSR response object and
+ * returns { props: { temporarilyUnavailable: true } } for use in
+ * getServerSideProps when an upstream fetch returns null (network failure).
+ *
+ * Callers should pass `context.res` (full context) or the destructured `res`.
+ * The component must handle the `temporarilyUnavailable` prop by rendering
+ * a ServiceUnavailable page rather than trying to use missing data.
+ *
+ * @param {import('http').ServerResponse} res - Next.js SSR response object
+ * @returns {{ props: { temporarilyUnavailable: true } }}
+ */
+export function upstreamUnavailable(res) {
+  res.statusCode = 503;
+  res.setHeader("Retry-After", "10");
+  return { props: { temporarilyUnavailable: true } };
+}
+
+/**
  * Checks a safeFetch response and returns { notFound: true } for 4xx errors,
  * or throws for 5xx/network errors so Next.js renders the 500 page.
  *

--- a/lib/safeFetch.js
+++ b/lib/safeFetch.js
@@ -141,15 +141,18 @@ export function isUpstreamUnavailable(fetchRes) {
 }
 
 /**
- * Sets a 503 status code + Retry-After header on the SSR response object and
- * returns { props: { temporarilyUnavailable: true } }.
+ * Cancels any open response bodies, sets a 503 + Retry-After header on the SSR
+ * response object, and returns { props: { temporarilyUnavailable: true } }.
  *
- * Used when upstream is temporarily unavailable (network failure or 503).
+ * Pass any safeFetch Response objects that need their bodies released as
+ * additional arguments; null/undefined entries are safely ignored.
  *
  * @param {import('http').ServerResponse} res - Next.js SSR response object
- * @returns {{ props: { temporarilyUnavailable: true } }}
+ * @param {...(Response|null|undefined)} fetchResponses - open fetch responses to cancel
+ * @returns {Promise<{ props: { temporarilyUnavailable: true } }>}
  */
-export function upstreamUnavailable(res) {
+export async function upstreamUnavailable(res, ...fetchResponses) {
+  await Promise.all(fetchResponses.map((r) => r?.body?.cancel()));
   res.statusCode = 503;
   res.setHeader("Retry-After", "10");
   return { props: { temporarilyUnavailable: true } };

--- a/lib/safeFetch.js
+++ b/lib/safeFetch.js
@@ -152,7 +152,7 @@ export function isUpstreamUnavailable(fetchRes) {
  * @returns {Promise<{ props: { temporarilyUnavailable: true } }>}
  */
 export async function upstreamUnavailable(res, ...fetchResponses) {
-  await Promise.all(fetchResponses.map((r) => r?.body?.cancel()));
+  await Promise.allSettled(fetchResponses.map((r) => r?.body?.cancel?.()));
   res.statusCode = 503;
   res.setHeader("Retry-After", "10");
   return { props: { temporarilyUnavailable: true } };

--- a/lib/safeFetch.js
+++ b/lib/safeFetch.js
@@ -136,6 +136,22 @@ export function checkResponseForSSRSafe(res, label) {
  * @param {import('http').ServerResponse} res - Next.js SSR response object
  * @returns {{ props: { temporarilyUnavailable: true } }}
  */
+/**
+ * Returns true when a safeFetch result indicates a temporary upstream
+ * unavailability: either a network failure (null) or an upstream 503 that
+ * persisted through safeFetch's built-in retry.
+ *
+ * Use this instead of a bare `!res` check so that upstream 503 responses
+ * are also converted to a client-facing 503 rather than silently becoming
+ * 404s via checkResponseForSSRSafe.
+ *
+ * @param {Response|null} fetchRes - return value of safeFetch / cachedSafeFetch
+ * @returns {boolean}
+ */
+export function isUpstreamUnavailable(fetchRes) {
+  return !fetchRes || fetchRes.status === 503;
+}
+
 export function upstreamUnavailable(res) {
   res.statusCode = 503;
   res.setHeader("Retry-After", "10");

--- a/lib/safeFetch.js
+++ b/lib/safeFetch.js
@@ -125,18 +125,6 @@ export function checkResponseForSSRSafe(res, label) {
 }
 
 /**
- * Sets a 503 status code + Retry-After header on the SSR response object and
- * returns { props: { temporarilyUnavailable: true } } for use in
- * getServerSideProps when an upstream fetch returns null (network failure).
- *
- * Callers should pass `context.res` (full context) or the destructured `res`.
- * The component must handle the `temporarilyUnavailable` prop by rendering
- * a ServiceUnavailable page rather than trying to use missing data.
- *
- * @param {import('http').ServerResponse} res - Next.js SSR response object
- * @returns {{ props: { temporarilyUnavailable: true } }}
- */
-/**
  * Returns true when a safeFetch result indicates a temporary upstream
  * unavailability: either a network failure (null) or an upstream 503 that
  * persisted through safeFetch's built-in retry.
@@ -152,6 +140,15 @@ export function isUpstreamUnavailable(fetchRes) {
   return !fetchRes || fetchRes.status === 503;
 }
 
+/**
+ * Sets a 503 status code + Retry-After header on the SSR response object and
+ * returns { props: { temporarilyUnavailable: true } }.
+ *
+ * Used when upstream is temporarily unavailable (network failure or 503).
+ *
+ * @param {import('http').ServerResponse} res - Next.js SSR response object
+ * @returns {{ props: { temporarilyUnavailable: true } }}
+ */
 export function upstreamUnavailable(res) {
   res.statusCode = 503;
   res.setHeader("Retry-After", "10");

--- a/lib/safeFetch.test.mjs
+++ b/lib/safeFetch.test.mjs
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { isUpstreamUnavailable, upstreamUnavailable } from './safeFetch.js';
+
+// isUpstreamUnavailable
+
+test('isUpstreamUnavailable returns true for null (network failure)', () => {
+  assert.equal(isUpstreamUnavailable(null), true);
+});
+
+test('isUpstreamUnavailable returns true for 503 response', () => {
+  assert.equal(isUpstreamUnavailable({ status: 503 }), true);
+});
+
+test('isUpstreamUnavailable returns false for a successful response', () => {
+  assert.equal(isUpstreamUnavailable({ status: 200, ok: true }), false);
+});
+
+test('isUpstreamUnavailable returns false for a 404 response', () => {
+  assert.equal(isUpstreamUnavailable({ status: 404, ok: false }), false);
+});
+
+// upstreamUnavailable
+
+function makeRes() {
+  const headers = {};
+  return {
+    statusCode: 200,
+    setHeader(name, value) { headers[name] = value; },
+    getHeader(name) { return headers[name]; },
+  };
+}
+
+test('upstreamUnavailable sets statusCode 503 and Retry-After: 10', async () => {
+  const res = makeRes();
+  await upstreamUnavailable(res);
+  assert.equal(res.statusCode, 503);
+  assert.equal(res.getHeader('Retry-After'), '10');
+});
+
+test('upstreamUnavailable returns { props: { temporarilyUnavailable: true } }', async () => {
+  const res = makeRes();
+  const result = await upstreamUnavailable(res);
+  assert.deepEqual(result, { props: { temporarilyUnavailable: true } });
+});
+
+test('upstreamUnavailable calls body.cancel on supplied fetch responses', async () => {
+  const res = makeRes();
+  let cancelCalled = 0;
+  const mockResponse = { body: { cancel: () => { cancelCalled++; return Promise.resolve(); } } };
+  await upstreamUnavailable(res, mockResponse, mockResponse);
+  assert.equal(cancelCalled, 2);
+});
+
+test('upstreamUnavailable ignores null and undefined fetch responses', async () => {
+  const res = makeRes();
+  // Should not throw when null/undefined are passed
+  await assert.doesNotReject(() => upstreamUnavailable(res, null, undefined));
+});

--- a/lib/safeFetch.test.mjs
+++ b/lib/safeFetch.test.mjs
@@ -57,3 +57,13 @@ test('upstreamUnavailable ignores null and undefined fetch responses', async () 
   // Should not throw when null/undefined are passed
   await assert.doesNotReject(() => upstreamUnavailable(res, null, undefined));
 });
+
+test('upstreamUnavailable tolerates rejected body.cancel()', async () => {
+  const res = makeRes();
+  const rejectingResponse = {
+    body: { cancel: () => Promise.reject(new Error('cancel failed')) },
+  };
+  await assert.doesNotReject(() => upstreamUnavailable(res, rejectingResponse));
+  assert.equal(res.statusCode, 503);
+  assert.equal(res.getHeader('Retry-After'), '10');
+});

--- a/pages/browse-by-partner/index.js
+++ b/pages/browse-by-partner/index.js
@@ -9,9 +9,11 @@ import { LOCALS } from "constants/local";
 
 import css from "components/PartnerBrowseComponents/PartnerBrowseContent.module.scss";
 import { washObject } from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable } from "lib/safeFetch";
+import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
-function PartnerBrowse({ partners }) {
+function PartnerBrowse({ partners, temporarilyUnavailable }) {
+  if (temporarilyUnavailable) return <ServiceUnavailable />;
   return (
     <div>
       <MainLayout pageTitle={TITLE}>
@@ -28,7 +30,7 @@ function PartnerBrowse({ partners }) {
   );
 }
 
-export const getServerSideProps = async () => {
+export const getServerSideProps = async ({ res }) => {
   const siteEnv = process.env.NEXT_PUBLIC_SITE_ENV;
   const localId = process.env.NEXT_PUBLIC_LOCAL_ID;
 
@@ -53,10 +55,13 @@ export const getServerSideProps = async () => {
     linkParam = "partner";
   }
 
-  const res = await safeFetch(apiQuery);
-  const resError = checkResponseForSSRSafe(res, "Partner browse");
+  const fetchRes = await safeFetch(apiQuery);
+  if (!fetchRes) {
+    return upstreamUnavailable(res);
+  }
+  const resError = checkResponseForSSRSafe(fetchRes, "Partner browse");
   if (resError) return resError;
-  const json = await res.json();
+  const json = await fetchRes.json();
   const terms = json?.facets?.[facetName]?.terms;
   if (!Array.isArray(terms)) {
     return { notFound: true };

--- a/pages/browse-by-partner/index.js
+++ b/pages/browse-by-partner/index.js
@@ -57,8 +57,7 @@ export const getServerSideProps = async ({ res }) => {
 
   const fetchRes = await safeFetch(apiQuery);
   if (isUpstreamUnavailable(fetchRes)) {
-    await fetchRes?.body?.cancel();
-    return upstreamUnavailable(res);
+    return upstreamUnavailable(res, fetchRes);
   }
   const resError = checkResponseForSSRSafe(fetchRes, "Partner browse");
   if (resError) return resError;

--- a/pages/browse-by-partner/index.js
+++ b/pages/browse-by-partner/index.js
@@ -9,7 +9,7 @@ import { LOCALS } from "constants/local";
 
 import css from "components/PartnerBrowseComponents/PartnerBrowseContent.module.scss";
 import { washObject } from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
 function PartnerBrowse({ partners, temporarilyUnavailable }) {
@@ -56,7 +56,8 @@ export const getServerSideProps = async ({ res }) => {
   }
 
   const fetchRes = await safeFetch(apiQuery);
-  if (!fetchRes) {
+  if (isUpstreamUnavailable(fetchRes)) {
+    await fetchRes?.body?.cancel();
     return upstreamUnavailable(res);
   }
   const resError = checkResponseForSSRSafe(fetchRes, "Partner browse");

--- a/pages/browse-by-topic/[topicSlug]/index.js
+++ b/pages/browse-by-topic/[topicSlug]/index.js
@@ -88,47 +88,59 @@ export const getServerSideProps = async (context) => {
     thumbnailUrl: subtopic.acf.category_image,
   }));
 
-  const suggestions = !currentTopic.acf.related_content
-    ? []
-    : await Promise.all(
-        currentTopic.acf.related_content.map(async (item) => {
-          if (item.related_content_type === "Exhibition") {
-            // load exhibit
-            const exhibition = exhibitions.exhibitions.find(
-              (exhibition) => exhibition.slug === item.exhibition_id,
-            );
-            // skip a nil exhibit
-            if (!exhibition) return;
-            const href = `/exhibitions/${exhibition.slug}`;
-            const as = `/exhibitions/${exhibition.slug}`;
-            return {
-              title: exhibition.title,
-              thumbnailUrl: exhibition.thumbnailUrl,
-              as,
-              href,
-              type: "Exhibition",
-            };
-          } else if (item.related_content_type === "Primary Source Set") {
-            if (!item.primary_source_set_id) return null;
-            const setId = sanitizeSourceSetId(item.primary_source_set_id);
-            const sourceSetRes = await safeFetch(
-              `${process.env.API_URL}/pss/sets/${setId}?api_key=${process.env.API_KEY}`,
-            );
-            if (!sourceSetRes?.ok) return null;
-            const sourceSetJson = await sourceSetRes.json();
-            const slug = extractSourceSetSlug(sourceSetJson["@id"]);
-            if (!slug) return null;
-            return {
-              title: sourceSetJson.name,
-              thumbnailUrl: sourceSetJson.thumbnailUrl,
-              href: `/primary-source-sets/${slug}`,
-              type: "Primary Source Set",
-            };
-          } else {
-            return null;
-          }
-        }),
-      );
+  let suggestions;
+  try {
+    suggestions = !currentTopic.acf.related_content
+      ? []
+      : await Promise.all(
+          currentTopic.acf.related_content.map(async (item) => {
+            if (item.related_content_type === "Exhibition") {
+              // load exhibit
+              const exhibition = exhibitions.exhibitions.find(
+                (exhibition) => exhibition.slug === item.exhibition_id,
+              );
+              // skip a nil exhibit
+              if (!exhibition) return;
+              const href = `/exhibitions/${exhibition.slug}`;
+              const as = `/exhibitions/${exhibition.slug}`;
+              return {
+                title: exhibition.title,
+                thumbnailUrl: exhibition.thumbnailUrl,
+                as,
+                href,
+                type: "Exhibition",
+              };
+            } else if (item.related_content_type === "Primary Source Set") {
+              if (!item.primary_source_set_id) return null;
+              const setId = sanitizeSourceSetId(item.primary_source_set_id);
+              const sourceSetRes = await safeFetch(
+                `${process.env.API_URL}/pss/sets/${setId}?api_key=${process.env.API_KEY}`,
+              );
+              if (isUpstreamUnavailable(sourceSetRes)) {
+                await sourceSetRes?.body?.cancel();
+                throw new Error("UPSTREAM_UNAVAILABLE");
+              }
+              if (!sourceSetRes?.ok) return null;
+              const sourceSetJson = await sourceSetRes.json();
+              const slug = extractSourceSetSlug(sourceSetJson["@id"]);
+              if (!slug) return null;
+              return {
+                title: sourceSetJson.name,
+                thumbnailUrl: sourceSetJson.thumbnailUrl,
+                href: `/primary-source-sets/${slug}`,
+                type: "Primary Source Set",
+              };
+            } else {
+              return null;
+            }
+          }),
+        );
+  } catch (err) {
+    if (err.message === "UPSTREAM_UNAVAILABLE") {
+      return upstreamUnavailable(context.res);
+    }
+    throw err;
+  }
 
   const props = washObject({
     topic: { ...currentTopic, subtopics },

--- a/pages/browse-by-topic/[topicSlug]/index.js
+++ b/pages/browse-by-topic/[topicSlug]/index.js
@@ -55,8 +55,7 @@ export const getServerSideProps = async (context) => {
   const topicSlug = context.params?.topicSlug;
   const topicsRes = await safeFetch(API_ENDPOINT_ALL_TOPICS + "?slug=" + topicSlug);
   if (isUpstreamUnavailable(topicsRes)) {
-    await topicsRes?.body?.cancel();
-    return upstreamUnavailable(context.res);
+    return upstreamUnavailable(context.res, topicsRes);
   }
   const topicsError = checkResponseForSSRSafe(topicsRes, "Topic");
   if (topicsError) return topicsError;
@@ -76,8 +75,7 @@ export const getServerSideProps = async (context) => {
   ]);
 
   if (isUpstreamUnavailable(subtopicsRes)) {
-    await subtopicsRes?.body?.cancel();
-    return upstreamUnavailable(context.res);
+    return upstreamUnavailable(context.res, subtopicsRes);
   }
   const subtopicsError = checkResponseForSSRSafe(subtopicsRes, "Topic subtopics");
   if (subtopicsError) return subtopicsError;

--- a/pages/browse-by-topic/[topicSlug]/index.js
+++ b/pages/browse-by-topic/[topicSlug]/index.js
@@ -115,7 +115,7 @@ export const getServerSideProps = async (context) => {
             // treat upstream unavailability as a skipped suggestion — a missing
             // sidebar card is not worth failing the whole topic page
             if (!sourceSetRes?.ok) {
-              await sourceSetRes?.body?.cancel();
+              await sourceSetRes?.body?.cancel?.().catch(() => {});
               return null;
             }
             const sourceSetJson = await sourceSetRes.json();

--- a/pages/browse-by-topic/[topicSlug]/index.js
+++ b/pages/browse-by-topic/[topicSlug]/index.js
@@ -88,6 +88,8 @@ export const getServerSideProps = async (context) => {
     thumbnailUrl: subtopic.acf.category_image,
   }));
 
+  // Use try-catch with a sentinel error because returning from getServerSideProps
+  // isn't possible inside a Promise.all callback — the outer catch converts it.
   let suggestions;
   try {
     suggestions = !currentTopic.acf.related_content

--- a/pages/browse-by-topic/[topicSlug]/index.js
+++ b/pages/browse-by-topic/[topicSlug]/index.js
@@ -13,7 +13,7 @@ import {
 } from "constants/topicBrowse";
 
 import { washObject } from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
 const sanitizeSourceSetId = (id) => {
@@ -54,7 +54,8 @@ function Topic(props) {
 export const getServerSideProps = async (context) => {
   const topicSlug = context.params?.topicSlug;
   const topicsRes = await safeFetch(API_ENDPOINT_ALL_TOPICS + "?slug=" + topicSlug);
-  if (!topicsRes) {
+  if (isUpstreamUnavailable(topicsRes)) {
+    await topicsRes?.body?.cancel();
     return upstreamUnavailable(context.res);
   }
   const topicsError = checkResponseForSSRSafe(topicsRes, "Topic");
@@ -74,7 +75,8 @@ export const getServerSideProps = async (context) => {
     loadExhibitionList(),
   ]);
 
-  if (!subtopicsRes) {
+  if (isUpstreamUnavailable(subtopicsRes)) {
+    await subtopicsRes?.body?.cancel();
     return upstreamUnavailable(context.res);
   }
   const subtopicsError = checkResponseForSSRSafe(subtopicsRes, "Topic subtopics");

--- a/pages/browse-by-topic/[topicSlug]/index.js
+++ b/pages/browse-by-topic/[topicSlug]/index.js
@@ -86,61 +86,52 @@ export const getServerSideProps = async (context) => {
     thumbnailUrl: subtopic.acf.category_image,
   }));
 
-  // Use try-catch with a sentinel error because returning from getServerSideProps
-  // isn't possible inside a Promise.all callback — the outer catch converts it.
-  let suggestions;
-  try {
-    suggestions = !currentTopic.acf.related_content
-      ? []
-      : await Promise.all(
-          currentTopic.acf.related_content.map(async (item) => {
-            if (item.related_content_type === "Exhibition") {
-              // load exhibit
-              const exhibition = exhibitions.exhibitions.find(
-                (exhibition) => exhibition.slug === item.exhibition_id,
-              );
-              // skip a nil exhibit
-              if (!exhibition) return;
-              const href = `/exhibitions/${exhibition.slug}`;
-              const as = `/exhibitions/${exhibition.slug}`;
-              return {
-                title: exhibition.title,
-                thumbnailUrl: exhibition.thumbnailUrl,
-                as,
-                href,
-                type: "Exhibition",
-              };
-            } else if (item.related_content_type === "Primary Source Set") {
-              if (!item.primary_source_set_id) return null;
-              const setId = sanitizeSourceSetId(item.primary_source_set_id);
-              const sourceSetRes = await safeFetch(
-                `${process.env.API_URL}/pss/sets/${setId}?api_key=${process.env.API_KEY}`,
-              );
-              if (isUpstreamUnavailable(sourceSetRes)) {
-                await sourceSetRes?.body?.cancel();
-                throw new Error("UPSTREAM_UNAVAILABLE");
-              }
-              if (!sourceSetRes?.ok) return null;
-              const sourceSetJson = await sourceSetRes.json();
-              const slug = extractSourceSetSlug(sourceSetJson["@id"]);
-              if (!slug) return null;
-              return {
-                title: sourceSetJson.name,
-                thumbnailUrl: sourceSetJson.thumbnailUrl,
-                href: `/primary-source-sets/${slug}`,
-                type: "Primary Source Set",
-              };
-            } else {
+  const suggestions = !currentTopic.acf.related_content
+    ? []
+    : await Promise.all(
+        currentTopic.acf.related_content.map(async (item) => {
+          if (item.related_content_type === "Exhibition") {
+            // load exhibit
+            const exhibition = exhibitions.exhibitions.find(
+              (exhibition) => exhibition.slug === item.exhibition_id,
+            );
+            // skip a nil exhibit
+            if (!exhibition) return;
+            const href = `/exhibitions/${exhibition.slug}`;
+            const as = `/exhibitions/${exhibition.slug}`;
+            return {
+              title: exhibition.title,
+              thumbnailUrl: exhibition.thumbnailUrl,
+              as,
+              href,
+              type: "Exhibition",
+            };
+          } else if (item.related_content_type === "Primary Source Set") {
+            if (!item.primary_source_set_id) return null;
+            const setId = sanitizeSourceSetId(item.primary_source_set_id);
+            const sourceSetRes = await safeFetch(
+              `${process.env.API_URL}/pss/sets/${setId}?api_key=${process.env.API_KEY}`,
+            );
+            // treat upstream unavailability as a skipped suggestion — a missing
+            // sidebar card is not worth failing the whole topic page
+            if (!sourceSetRes?.ok) {
+              await sourceSetRes?.body?.cancel();
               return null;
             }
-          }),
-        );
-  } catch (err) {
-    if (err.message === "UPSTREAM_UNAVAILABLE") {
-      return upstreamUnavailable(context.res);
-    }
-    throw err;
-  }
+            const sourceSetJson = await sourceSetRes.json();
+            const slug = extractSourceSetSlug(sourceSetJson["@id"]);
+            if (!slug) return null;
+            return {
+              title: sourceSetJson.name,
+              thumbnailUrl: sourceSetJson.thumbnailUrl,
+              href: `/primary-source-sets/${slug}`,
+              type: "Primary Source Set",
+            };
+          } else {
+            return null;
+          }
+        }),
+      );
 
   const props = washObject({
     topic: { ...currentTopic, subtopics },

--- a/pages/browse-by-topic/[topicSlug]/index.js
+++ b/pages/browse-by-topic/[topicSlug]/index.js
@@ -13,7 +13,8 @@ import {
 } from "constants/topicBrowse";
 
 import { washObject } from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable } from "lib/safeFetch";
+import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
 const sanitizeSourceSetId = (id) => {
   let sanitized = id.replace(" ", "");
@@ -24,7 +25,8 @@ const sanitizeSourceSetId = (id) => {
 };
 
 function Topic(props) {
-  const { topic, suggestions } = props;
+  const { topic, suggestions, temporarilyUnavailable } = props;
+  if (temporarilyUnavailable) return <ServiceUnavailable />;
   if (!topic) return null;
   return (
     <MainLayout pageTitle={topic.name}>
@@ -52,7 +54,9 @@ function Topic(props) {
 export const getServerSideProps = async (context) => {
   const topicSlug = context.params?.topicSlug;
   const topicsRes = await safeFetch(API_ENDPOINT_ALL_TOPICS + "?slug=" + topicSlug);
-
+  if (!topicsRes) {
+    return upstreamUnavailable(context.res);
+  }
   const topicsError = checkResponseForSSRSafe(topicsRes, "Topic");
   if (topicsError) return topicsError;
 
@@ -70,6 +74,9 @@ export const getServerSideProps = async (context) => {
     loadExhibitionList(),
   ]);
 
+  if (!subtopicsRes) {
+    return upstreamUnavailable(context.res);
+  }
   const subtopicsError = checkResponseForSSRSafe(subtopicsRes, "Topic subtopics");
   if (subtopicsError) return subtopicsError;
 

--- a/pages/guides/[guideSlug].js
+++ b/pages/guides/[guideSlug].js
@@ -15,7 +15,7 @@ import contentCss from "stylesheets/content-pages.module.scss";
 import css from "stylesheets/guides.module.scss";
 import utils from "stylesheets/utils.module.scss";
 import { washObject } from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe, wpAuthFetchOptions, wpDraftUrl, upstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, wpAuthFetchOptions, wpDraftUrl, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
 import { upgradeWordPressUrls } from "lib/upgradeWordPressUrls";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
@@ -81,7 +81,8 @@ export async function getServerSideProps(context) {
   const { draftMode } = context;
   const authOptions = wpAuthFetchOptions(draftMode);
   const menuItemsRes = await safeFetch(ABOUT_MENU_ENDPOINT);
-  if (!menuItemsRes) {
+  if (isUpstreamUnavailable(menuItemsRes)) {
+    await menuItemsRes?.body?.cancel();
     return upstreamUnavailable(context.res);
   }
   const menuError = checkResponseForSSRSafe(menuItemsRes, "Guides menu");
@@ -96,7 +97,8 @@ export async function getServerSideProps(context) {
   }
   const guideUrl = draftMode ? wpDraftUrl(getMenuItemUrl(guide)) : getMenuItemUrl(guide);
   const guideRes = await safeFetch(guideUrl, authOptions);
-  if (!guideRes) {
+  if (isUpstreamUnavailable(guideRes)) {
+    await guideRes?.body?.cancel();
     return upstreamUnavailable(context.res);
   }
   const guideError = checkResponseForSSRSafe(guideRes, "Guide page");

--- a/pages/guides/[guideSlug].js
+++ b/pages/guides/[guideSlug].js
@@ -82,8 +82,7 @@ export async function getServerSideProps(context) {
   const authOptions = wpAuthFetchOptions(draftMode);
   const menuItemsRes = await safeFetch(ABOUT_MENU_ENDPOINT);
   if (isUpstreamUnavailable(menuItemsRes)) {
-    await menuItemsRes?.body?.cancel();
-    return upstreamUnavailable(context.res);
+    return upstreamUnavailable(context.res, menuItemsRes);
   }
   const menuError = checkResponseForSSRSafe(menuItemsRes, "Guides menu");
   if (menuError) return menuError;
@@ -98,8 +97,7 @@ export async function getServerSideProps(context) {
   const guideUrl = draftMode ? wpDraftUrl(getMenuItemUrl(guide)) : getMenuItemUrl(guide);
   const guideRes = await safeFetch(guideUrl, authOptions);
   if (isUpstreamUnavailable(guideRes)) {
-    await guideRes?.body?.cancel();
-    return upstreamUnavailable(context.res);
+    return upstreamUnavailable(context.res, guideRes);
   }
   const guideError = checkResponseForSSRSafe(guideRes, "Guide page");
   if (guideError) return guideError;

--- a/pages/guides/[guideSlug].js
+++ b/pages/guides/[guideSlug].js
@@ -15,8 +15,9 @@ import contentCss from "stylesheets/content-pages.module.scss";
 import css from "stylesheets/guides.module.scss";
 import utils from "stylesheets/utils.module.scss";
 import { washObject } from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe, wpAuthFetchOptions, wpDraftUrl } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, wpAuthFetchOptions, wpDraftUrl, upstreamUnavailable } from "lib/safeFetch";
 import { upgradeWordPressUrls } from "lib/upgradeWordPressUrls";
+import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
 class Guides extends React.Component {
   refreshExternalLinks() {
@@ -37,7 +38,8 @@ class Guides extends React.Component {
   }
 
   render() {
-    const { sidebarItems, breadcrumbs, guide } = this.props;
+    const { sidebarItems, breadcrumbs, guide, temporarilyUnavailable } = this.props;
+    if (temporarilyUnavailable) return <ServiceUnavailable />;
     if (!guide) return null;
     return (
       <MainLayout pageTitle={guide.title} seoType={SEO_TYPE}>
@@ -79,6 +81,9 @@ export async function getServerSideProps(context) {
   const { draftMode } = context;
   const authOptions = wpAuthFetchOptions(draftMode);
   const menuItemsRes = await safeFetch(ABOUT_MENU_ENDPOINT);
+  if (!menuItemsRes) {
+    return upstreamUnavailable(context.res);
+  }
   const menuError = checkResponseForSSRSafe(menuItemsRes, "Guides menu");
   if (menuError) return menuError;
   const menuItemsJson = await menuItemsRes.json();
@@ -91,6 +96,9 @@ export async function getServerSideProps(context) {
   }
   const guideUrl = draftMode ? wpDraftUrl(getMenuItemUrl(guide)) : getMenuItemUrl(guide);
   const guideRes = await safeFetch(guideUrl, authOptions);
+  if (!guideRes) {
+    return upstreamUnavailable(context.res);
+  }
   const guideError = checkResponseForSSRSafe(guideRes, "Guide page");
   if (guideError) return guideError;
   const guideJson = await guideRes.json();

--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -23,7 +23,7 @@ import contentCss from "stylesheets/content-pages.module.scss";
 import donateCss from "stylesheets/donate.module.scss";
 import Button from "components/shared/Button";
 import { washObject } from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
 import { DPLA_ITEM_ID_REGEX } from "constants/items";
 
 export default function ItemDetail({ item, temporarilyUnavailable, randomItemId, isQA, pageDescription, canonicalUrl }) {
@@ -149,13 +149,9 @@ export async function getServerSideProps(context) {
   itemUrl.searchParams.set("api_key", process.env.API_KEY);
 
   const res = await safeFetch(itemUrl);
-  if (!res) {
-    console.warn(`[SSR] Item ${itemId} fetch returned null (network error)`);
-    return upstreamUnavailable(context.res);
-  }
-  if (res?.status === 503) {
-    console.warn(`[SSR] Item ${itemId} returned 503 after retry`);
-    await res.body?.cancel();
+  if (isUpstreamUnavailable(res)) {
+    console.warn(`[SSR] Item ${itemId}: ${!res ? "network error" : "503 after retry"}`);
+    await res?.body?.cancel();
     return upstreamUnavailable(context.res);
   }
   const errorResult = checkResponseForSSRSafe(res, "Item");

--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -151,8 +151,7 @@ export async function getServerSideProps(context) {
   const res = await safeFetch(itemUrl);
   if (isUpstreamUnavailable(res)) {
     console.warn(`[SSR] Item ${itemId}: ${!res ? "network error" : "503 after retry"}`);
-    await res?.body?.cancel();
-    return upstreamUnavailable(context.res);
+    return upstreamUnavailable(context.res, res);
   }
   const errorResult = checkResponseForSSRSafe(res, "Item");
   if (errorResult) return errorResult;

--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -23,7 +23,7 @@ import contentCss from "stylesheets/content-pages.module.scss";
 import donateCss from "stylesheets/donate.module.scss";
 import Button from "components/shared/Button";
 import { washObject } from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable } from "lib/safeFetch";
 import { DPLA_ITEM_ID_REGEX } from "constants/items";
 
 export default function ItemDetail({ item, temporarilyUnavailable, randomItemId, isQA, pageDescription, canonicalUrl }) {
@@ -149,12 +149,14 @@ export async function getServerSideProps(context) {
   itemUrl.searchParams.set("api_key", process.env.API_KEY);
 
   const res = await safeFetch(itemUrl);
+  if (!res) {
+    console.warn(`[SSR] Item ${itemId} fetch returned null (network error)`);
+    return upstreamUnavailable(context.res);
+  }
   if (res?.status === 503) {
     console.warn(`[SSR] Item ${itemId} returned 503 after retry`);
     await res.body?.cancel();
-    context.res.statusCode = 503;
-    context.res.setHeader("Retry-After", "10");
-    return { props: { temporarilyUnavailable: true } };
+    return upstreamUnavailable(context.res);
   }
   const errorResult = checkResponseForSSRSafe(res, "Item");
   if (errorResult) return errorResult;

--- a/pages/news/[slug].js
+++ b/pages/news/[slug].js
@@ -22,6 +22,7 @@ import css from "stylesheets/news.module.scss";
 import { washObject } from "lib/washObject";
 import { safeFetch, checkResponseForSSRSafe, wpAuthFetchOptions } from "lib/safeFetch";
 import { upgradeWordPressUrls } from "lib/upgradeWordPressUrls";
+import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
 class PostPage extends React.Component {
   refreshExternalLinks() {
@@ -42,7 +43,8 @@ class PostPage extends React.Component {
   }
 
   render() {
-    const { content, menuItems, author, pageDescription } = this.props;
+    const { content, menuItems, author, pageDescription, temporarilyUnavailable } = this.props;
+    if (temporarilyUnavailable) return <ServiceUnavailable />;
     let hasTags = false;
     NEWS_TAGS.forEach((tag) => {
       if (content.tags.indexOf(tag.id) !== -1) {
@@ -151,6 +153,9 @@ export async function getServerSideProps(context) {
     safeFetch(`${NEWS_ENDPOINT}${postParams}`, authOptions),
   ]);
 
+  if (!menuResponse || !postRes) {
+    return upstreamUnavailable(context.res);
+  }
   const menuError = checkResponseForSSRSafe(menuResponse, "News menu");
   if (menuError) return menuError;
   const postError = checkResponseForSSRSafe(postRes, "News post");
@@ -169,6 +174,9 @@ export async function getServerSideProps(context) {
       `${NEWS_ENDPOINT}?include=${slug}&status=any&context=edit`,
       authOptions,
     );
+    if (!byIdRes) {
+      return upstreamUnavailable(context.res);
+    }
     const byIdError = checkResponseForSSRSafe(byIdRes, "News post by ID");
     if (byIdError) return byIdError;
     postJson = await byIdRes.json();
@@ -185,6 +193,9 @@ export async function getServerSideProps(context) {
     `${wordpressUrl}/wp-json/wp/v2/users/${postJson[0].author}`,
   );
 
+  if (!authorRes) {
+    return upstreamUnavailable(context.res);
+  }
   const authorError = checkResponseForSSRSafe(authorRes, "News post author");
   if (authorError) return authorError;
 

--- a/pages/news/[slug].js
+++ b/pages/news/[slug].js
@@ -20,7 +20,7 @@ import utils from "stylesheets/utils.module.scss";
 import contentCss from "stylesheets/content-pages.module.scss";
 import css from "stylesheets/news.module.scss";
 import { washObject } from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe, wpAuthFetchOptions, upstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, wpAuthFetchOptions, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
 import { upgradeWordPressUrls } from "lib/upgradeWordPressUrls";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
@@ -153,7 +153,9 @@ export async function getServerSideProps(context) {
     safeFetch(`${NEWS_ENDPOINT}${postParams}`, authOptions),
   ]);
 
-  if (!menuResponse || !postRes) {
+  if (isUpstreamUnavailable(menuResponse) || isUpstreamUnavailable(postRes)) {
+    await menuResponse?.body?.cancel();
+    await postRes?.body?.cancel();
     return upstreamUnavailable(context.res);
   }
   const menuError = checkResponseForSSRSafe(menuResponse, "News menu");
@@ -174,7 +176,8 @@ export async function getServerSideProps(context) {
       `${NEWS_ENDPOINT}?include=${slug}&status=any&context=edit`,
       authOptions,
     );
-    if (!byIdRes) {
+    if (isUpstreamUnavailable(byIdRes)) {
+      await byIdRes?.body?.cancel();
       return upstreamUnavailable(context.res);
     }
     const byIdError = checkResponseForSSRSafe(byIdRes, "News post by ID");
@@ -193,7 +196,8 @@ export async function getServerSideProps(context) {
     `${wordpressUrl}/wp-json/wp/v2/users/${postJson[0].author}`,
   );
 
-  if (!authorRes) {
+  if (isUpstreamUnavailable(authorRes)) {
+    await authorRes?.body?.cancel();
     return upstreamUnavailable(context.res);
   }
   const authorError = checkResponseForSSRSafe(authorRes, "News post author");

--- a/pages/news/[slug].js
+++ b/pages/news/[slug].js
@@ -154,9 +154,7 @@ export async function getServerSideProps(context) {
   ]);
 
   if (isUpstreamUnavailable(menuResponse) || isUpstreamUnavailable(postRes)) {
-    await menuResponse?.body?.cancel();
-    await postRes?.body?.cancel();
-    return upstreamUnavailable(context.res);
+    return upstreamUnavailable(context.res, menuResponse, postRes);
   }
   const menuError = checkResponseForSSRSafe(menuResponse, "News menu");
   if (menuError) return menuError;
@@ -177,8 +175,7 @@ export async function getServerSideProps(context) {
       authOptions,
     );
     if (isUpstreamUnavailable(byIdRes)) {
-      await byIdRes?.body?.cancel();
-      return upstreamUnavailable(context.res);
+      return upstreamUnavailable(context.res, byIdRes);
     }
     const byIdError = checkResponseForSSRSafe(byIdRes, "News post by ID");
     if (byIdError) return byIdError;
@@ -197,8 +194,7 @@ export async function getServerSideProps(context) {
   );
 
   if (isUpstreamUnavailable(authorRes)) {
-    await authorRes?.body?.cancel();
-    return upstreamUnavailable(context.res);
+    return upstreamUnavailable(context.res, authorRes);
   }
   const authorError = checkResponseForSSRSafe(authorRes, "News post author");
   if (authorError) return authorError;

--- a/pages/news/[slug].js
+++ b/pages/news/[slug].js
@@ -20,7 +20,7 @@ import utils from "stylesheets/utils.module.scss";
 import contentCss from "stylesheets/content-pages.module.scss";
 import css from "stylesheets/news.module.scss";
 import { washObject } from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe, wpAuthFetchOptions } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, wpAuthFetchOptions, upstreamUnavailable } from "lib/safeFetch";
 import { upgradeWordPressUrls } from "lib/upgradeWordPressUrls";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 

--- a/pages/news/index.js
+++ b/pages/news/index.js
@@ -147,9 +147,7 @@ export async function getServerSideProps({ query, res }) {
   ]);
 
   if (isUpstreamUnavailable(menuResponse)) {
-    await menuResponse?.body?.cancel();
-    await authorRes?.body?.cancel();
-    return upstreamUnavailable(res);
+    return upstreamUnavailable(res, menuResponse, authorRes);
   }
   const menuError = checkResponseForSSRSafe(menuResponse, "news menu");
   if (menuError) return menuError;
@@ -162,8 +160,7 @@ export async function getServerSideProps({ query, res }) {
   let authorJson = null;
   if (authorId !== "") {
     if (isUpstreamUnavailable(authorRes)) {
-      await authorRes?.body?.cancel();
-      return upstreamUnavailable(res);
+      return upstreamUnavailable(res, authorRes);
     }
     const authorError = checkResponseForSSRSafe(authorRes, "news author");
     if (authorError) return authorError;
@@ -192,8 +189,7 @@ export async function getServerSideProps({ query, res }) {
     // page numbers with a parseable JSON body, which the retry loop handles by
     // resetting to page 1. checkResponseForSSR would short-circuit to notFound.
     if (isUpstreamUnavailable(newsRes)) {
-      await newsRes?.body?.cancel();
-      return upstreamUnavailable(res);
+      return upstreamUnavailable(res, newsRes);
     }
     newsItems = await newsRes.json();
     newsCount = newsRes.headers.get("X-WP-Total");

--- a/pages/news/index.js
+++ b/pages/news/index.js
@@ -9,7 +9,8 @@ import TagList from "components/NewsComponents/TagList";
 import Button from "shared/Button";
 
 import { formatDate } from "lib";
-import { safeFetch, checkResponseForSSRSafe } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable } from "lib/safeFetch";
+import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
 import { DESCRIPTION, NEWS_TAGS, TITLE } from "constants/news";
 import {
@@ -36,7 +37,9 @@ function NewsPage({
   currentTag,
   keywords,
   author,
+  temporarilyUnavailable,
 }) {
+  if (temporarilyUnavailable) return <ServiceUnavailable />;
   const resultSummary =
     `${author ? " by " + author.name : ""}` +
     `${currentTag ? " under " + currentTag.name : ""}` +
@@ -127,7 +130,7 @@ function NewsPage({
   );
 }
 
-export async function getServerSideProps({ query }) {
+export async function getServerSideProps({ query, res }) {
   const siteEnv = process.env.NEXT_PUBLIC_SITE_ENV;
   const wordPressUrl = process.env.NEXT_PUBLIC_WORDPRESS_URL;
 
@@ -143,6 +146,9 @@ export async function getServerSideProps({ query }) {
       : Promise.resolve(null),
   ]);
 
+  if (!menuResponse) {
+    return upstreamUnavailable(res);
+  }
   const menuError = checkResponseForSSRSafe(menuResponse, "news menu");
   if (menuError) return menuError;
   const menuJson = await menuResponse.json();
@@ -153,6 +159,9 @@ export async function getServerSideProps({ query }) {
 
   let authorJson = null;
   if (authorId !== "") {
+    if (!authorRes) {
+      return upstreamUnavailable(res);
+    }
     const authorError = checkResponseForSSRSafe(authorRes, "news author");
     if (authorError) return authorError;
     authorJson = await authorRes.json();
@@ -179,7 +188,9 @@ export async function getServerSideProps({ query }) {
     // Only guard against network errors here — WP returns HTTP 400 for invalid
     // page numbers with a parseable JSON body, which the retry loop handles by
     // resetting to page 1. checkResponseForSSR would short-circuit to notFound.
-    if (!newsRes) throw new Error("Upstream fetch failed: network error");
+    if (!newsRes) {
+      return upstreamUnavailable(res);
+    }
     newsItems = await newsRes.json();
     newsCount = newsRes.headers.get("X-WP-Total");
     newsPageCount = newsRes.headers.get("X-WP-TotalPages");

--- a/pages/news/index.js
+++ b/pages/news/index.js
@@ -148,6 +148,7 @@ export async function getServerSideProps({ query, res }) {
 
   if (isUpstreamUnavailable(menuResponse)) {
     await menuResponse?.body?.cancel();
+    await authorRes?.body?.cancel();
     return upstreamUnavailable(res);
   }
   const menuError = checkResponseForSSRSafe(menuResponse, "news menu");

--- a/pages/news/index.js
+++ b/pages/news/index.js
@@ -9,7 +9,7 @@ import TagList from "components/NewsComponents/TagList";
 import Button from "shared/Button";
 
 import { formatDate } from "lib";
-import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
 import { DESCRIPTION, NEWS_TAGS, TITLE } from "constants/news";
@@ -146,7 +146,8 @@ export async function getServerSideProps({ query, res }) {
       : Promise.resolve(null),
   ]);
 
-  if (!menuResponse) {
+  if (isUpstreamUnavailable(menuResponse)) {
+    await menuResponse?.body?.cancel();
     return upstreamUnavailable(res);
   }
   const menuError = checkResponseForSSRSafe(menuResponse, "news menu");
@@ -159,7 +160,8 @@ export async function getServerSideProps({ query, res }) {
 
   let authorJson = null;
   if (authorId !== "") {
-    if (!authorRes) {
+    if (isUpstreamUnavailable(authorRes)) {
+      await authorRes?.body?.cancel();
       return upstreamUnavailable(res);
     }
     const authorError = checkResponseForSSRSafe(authorRes, "news author");
@@ -188,7 +190,8 @@ export async function getServerSideProps({ query, res }) {
     // Only guard against network errors here — WP returns HTTP 400 for invalid
     // page numbers with a parseable JSON body, which the retry loop handles by
     // resetting to page 1. checkResponseForSSR would short-circuit to notFound.
-    if (!newsRes) {
+    if (isUpstreamUnavailable(newsRes)) {
+      await newsRes?.body?.cancel();
       return upstreamUnavailable(res);
     }
     newsItems = await newsRes.json();

--- a/pages/primary-source-sets/[set]/additional-resources.js
+++ b/pages/primary-source-sets/[set]/additional-resources.js
@@ -71,8 +71,7 @@ export async function getServerSideProps({ query, res }) {
     `${process.env.API_URL}/pss/sets/${encodeURIComponent(query.set)}?api_key=${process.env.API_KEY}`,
   );
   if (isUpstreamUnavailable(setRes)) {
-    await setRes?.body?.cancel();
-    return upstreamUnavailable(res);
+    return upstreamUnavailable(res, setRes);
   }
   const setError = checkResponseForSSRSafe(setRes, `set "${query.set}"`);
   if (setError) return setError;

--- a/pages/primary-source-sets/[set]/additional-resources.js
+++ b/pages/primary-source-sets/[set]/additional-resources.js
@@ -14,7 +14,7 @@ import utils from "stylesheets/utils.module.scss";
 import contentCss from "stylesheets/content-pages.module.scss";
 import css from "components/PrimarySourceSetsComponents/SingleSet/TeachersGuide/TeachersGuide.module.scss";
 import {washObject} from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
 import isValidPSSSlug from "lib/isValidPSSSlug";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
@@ -70,7 +70,8 @@ export async function getServerSideProps({ query, res }) {
   const setRes = await safeFetch(
     `${process.env.API_URL}/pss/sets/${encodeURIComponent(query.set)}?api_key=${process.env.API_KEY}`,
   );
-  if (!setRes) {
+  if (isUpstreamUnavailable(setRes)) {
+    await setRes?.body?.cancel();
     return upstreamUnavailable(res);
   }
   const setError = checkResponseForSSRSafe(setRes, `set "${query.set}"`);

--- a/pages/primary-source-sets/[set]/additional-resources.js
+++ b/pages/primary-source-sets/[set]/additional-resources.js
@@ -14,10 +14,12 @@ import utils from "stylesheets/utils.module.scss";
 import contentCss from "stylesheets/content-pages.module.scss";
 import css from "components/PrimarySourceSetsComponents/SingleSet/TeachersGuide/TeachersGuide.module.scss";
 import {washObject} from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable } from "lib/safeFetch";
 import isValidPSSSlug from "lib/isValidPSSSlug";
+import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
-function SingleSet({router, set, currentFullUrl}) {
+function SingleSet({ router, set, currentFullUrl, temporarilyUnavailable }) {
+  if (temporarilyUnavailable) return <ServiceUnavailable />;
   if (!set) return null;
   return (
     <MainLayout
@@ -62,12 +64,15 @@ function SingleSet({router, set, currentFullUrl}) {
   );
 }
 
-export async function getServerSideProps({query}) {
+export async function getServerSideProps({ query, res }) {
   if (!isValidPSSSlug(query.set)) return { notFound: true };
   const currentFullUrl = `${process.env.BASE_URL}/primary-source-sets/${query.set}`;
   const setRes = await safeFetch(
     `${process.env.API_URL}/pss/sets/${encodeURIComponent(query.set)}?api_key=${process.env.API_KEY}`,
   );
+  if (!setRes) {
+    return upstreamUnavailable(res);
+  }
   const setError = checkResponseForSSRSafe(setRes, `set "${query.set}"`);
   if (setError) return setError;
   const set = await setRes.json();

--- a/pages/primary-source-sets/[set]/index.js
+++ b/pages/primary-source-sets/[set]/index.js
@@ -11,7 +11,7 @@ import SourceSetSources from "components/PrimarySourceSetsComponents/SingleSet/S
 
 import { removeQueryParams } from "lib";
 import { washObject } from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
 import isValidPSSSlug from "lib/isValidPSSSlug";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
@@ -59,7 +59,8 @@ export async function getServerSideProps(context) {
   const api = await safeFetch(
     `${process.env.API_URL}/pss/sets/${encodeURIComponent(set)}?api_key=${process.env.API_KEY}`,
   );
-  if (!api) {
+  if (isUpstreamUnavailable(api)) {
+    await api?.body?.cancel();
     return upstreamUnavailable(context.res);
   }
   const apiError = checkResponseForSSRSafe(api, `set "${set}"`);

--- a/pages/primary-source-sets/[set]/index.js
+++ b/pages/primary-source-sets/[set]/index.js
@@ -60,8 +60,7 @@ export async function getServerSideProps(context) {
     `${process.env.API_URL}/pss/sets/${encodeURIComponent(set)}?api_key=${process.env.API_KEY}`,
   );
   if (isUpstreamUnavailable(api)) {
-    await api?.body?.cancel();
-    return upstreamUnavailable(context.res);
+    return upstreamUnavailable(context.res, api);
   }
   const apiError = checkResponseForSSRSafe(api, `set "${set}"`);
   if (apiError) return apiError;

--- a/pages/primary-source-sets/[set]/index.js
+++ b/pages/primary-source-sets/[set]/index.js
@@ -11,14 +11,16 @@ import SourceSetSources from "components/PrimarySourceSetsComponents/SingleSet/S
 
 import { removeQueryParams } from "lib";
 import { washObject } from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable } from "lib/safeFetch";
 import isValidPSSSlug from "lib/isValidPSSSlug";
+import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
 const videoIcon = "/static/placeholderImages/Video.svg";
 const audioIcon = "/static/placeholderImages/Sound.svg";
 
-function SingleSet({ set }) {
+function SingleSet({ set, temporarilyUnavailable }) {
   const router = useRouter();
+  if (temporarilyUnavailable) return <ServiceUnavailable />;
   if (!set) return null;
   return (
     <MainLayout
@@ -57,6 +59,9 @@ export async function getServerSideProps(context) {
   const api = await safeFetch(
     `${process.env.API_URL}/pss/sets/${encodeURIComponent(set)}?api_key=${process.env.API_KEY}`,
   );
+  if (!api) {
+    return upstreamUnavailable(context.res);
+  }
   const apiError = checkResponseForSSRSafe(api, `set "${set}"`);
   if (apiError) return apiError;
 

--- a/pages/primary-source-sets/[set]/sources/[source].js
+++ b/pages/primary-source-sets/[set]/sources/[source].js
@@ -9,14 +9,16 @@ import SourceCarousel from "components/PrimarySourceSetsComponents/Source/compon
 
 import { removeQueryParams } from "lib";
 import { washObject } from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable } from "lib/safeFetch";
 import isValidPSSSlug from "lib/isValidPSSSlug";
+import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
 const videoIcon = "/static/placeholderImages/Video.svg";
 const audioIcon = "/static/placeholderImages/Sound.svg";
 
-function Source({ source, set, currentSourceIdx }) {
+function Source({ source, set, currentSourceIdx, temporarilyUnavailable }) {
   const router = useRouter();
+  if (temporarilyUnavailable) return <ServiceUnavailable />;
   if (!source || !set) return null;
   return (
     <MainLayout pageTitle={source.name} pageImage={source.thumbnailUrl}>
@@ -60,6 +62,9 @@ export async function getServerSideProps(context) {
     safeFetch(`${process.env.API_URL}/pss/sources/${encodeURIComponent(source)}?api_key=${process.env.API_KEY}`),
     safeFetch(`${process.env.API_URL}/pss/sets/${encodeURIComponent(set)}?api_key=${process.env.API_KEY}`),
   ]);
+  if (!sourceRes || !setRes) {
+    return upstreamUnavailable(context.res);
+  }
   const sourceError = checkResponseForSSRSafe(sourceRes, `source "${source}"`);
   if (sourceError) return sourceError;
   const setError = checkResponseForSSRSafe(setRes, `set "${set}"`);

--- a/pages/primary-source-sets/[set]/sources/[source].js
+++ b/pages/primary-source-sets/[set]/sources/[source].js
@@ -63,9 +63,7 @@ export async function getServerSideProps(context) {
     safeFetch(`${process.env.API_URL}/pss/sets/${encodeURIComponent(set)}?api_key=${process.env.API_KEY}`),
   ]);
   if (isUpstreamUnavailable(sourceRes) || isUpstreamUnavailable(setRes)) {
-    await sourceRes?.body?.cancel();
-    await setRes?.body?.cancel();
-    return upstreamUnavailable(context.res);
+    return upstreamUnavailable(context.res, sourceRes, setRes);
   }
   const sourceError = checkResponseForSSRSafe(sourceRes, `source "${source}"`);
   if (sourceError) return sourceError;

--- a/pages/primary-source-sets/[set]/sources/[source].js
+++ b/pages/primary-source-sets/[set]/sources/[source].js
@@ -9,7 +9,7 @@ import SourceCarousel from "components/PrimarySourceSetsComponents/Source/compon
 
 import { removeQueryParams } from "lib";
 import { washObject } from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
 import isValidPSSSlug from "lib/isValidPSSSlug";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
@@ -62,7 +62,9 @@ export async function getServerSideProps(context) {
     safeFetch(`${process.env.API_URL}/pss/sources/${encodeURIComponent(source)}?api_key=${process.env.API_KEY}`),
     safeFetch(`${process.env.API_URL}/pss/sets/${encodeURIComponent(set)}?api_key=${process.env.API_KEY}`),
   ]);
-  if (!sourceRes || !setRes) {
+  if (isUpstreamUnavailable(sourceRes) || isUpstreamUnavailable(setRes)) {
+    await sourceRes?.body?.cancel();
+    await setRes?.body?.cancel();
     return upstreamUnavailable(context.res);
   }
   const sourceError = checkResponseForSSRSafe(sourceRes, `source "${source}"`);

--- a/pages/primary-source-sets/[set]/teaching-guide-print.js
+++ b/pages/primary-source-sets/[set]/teaching-guide-print.js
@@ -7,8 +7,9 @@ import TeachersGuide from "components/PrimarySourceSetsComponents/SingleSet/Teac
 
 import utils from "stylesheets/utils.module.scss";
 import { washObject } from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable } from "lib/safeFetch";
 import isValidPSSSlug from "lib/isValidPSSSlug";
+import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
 class Printable extends React.Component {
   componentDidMount() {
@@ -16,7 +17,8 @@ class Printable extends React.Component {
   }
 
   render() {
-    const { set, teachingGuide } = this.props;
+    const { set, teachingGuide, temporarilyUnavailable } = this.props;
+    if (temporarilyUnavailable) return <ServiceUnavailable />;
     if (!set) return null;
     return (
       <MinimalLayout route={this.props.router} isPrintable={true}>
@@ -38,10 +40,13 @@ class Printable extends React.Component {
   }
 }
 
-export async function getServerSideProps({ query }) {
+export async function getServerSideProps({ query, res }) {
   if (!isValidPSSSlug(query.set)) return { notFound: true };
   const url = `${process.env.API_URL}/pss/sets/${encodeURIComponent(query.set)}?api_key=${process.env.API_KEY}`;
   const setRes = await safeFetch(url);
+  if (!setRes) {
+    return upstreamUnavailable(res);
+  }
   const setError = checkResponseForSSRSafe(setRes, `set "${query.set}"`);
   if (setError) return setError;
   const set = await setRes.json();

--- a/pages/primary-source-sets/[set]/teaching-guide-print.js
+++ b/pages/primary-source-sets/[set]/teaching-guide-print.js
@@ -45,8 +45,7 @@ export async function getServerSideProps({ query, res }) {
   const url = `${process.env.API_URL}/pss/sets/${encodeURIComponent(query.set)}?api_key=${process.env.API_KEY}`;
   const setRes = await safeFetch(url);
   if (isUpstreamUnavailable(setRes)) {
-    await setRes?.body?.cancel();
-    return upstreamUnavailable(res);
+    return upstreamUnavailable(res, setRes);
   }
   const setError = checkResponseForSSRSafe(setRes, `set "${query.set}"`);
   if (setError) return setError;

--- a/pages/primary-source-sets/[set]/teaching-guide-print.js
+++ b/pages/primary-source-sets/[set]/teaching-guide-print.js
@@ -7,13 +7,13 @@ import TeachersGuide from "components/PrimarySourceSetsComponents/SingleSet/Teac
 
 import utils from "stylesheets/utils.module.scss";
 import { washObject } from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
 import isValidPSSSlug from "lib/isValidPSSSlug";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
 class Printable extends React.Component {
   componentDidMount() {
-    window.print();
+    if (!this.props.temporarilyUnavailable) window.print();
   }
 
   render() {
@@ -44,7 +44,8 @@ export async function getServerSideProps({ query, res }) {
   if (!isValidPSSSlug(query.set)) return { notFound: true };
   const url = `${process.env.API_URL}/pss/sets/${encodeURIComponent(query.set)}?api_key=${process.env.API_KEY}`;
   const setRes = await safeFetch(url);
-  if (!setRes) {
+  if (isUpstreamUnavailable(setRes)) {
+    await setRes?.body?.cancel();
     return upstreamUnavailable(res);
   }
   const setError = checkResponseForSSRSafe(setRes, `set "${query.set}"`);

--- a/pages/primary-source-sets/[set]/teaching-guide.js
+++ b/pages/primary-source-sets/[set]/teaching-guide.js
@@ -10,10 +10,12 @@ import TeachersGuide from "components/PrimarySourceSetsComponents/SingleSet/Teac
 
 import { removeQueryParams } from "lib";
 import { washObject } from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable } from "lib/safeFetch";
 import isValidPSSSlug from "lib/isValidPSSSlug";
+import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
-function SingleSet({ router, set, teachingGuide, currentFullUrl }) {
+function SingleSet({ router, set, teachingGuide, currentFullUrl, temporarilyUnavailable }) {
+  if (temporarilyUnavailable) return <ServiceUnavailable />;
   if (!set) return null;
   return (
     <MainLayout
@@ -41,11 +43,14 @@ function SingleSet({ router, set, teachingGuide, currentFullUrl }) {
   );
 }
 
-export async function getServerSideProps({ query }) {
+export async function getServerSideProps({ query, res }) {
   if (!isValidPSSSlug(query.set)) return { notFound: true };
   const currentFullUrl = `${process.env.BASE_URL}/primary-source-sets/${query.set}`;
   const url = `${process.env.API_URL}/pss/sets/${encodeURIComponent(query.set)}?api_key=${process.env.API_KEY}`;
   const setRes = await safeFetch(url);
+  if (!setRes) {
+    return upstreamUnavailable(res);
+  }
   const setError = checkResponseForSSRSafe(setRes, `set "${query.set}"`);
   if (setError) return setError;
   const set = await setRes.json();

--- a/pages/primary-source-sets/[set]/teaching-guide.js
+++ b/pages/primary-source-sets/[set]/teaching-guide.js
@@ -49,8 +49,7 @@ export async function getServerSideProps({ query, res }) {
   const url = `${process.env.API_URL}/pss/sets/${encodeURIComponent(query.set)}?api_key=${process.env.API_KEY}`;
   const setRes = await safeFetch(url);
   if (isUpstreamUnavailable(setRes)) {
-    await setRes?.body?.cancel();
-    return upstreamUnavailable(res);
+    return upstreamUnavailable(res, setRes);
   }
   const setError = checkResponseForSSRSafe(setRes, `set "${query.set}"`);
   if (setError) return setError;

--- a/pages/primary-source-sets/[set]/teaching-guide.js
+++ b/pages/primary-source-sets/[set]/teaching-guide.js
@@ -10,7 +10,7 @@ import TeachersGuide from "components/PrimarySourceSetsComponents/SingleSet/Teac
 
 import { removeQueryParams } from "lib";
 import { washObject } from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
 import isValidPSSSlug from "lib/isValidPSSSlug";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
@@ -48,7 +48,8 @@ export async function getServerSideProps({ query, res }) {
   const currentFullUrl = `${process.env.BASE_URL}/primary-source-sets/${query.set}`;
   const url = `${process.env.API_URL}/pss/sets/${encodeURIComponent(query.set)}?api_key=${process.env.API_KEY}`;
   const setRes = await safeFetch(url);
-  if (!setRes) {
+  if (isUpstreamUnavailable(setRes)) {
+    await setRes?.body?.cancel();
     return upstreamUnavailable(res);
   }
   const setError = checkResponseForSSRSafe(setRes, `set "${query.set}"`);

--- a/pages/primary-source-sets/index.js
+++ b/pages/primary-source-sets/index.js
@@ -4,7 +4,8 @@ import MainLayout from "components/MainLayout";
 import AllSets from "components/PrimarySourceSetsComponents/AllSets";
 import PSSFooter from "components/PrimarySourceSetsComponents/PSSFooter";
 import {washObject} from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable } from "lib/safeFetch";
+import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
 import {
   subjectOptions,
@@ -12,8 +13,8 @@ import {
   TITLE,
 } from "constants/primarySourceSets";
 
-function PrimarySourceSets(props) {
-  const {sets} = props;
+function PrimarySourceSets({ sets, temporarilyUnavailable }) {
+  if (temporarilyUnavailable) return <ServiceUnavailable />;
   return (
     <div>
       <MainLayout pageTitle={TITLE}>
@@ -26,7 +27,7 @@ function PrimarySourceSets(props) {
   );
 }
 
-export async function getServerSideProps({query}) {
+export async function getServerSideProps({ query, res }) {
   const findTimePeriod = query.timePeriod && query.timePeriod !== "all-time-periods" ? timePeriodOptions.find(
     (option) => option.value === query.timePeriod,
   ) : null;
@@ -46,10 +47,13 @@ export async function getServerSideProps({query}) {
     filter = `&filter=about.name:${encodeURIComponent(subject)}`;
   }
   const url = `${process.env.API_URL}/pss/sets?api_key=${process.env.API_KEY}${filter}`;
-  const res = await safeFetch(url);
-  const resError = checkResponseForSSRSafe(res, "PSS sets");
+  const fetchRes = await safeFetch(url);
+  if (!fetchRes) {
+    return upstreamUnavailable(res);
+  }
+  const resError = checkResponseForSSRSafe(fetchRes, "PSS sets");
   if (resError) return resError;
-  const json = await res.json();
+  const json = await fetchRes.json();
   const props = washObject({
     sets: json,
   });

--- a/pages/primary-source-sets/index.js
+++ b/pages/primary-source-sets/index.js
@@ -4,7 +4,7 @@ import MainLayout from "components/MainLayout";
 import AllSets from "components/PrimarySourceSetsComponents/AllSets";
 import PSSFooter from "components/PrimarySourceSetsComponents/PSSFooter";
 import {washObject} from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
 import {
@@ -48,7 +48,8 @@ export async function getServerSideProps({ query, res }) {
   }
   const url = `${process.env.API_URL}/pss/sets?api_key=${process.env.API_KEY}${filter}`;
   const fetchRes = await safeFetch(url);
-  if (!fetchRes) {
+  if (isUpstreamUnavailable(fetchRes)) {
+    await fetchRes?.body?.cancel();
     return upstreamUnavailable(res);
   }
   const resError = checkResponseForSSRSafe(fetchRes, "PSS sets");

--- a/pages/primary-source-sets/index.js
+++ b/pages/primary-source-sets/index.js
@@ -49,8 +49,7 @@ export async function getServerSideProps({ query, res }) {
   const url = `${process.env.API_URL}/pss/sets?api_key=${process.env.API_KEY}${filter}`;
   const fetchRes = await safeFetch(url);
   if (isUpstreamUnavailable(fetchRes)) {
-    await fetchRes?.body?.cancel();
-    return upstreamUnavailable(res);
+    return upstreamUnavailable(res, fetchRes);
   }
   const resError = checkResponseForSSRSafe(fetchRes, "PSS sets");
   if (resError) return resError;

--- a/pages/pro/index.js
+++ b/pages/pro/index.js
@@ -33,7 +33,7 @@ export async function getServerSideProps(context) {
     return upstreamUnavailable(context.res, settingsRes, newsRes);
   }
   if (isUpstreamUnavailable(newsRes)) {
-    await newsRes?.body?.cancel();
+    await Promise.allSettled([newsRes?.body?.cancel?.()]);
   }
   const settingsError = checkResponseForSSRSafe(settingsRes, "Pro settings");
   if (settingsError) return settingsError;

--- a/pages/pro/index.js
+++ b/pages/pro/index.js
@@ -29,12 +29,7 @@ export async function getServerSideProps(context) {
     cachedSafeFetch(API_SETTINGS_ENDPOINT),
     cachedSafeFetch(NEWS_PRO_ENDPOINT),
   ]);
-  if (isUpstreamUnavailable(newsRes)) {
-    await settingsRes?.body?.cancel();
-    await newsRes?.body?.cancel();
-    return upstreamUnavailable(context.res);
-  }
-  if (isUpstreamUnavailable(settingsRes)) {
+  if (isUpstreamUnavailable(newsRes) || isUpstreamUnavailable(settingsRes)) {
     await newsRes?.body?.cancel();
     await settingsRes?.body?.cancel();
     return upstreamUnavailable(context.res);

--- a/pages/pro/index.js
+++ b/pages/pro/index.js
@@ -6,7 +6,7 @@ import HomePro from "components/HomePageComponents/HomePro";
 import { NEWS_PRO_ENDPOINT, PAGES_ENDPOINT } from "constants/content-pages";
 import { API_SETTINGS_ENDPOINT } from "constants/site";
 import { washObject } from "lib/washObject";
-import { checkResponseForSSRSafe, wpAuthFetchOptions, wpDraftUrl, upstreamUnavailable } from "lib/safeFetch";
+import { checkResponseForSSRSafe, wpAuthFetchOptions, wpDraftUrl, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
 import { cachedSafeFetch } from "lib/wpCache";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
@@ -29,7 +29,8 @@ export async function getServerSideProps(context) {
     cachedSafeFetch(API_SETTINGS_ENDPOINT),
     cachedSafeFetch(NEWS_PRO_ENDPOINT),
   ]);
-  if (!settingsRes) {
+  if (isUpstreamUnavailable(settingsRes)) {
+    await settingsRes?.body?.cancel();
     return upstreamUnavailable(context.res);
   }
   const settingsError = checkResponseForSSRSafe(settingsRes, "Pro settings");
@@ -40,7 +41,8 @@ export async function getServerSideProps(context) {
   const baseEndpoint = `${PAGES_ENDPOINT}/${settingsJson.acf.pro_homepage_endpoint}`;
   const endpoint = draftMode ? wpDraftUrl(baseEndpoint) : baseEndpoint;
   const homeRes = await cachedSafeFetch(endpoint, authOptions);
-  if (!homeRes) {
+  if (isUpstreamUnavailable(homeRes)) {
+    await homeRes?.body?.cancel();
     return upstreamUnavailable(context.res);
   }
   const homeError = checkResponseForSSRSafe(homeRes, "Pro homepage");

--- a/pages/pro/index.js
+++ b/pages/pro/index.js
@@ -30,9 +30,7 @@ export async function getServerSideProps(context) {
     cachedSafeFetch(NEWS_PRO_ENDPOINT),
   ]);
   if (isUpstreamUnavailable(newsRes) || isUpstreamUnavailable(settingsRes)) {
-    await newsRes?.body?.cancel();
-    await settingsRes?.body?.cancel();
-    return upstreamUnavailable(context.res);
+    return upstreamUnavailable(context.res, newsRes, settingsRes);
   }
   const settingsError = checkResponseForSSRSafe(settingsRes, "Pro settings");
   if (settingsError) return settingsError;
@@ -43,9 +41,7 @@ export async function getServerSideProps(context) {
   const endpoint = draftMode ? wpDraftUrl(baseEndpoint) : baseEndpoint;
   const homeRes = await cachedSafeFetch(endpoint, authOptions);
   if (isUpstreamUnavailable(homeRes)) {
-    await newsRes?.body?.cancel();
-    await homeRes?.body?.cancel();
-    return upstreamUnavailable(context.res);
+    return upstreamUnavailable(context.res, newsRes, homeRes);
   }
   const homeError = checkResponseForSSRSafe(homeRes, "Pro homepage");
   if (homeError) return homeError;

--- a/pages/pro/index.js
+++ b/pages/pro/index.js
@@ -6,10 +6,12 @@ import HomePro from "components/HomePageComponents/HomePro";
 import { NEWS_PRO_ENDPOINT, PAGES_ENDPOINT } from "constants/content-pages";
 import { API_SETTINGS_ENDPOINT } from "constants/site";
 import { washObject } from "lib/washObject";
-import { checkResponseForSSRSafe, wpAuthFetchOptions, wpDraftUrl } from "lib/safeFetch";
+import { checkResponseForSSRSafe, wpAuthFetchOptions, wpDraftUrl, upstreamUnavailable } from "lib/safeFetch";
 import { cachedSafeFetch } from "lib/wpCache";
+import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
-function Home({ news, content }) {
+function Home({ news, content, temporarilyUnavailable }) {
+  if (temporarilyUnavailable) return <ServiceUnavailable />;
   return (
     <MainLayout hidePageHeader={false} hideSearchBar={true}>
       <div id="main" role="main">
@@ -27,6 +29,9 @@ export async function getServerSideProps(context) {
     cachedSafeFetch(API_SETTINGS_ENDPOINT),
     cachedSafeFetch(NEWS_PRO_ENDPOINT),
   ]);
+  if (!settingsRes) {
+    return upstreamUnavailable(context.res);
+  }
   const settingsError = checkResponseForSSRSafe(settingsRes, "Pro settings");
   if (settingsError) return settingsError;
   const settingsJson = await settingsRes.json();
@@ -35,6 +40,9 @@ export async function getServerSideProps(context) {
   const baseEndpoint = `${PAGES_ENDPOINT}/${settingsJson.acf.pro_homepage_endpoint}`;
   const endpoint = draftMode ? wpDraftUrl(baseEndpoint) : baseEndpoint;
   const homeRes = await cachedSafeFetch(endpoint, authOptions);
+  if (!homeRes) {
+    return upstreamUnavailable(context.res);
+  }
   const homeError = checkResponseForSSRSafe(homeRes, "Pro homepage");
   if (homeError) return homeError;
   const [homeJson, newsItems] = await Promise.all([

--- a/pages/pro/index.js
+++ b/pages/pro/index.js
@@ -29,8 +29,11 @@ export async function getServerSideProps(context) {
     cachedSafeFetch(API_SETTINGS_ENDPOINT),
     cachedSafeFetch(NEWS_PRO_ENDPOINT),
   ]);
-  if (isUpstreamUnavailable(newsRes) || isUpstreamUnavailable(settingsRes)) {
-    return upstreamUnavailable(context.res, newsRes, settingsRes);
+  if (isUpstreamUnavailable(settingsRes)) {
+    return upstreamUnavailable(context.res, settingsRes, newsRes);
+  }
+  if (isUpstreamUnavailable(newsRes)) {
+    await newsRes?.body?.cancel();
   }
   const settingsError = checkResponseForSSRSafe(settingsRes, "Pro settings");
   if (settingsError) return settingsError;

--- a/pages/pro/index.js
+++ b/pages/pro/index.js
@@ -29,7 +29,13 @@ export async function getServerSideProps(context) {
     cachedSafeFetch(API_SETTINGS_ENDPOINT),
     cachedSafeFetch(NEWS_PRO_ENDPOINT),
   ]);
+  if (isUpstreamUnavailable(newsRes)) {
+    await settingsRes?.body?.cancel();
+    await newsRes?.body?.cancel();
+    return upstreamUnavailable(context.res);
+  }
   if (isUpstreamUnavailable(settingsRes)) {
+    await newsRes?.body?.cancel();
     await settingsRes?.body?.cancel();
     return upstreamUnavailable(context.res);
   }
@@ -42,6 +48,7 @@ export async function getServerSideProps(context) {
   const endpoint = draftMode ? wpDraftUrl(baseEndpoint) : baseEndpoint;
   const homeRes = await cachedSafeFetch(endpoint, authOptions);
   if (isUpstreamUnavailable(homeRes)) {
+    await newsRes?.body?.cancel();
     await homeRes?.body?.cancel();
     return upstreamUnavailable(context.res);
   }

--- a/pages/pro/wp/index.js
+++ b/pages/pro/wp/index.js
@@ -121,8 +121,7 @@ export async function getServerSideProps(context) {
   const authOptions = wpAuthFetchOptions(draftMode);
   const menuResponse = await cachedSafeFetch(PRO_MENU_ENDPOINT);
   if (isUpstreamUnavailable(menuResponse)) {
-    await menuResponse?.body?.cancel();
-    return upstreamUnavailable(context.res);
+    return upstreamUnavailable(context.res, menuResponse);
   }
   const menuError = checkResponseForSSRSafe(menuResponse, "Pro menu");
   if (menuError) return menuError;
@@ -136,8 +135,7 @@ export async function getServerSideProps(context) {
   const pageUrl = draftMode ? wpDraftUrl(getMenuItemUrl(pageItem)) : getMenuItemUrl(pageItem);
   const pageRes = await safeFetch(pageUrl, authOptions);
   if (isUpstreamUnavailable(pageRes)) {
-    await pageRes?.body?.cancel();
-    return upstreamUnavailable(context.res);
+    return upstreamUnavailable(context.res, pageRes);
   }
   const pageError = checkResponseForSSRSafe(pageRes, "Pro page");
   if (pageError) return pageError;

--- a/pages/pro/wp/index.js
+++ b/pages/pro/wp/index.js
@@ -14,8 +14,9 @@ import {
   decodeHTMLEntities,
   wordpressLinks,
 } from "lib";
-import { safeFetch, checkResponseForSSRSafe, wpAuthFetchOptions, wpDraftUrl } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, wpAuthFetchOptions, wpDraftUrl, upstreamUnavailable } from "lib/safeFetch";
 import { cachedSafeFetch } from "lib/wpCache";
+import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
 import { PRO_MENU_ENDPOINT, SEO_TYPE } from "constants/content-pages";
 
@@ -49,7 +50,9 @@ class ProMenuPage extends React.Component {
       pageTitle,
       pageDescription,
       illustration,
+      temporarilyUnavailable,
     } = this.props;
+    if (temporarilyUnavailable) return <ServiceUnavailable />;
     return (
       <MainLayout
         pageTitle={pageTitle}
@@ -117,6 +120,9 @@ export async function getServerSideProps(context) {
   const { draftMode } = context;
   const authOptions = wpAuthFetchOptions(draftMode);
   const menuResponse = await cachedSafeFetch(PRO_MENU_ENDPOINT);
+  if (!menuResponse) {
+    return upstreamUnavailable(context.res);
+  }
   const menuError = checkResponseForSSRSafe(menuResponse, "Pro menu");
   if (menuError) return menuError;
   const menuJson = await menuResponse.json();
@@ -128,6 +134,9 @@ export async function getServerSideProps(context) {
   // In draft mode, append context=edit so WP returns draft content
   const pageUrl = draftMode ? wpDraftUrl(getMenuItemUrl(pageItem)) : getMenuItemUrl(pageItem);
   const pageRes = await safeFetch(pageUrl, authOptions);
+  if (!pageRes) {
+    return upstreamUnavailable(context.res);
+  }
   const pageError = checkResponseForSSRSafe(pageRes, "Pro page");
   if (pageError) return pageError;
   const pageJson = await pageRes.json();

--- a/pages/pro/wp/index.js
+++ b/pages/pro/wp/index.js
@@ -14,7 +14,7 @@ import {
   decodeHTMLEntities,
   wordpressLinks,
 } from "lib";
-import { safeFetch, checkResponseForSSRSafe, wpAuthFetchOptions, wpDraftUrl, upstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, wpAuthFetchOptions, wpDraftUrl, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
 import { cachedSafeFetch } from "lib/wpCache";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
@@ -120,7 +120,8 @@ export async function getServerSideProps(context) {
   const { draftMode } = context;
   const authOptions = wpAuthFetchOptions(draftMode);
   const menuResponse = await cachedSafeFetch(PRO_MENU_ENDPOINT);
-  if (!menuResponse) {
+  if (isUpstreamUnavailable(menuResponse)) {
+    await menuResponse?.body?.cancel();
     return upstreamUnavailable(context.res);
   }
   const menuError = checkResponseForSSRSafe(menuResponse, "Pro menu");
@@ -134,7 +135,8 @@ export async function getServerSideProps(context) {
   // In draft mode, append context=edit so WP returns draft content
   const pageUrl = draftMode ? wpDraftUrl(getMenuItemUrl(pageItem)) : getMenuItemUrl(pageItem);
   const pageRes = await safeFetch(pageUrl, authOptions);
-  if (!pageRes) {
+  if (isUpstreamUnavailable(pageRes)) {
+    await pageRes?.body?.cancel();
     return upstreamUnavailable(context.res);
   }
   const pageError = checkResponseForSSRSafe(pageRes, "Pro page");


### PR DESCRIPTION
## Summary

- Adds `upstreamUnavailable(res)` helper to `lib/safeFetch` that sets HTTP 503 + `Retry-After: 10` and returns `{ props: { temporarilyUnavailable: true } }` — replacing 20+ identical inline blocks
- Adds `components/shared/ServiceUnavailable` page component rendered when the prop is set
- Applies null checks in all 14 `getServerSideProps` handlers that call `safeFetch`: PSS (6 pages), item, news (2), guides, browse-by-topic, browse-by-partner, pro (2)
- Fixes `news/index.js` which was throwing (→ HTTP 500) on null newsRes; now returns 503

**Before:** `safeFetch` returns `null` on network failure → `checkResponseForSSRSafe` catches the throw → `{ notFound: true }` → Next.js renders the 404 page with HTTP 404. Crawlers treat the page as permanently gone.

**After:** null check fires first → HTTP 503 + `Retry-After: 10` → "temporarily unavailable" page. Crawlers retry instead of deindexing.

## Context

Investigated Sentry issues DPLA-FRONTEND-1CP (PSS source pages, 759 events) and DPLA-FRONTEND-1CN (item pages, 1049 events). Both were triggered by an internal crawler hitting all PSS source and item pages in a ~9-minute burst on March 12, overwhelming `api.dp.la` with concurrent requests. The code at the time threw on network errors; it was refactored to use `safeFetch` + `checkResponseForSSRSafe` shortly after, but that silently converted network failures to 404s rather than 503s.

## Test plan

- [ ] Load a PSS source page, set page, guide, additional resources, and item page while `API_URL` is unreachable — should see "temporarily unavailable" message with HTTP 503
- [ ] Normal page loads continue to work
- [ ] `curl -I` a page during simulated outage shows `503` status and `Retry-After: 10` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit (updated)

* **What changed**
  * Adds a Service Unavailable page component that shows a “temporarily unavailable” message and a refresh button.
  * Introduces two helpers in lib/safeFetch:
    - isUpstreamUnavailable(fetchRes) — detects network failures (null/falsy) and 503 responses.
    - upstreamUnavailable(res, ...fetchResponses) — cancels response bodies, sets HTTP 503 and Retry-After: 10, and returns { props: { temporarilyUnavailable: true } } for SSR.
  * Replaces ~20 inline upstream-failure blocks by short-circuiting getServerSideProps across many pages to return the 503 flow when upstream API calls fail. Affected pages include multiple primary-source-sets pages, browse-by-topic, browse-by-partner, item, news (index and slug), guides, pro (two pages), and others listed in the PR.
  * Adds unit tests for isUpstreamUnavailable and upstreamUnavailable verifying detection logic, header/status behavior, and body.cancel handling.

* **Behavioral impact**
  * On upstream network failures or 503 responses, server-side renders now return HTTP 503 with Retry-After: 10 and render the Service Unavailable page (temporarilyUnavailable prop), instead of previously returning 404 or throwing server errors. Normal operation (when upstream is reachable) is unchanged.
  * Some pages cancel open response bodies when short-circuiting to avoid resource leaks.

* **Tests**
  * New Node tests (lib/safeFetch.test.mjs) cover detection and upstreamUnavailable behavior, including robustness when body.cancel rejects or when nulls are passed.

* **Deployment / infra / security / data considerations**
  * No database migrations.
  * No environment variables, AWS Secrets Manager keys, CodePipeline/CodeBuild/ECS task definition, or IAM policy changes are introduced by this PR.
  * No public-facing API surface or response shape changes are made; the change affects server-side error handling and response status for upstream failures only (responses now return 503 instead of 404 on upstream unreachability).
  * Security implications: minimal. The PR changes error-handling behavior and does not add new credential handling or external input parsing. Reviewers may want to confirm no sensitive information is leaked in any new logs, but none were added by the changes described.

* **Operational notes**
  * No manual pipeline trigger or ECS redeployment is required beyond the normal deployment that ships these code changes.
  * Verify in staging (or with API_URL temporarily unreachable) that affected pages return HTTP 503 and include the Retry-After: 10 header; curl -I should show 503 and Retry-After: 10.

* **Conclusion**
  * This PR centralizes upstream-unavailable handling, reduces duplicated inline logic, fixes a news index null-error that previously caused 500, and improves crawler behavior by signaling transient outages (503 + Retry-After) instead of 404.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->