### PR TITLE
fix(csp): add sha256 hash for gtag inline bootstrap script

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -34,11 +34,12 @@ function redirect(source, dest, permanent = true) {
 // challenge pages are served directly by CloudFront and never reach the origin.
 //
 // IMPORTANT — CSP HASH MAINTENANCE:
-// The two sha256 hashes in script-src below cover the fixed inline bootstrap
-// scripts that Next.js injects into every page. They do NOT cover __NEXT_DATA__
-// (which is dynamic and excluded from hashing). The hashes are stable across
-// normal code deploys, but WILL change when Next.js itself is upgraded, because
-// the bootstrap scripts are part of the Next.js package.
+// The sha256 hashes in script-src below cover fixed inline scripts in every page:
+//   - Two hashes for the Next.js bootstrap scripts (injected by the framework)
+//   - One hash for the gtag dataLayer/window.gtag stub in pages/_app.js
+// They do NOT cover __NEXT_DATA__ (dynamic, excluded from hashing). The Next.js
+// hashes are stable across normal deploys but WILL change on Next.js upgrades.
+// The gtag hash must be updated whenever the inline script in pages/_app.js changes.
 //
 // Whenever a Next.js version bump is part of a PR:
 //   1. Do a production build locally: `npm run build && npm start`
@@ -56,7 +57,7 @@ const CSP = [
   "frame-ancestors 'self'",
   "form-action 'self'",
   "default-src 'self'",
-  "script-src 'self' 'sha256-sYQvVdNrbb2ldJRpproLbB3h5LhCcbCA1SUM1wTfomI=' 'sha256-uZYgrdXqFswjbPEZxW2e6bv+djcz8D4kcJKjWyznRmk=' *.google-analytics.com *.googletagmanager.com *.sentry.io https://*.awswaf.com https://www.gstatic.com",
+  "script-src 'self' 'sha256-sYQvVdNrbb2ldJRpproLbB3h5LhCcbCA1SUM1wTfomI=' 'sha256-uZYgrdXqFswjbPEZxW2e6bv+djcz8D4kcJKjWyznRmk=' 'sha256-R7BycX6lCwOq9x3CZpytPnOyYvDNpLs38i6qKfpCcVY=' *.google-analytics.com *.googletagmanager.com *.sentry.io https://*.awswaf.com https://www.gstatic.com",
   "img-src 'self' http: https:",
   `connect-src 'self' https://dp.la https://*.dp.la ${CLOUDFRONT_MEDIA} *.google-analytics.com *.analytics.google.com *.sentry.io https://*.awswaf.com https://gitlab.wikimedia.org https://commons.wikimedia.org https://wikimedia.org`,
   "style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://www.gstatic.com",


### PR DESCRIPTION
## Summary

- The `<script dangerouslySetInnerHTML>` added in #1439 was blocked by the site's CSP on every page load because its hash wasn't in the `script-src` allowlist — producing a console violation and silently dropping the inline script
- The `onLoad` fallback from #1440 prevented crashes, but the queueing benefit of the inline script was lost for all users
- Fix: adds `'sha256-R7BycX6lCwOq9x3CZpytPnOyYvDNpLs38i6qKfpCcVY='` to `script-src` in `next.config.js` — hash verified against the exact inline script content with `openssl dgst -sha256`
- Updates the CSP comment to document that there are now three hashes (two Next.js bootstrap + one gtag stub) and that the gtag hash must be kept in sync with `pages/_app.js`

## Test plan

- [ ] Hard-navigate to an item page — confirm no CSP violation in the console
- [ ] Confirm `View Item` GA event fires on hard load (Network tab → `google-analytics.com`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Content Security Policy configuration to adjust which inline scripts are allowed to execute on the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->