### PR TITLE
Show placeholder for thumbnail 504s, not just 4xx/network errors

### DIFF
--- a/components/ItemComponents/Content/ItemImage/index.js
+++ b/components/ItemComponents/Content/ItemImage/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { getDefaultThumbnail } from "lib";
+import { getDefaultThumbnail, probeImage } from "lib";
 
 import css from "./ItemImage.module.scss";
 
@@ -10,12 +10,9 @@ class ItemImage extends React.Component {
   };
 
   componentDidMount() {
-    // Check for images that error so we can replace them with a default image
-    const _img = document.createElement("img");
-    _img.src = this.props.url;
-    _img.onerror = () => {
+    probeImage(this.props.url, () => {
       this.setState({ updateToDefaultImage: true });
-    };
+    });
   }
 
   render() {

--- a/components/ItemComponents/Content/ItemImage/index.js
+++ b/components/ItemComponents/Content/ItemImage/index.js
@@ -10,13 +10,28 @@ class ItemImage extends React.Component {
   };
 
   componentDidMount() {
-    this._cancelProbe = probeImage(this.props.url, () => {
-      this.setState({ updateToDefaultImage: true });
-    });
+    this.updateImage();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.url !== this.props.url) {
+      if (this._cancelProbe) this._cancelProbe();
+      this.setState({ updateToDefaultImage: false });
+      this.updateImage();
+    }
   }
 
   componentWillUnmount() {
     if (this._cancelProbe) this._cancelProbe();
+  }
+
+  updateImage() {
+    const probedUrl = this.props.url;
+    this._cancelProbe = probeImage(probedUrl, () => {
+      if (this.props.url === probedUrl) {
+        this.setState({ updateToDefaultImage: true });
+      }
+    });
   }
 
   render() {

--- a/components/ItemComponents/Content/ItemImage/index.js
+++ b/components/ItemComponents/Content/ItemImage/index.js
@@ -10,9 +10,13 @@ class ItemImage extends React.Component {
   };
 
   componentDidMount() {
-    probeImage(this.props.url, () => {
+    this._cancelProbe = probeImage(this.props.url, () => {
       this.setState({ updateToDefaultImage: true });
     });
+  }
+
+  componentWillUnmount() {
+    if (this._cancelProbe) this._cancelProbe();
   }
 
   render() {

--- a/components/shared/ListView/ListImage.js
+++ b/components/shared/ListView/ListImage.js
@@ -1,7 +1,7 @@
 import React from "react";
 import Link from "next/link";
 
-import { getDefaultThumbnail } from "lib";
+import { getDefaultThumbnail, probeImage } from "lib";
 
 import css from "./ListView.module.scss";
 
@@ -23,12 +23,9 @@ class ListImage extends React.Component {
   }
 
   updateImage() {
-    // Check for images that error so we can replace them with a default image
-    const _img = document.createElement("img");
-    _img.src = this.props.url;
-    _img.onerror = () => {
+    probeImage(this.props.url, () => {
       this.setState({ updateToDefaultImage: true });
-    };
+    });
   }
 
   render() {

--- a/components/shared/ListView/ListImage.js
+++ b/components/shared/ListView/ListImage.js
@@ -17,14 +17,22 @@ class ListImage extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (prevProps.url !== this.props.url) {
+      if (this._cancelProbe) this._cancelProbe();
       this.setState({ updateToDefaultImage: false });
       this.updateImage();
     }
   }
 
+  componentWillUnmount() {
+    if (this._cancelProbe) this._cancelProbe();
+  }
+
   updateImage() {
-    probeImage(this.props.url, () => {
-      this.setState({ updateToDefaultImage: true });
+    const probedUrl = this.props.url;
+    this._cancelProbe = probeImage(probedUrl, () => {
+      if (this.props.url === probedUrl) {
+        this.setState({ updateToDefaultImage: true });
+      }
     });
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,6 +39,7 @@ import truncateString from "./truncateString";
 import getItemThumbnail from "./getItemThumbnail";
 import isValidPSSSlug from "./isValidPSSSlug";
 import {isBalanced} from "./balancing.mjs";
+import probeImage from "./probeImage";
 
 export {
     addCommasToNumber,
@@ -80,5 +81,6 @@ export {
     truncateString,
     getItemThumbnail,
     isValidPSSSlug,
-    isBalanced
+    isBalanced,
+    probeImage
 };

--- a/lib/probeImage.js
+++ b/lib/probeImage.js
@@ -14,6 +14,11 @@ const BLANK_IMAGE =
   "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
 
 const probeImage = (url, onError) => {
+  if (typeof url !== "string" || url.trim() === "") {
+    onError();
+    return () => {};
+  }
+
   const img = document.createElement("img");
   let cancelled = false;
 

--- a/lib/probeImage.js
+++ b/lib/probeImage.js
@@ -41,4 +41,5 @@ const probeImage = (url, onError) => {
   };
 };
 
+export { BLANK_IMAGE };
 export default probeImage;

--- a/lib/probeImage.js
+++ b/lib/probeImage.js
@@ -1,0 +1,26 @@
+/**
+ * Probes a URL to determine whether it resolves to a usable image, then calls
+ * onError if it doesn't.
+ *
+ * Why not just rely on the <img> element's onerror?  onerror fires on network
+ * errors and 4xx responses, but NOT on 5xx responses (e.g. 504 Gateway
+ * Timeout): the browser considers a 5xx a successful HTTP load, it just can't
+ * decode the body as an image.  Checking naturalWidth === 0 in onload catches
+ * that case — the image "loaded" but has no displayable pixels.
+ */
+const probeImage = (url, onError) => {
+  const img = document.createElement("img");
+  img.onload = () => {
+    if (img.naturalWidth === 0) onError();
+    img.onload = null;
+    img.onerror = null;
+  };
+  img.onerror = () => {
+    onError();
+    img.onload = null;
+    img.onerror = null;
+  };
+  img.src = url;
+};
+
+export default probeImage;

--- a/lib/probeImage.js
+++ b/lib/probeImage.js
@@ -10,17 +10,30 @@
  */
 const probeImage = (url, onError) => {
   const img = document.createElement("img");
-  img.onload = () => {
-    if (img.naturalWidth === 0) onError();
+  let cancelled = false;
+
+  const cleanup = () => {
     img.onload = null;
     img.onerror = null;
+  };
+
+  img.onload = () => {
+    if (!cancelled && img.naturalWidth === 0) onError();
+    cleanup();
   };
   img.onerror = () => {
-    onError();
-    img.onload = null;
-    img.onerror = null;
+    if (!cancelled) onError();
+    cleanup();
   };
   img.src = url;
+
+  // Returns a disposer. Call it to cancel a pending probe — e.g. in
+  // componentWillUnmount or when the URL changes before the probe finishes.
+  return () => {
+    cancelled = true;
+    cleanup();
+    img.src = "";
+  };
 };
 
 export default probeImage;

--- a/lib/probeImage.js
+++ b/lib/probeImage.js
@@ -8,6 +8,11 @@
  * decode the body as an image.  Checking naturalWidth === 0 in onload catches
  * that case — the image "loaded" but has no displayable pixels.
  */
+// 1×1 transparent GIF — safe no-op src for cancelling in-flight image loads
+// without triggering a document fetch (unlike img.src = "")
+const BLANK_IMAGE =
+  "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
+
 const probeImage = (url, onError) => {
   const img = document.createElement("img");
   let cancelled = false;
@@ -32,7 +37,7 @@ const probeImage = (url, onError) => {
   return () => {
     cancelled = true;
     cleanup();
-    img.src = "";
+    img.src = BLANK_IMAGE;
   };
 };
 

--- a/lib/probeImage.test.mjs
+++ b/lib/probeImage.test.mjs
@@ -16,6 +16,15 @@ function installMockDocument(t, naturalWidth) {
   return () => img;
 }
 
+for (const [label, url] of [['undefined', undefined], ['empty string', ''], ['whitespace', '   ']]) {
+  test(`invalid url: ${label} calls onError immediately and returns safe disposer`, () => {
+    let errorCalled = false;
+    const dispose = probeImage(url, () => { errorCalled = true; });
+    assert.equal(errorCalled, true);
+    assert.doesNotThrow(() => dispose());
+  });
+}
+
 test('onload: naturalWidth === 0 calls onError', (t) => {
   const getImg = installMockDocument(t, 0);
   let errorCalled = false;

--- a/lib/probeImage.test.mjs
+++ b/lib/probeImage.test.mjs
@@ -1,12 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import probeImage from './probeImage.js';
+import probeImage, { BLANK_IMAGE } from './probeImage.js';
 
-// Blank GIF data URL used by the disposer to cancel in-flight loads
-const BLANK_IMAGE =
-  "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
-
-function installMockDocument(naturalWidth) {
+function installMockDocument(t, naturalWidth) {
+  const previousDocument = globalThis.document;
   let img;
   globalThis.document = {
     createElement(tag) {
@@ -15,41 +12,36 @@ function installMockDocument(naturalWidth) {
       return img;
     },
   };
+  t.after(() => { globalThis.document = previousDocument; });
   return () => img;
 }
 
-// onload path
-
-test('onload: naturalWidth === 0 calls onError', () => {
-  const getImg = installMockDocument(0);
+test('onload: naturalWidth === 0 calls onError', (t) => {
+  const getImg = installMockDocument(t, 0);
   let errorCalled = false;
   probeImage('https://example.com/image.jpg', () => { errorCalled = true; });
   getImg().onload();
   assert.equal(errorCalled, true);
 });
 
-test('onload: naturalWidth > 0 does not call onError', () => {
-  const getImg = installMockDocument(50);
+test('onload: naturalWidth > 0 does not call onError', (t) => {
+  const getImg = installMockDocument(t, 50);
   let errorCalled = false;
   probeImage('https://example.com/image.jpg', () => { errorCalled = true; });
   getImg().onload();
   assert.equal(errorCalled, false);
 });
 
-// onerror path
-
-test('onerror calls onError', () => {
-  const getImg = installMockDocument(100);
+test('onerror calls onError', (t) => {
+  const getImg = installMockDocument(t, 100);
   let errorCalled = false;
   probeImage('https://example.com/image.jpg', () => { errorCalled = true; });
   getImg().onerror();
   assert.equal(errorCalled, true);
 });
 
-// disposer
-
-test('disposer: sets src to BLANK_IMAGE and clears handlers', () => {
-  const getImg = installMockDocument(0);
+test('disposer: sets src to BLANK_IMAGE and clears handlers', (t) => {
+  const getImg = installMockDocument(t, 0);
   const dispose = probeImage('https://example.com/image.jpg', () => {});
   dispose();
   const img = getImg();
@@ -58,8 +50,8 @@ test('disposer: sets src to BLANK_IMAGE and clears handlers', () => {
   assert.equal(img.onerror, null);
 });
 
-test('disposer: suppresses onError even if onload fires after disposal', () => {
-  const getImg = installMockDocument(0);
+test('disposer: suppresses onError even if onload fires after disposal', (t) => {
+  const getImg = installMockDocument(t, 0);
   let errorCalled = false;
   const dispose = probeImage('https://example.com/image.jpg', () => { errorCalled = true; });
   const savedOnload = getImg().onload; // capture before disposal clears it
@@ -68,8 +60,8 @@ test('disposer: suppresses onError even if onload fires after disposal', () => {
   assert.equal(errorCalled, false);
 });
 
-test('disposer: suppresses onError even if onerror fires after disposal', () => {
-  const getImg = installMockDocument(100);
+test('disposer: suppresses onError even if onerror fires after disposal', (t) => {
+  const getImg = installMockDocument(t, 100);
   let errorCalled = false;
   const dispose = probeImage('https://example.com/image.jpg', () => { errorCalled = true; });
   const savedOnerror = getImg().onerror; // capture before disposal clears it

--- a/lib/probeImage.test.mjs
+++ b/lib/probeImage.test.mjs
@@ -1,0 +1,79 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import probeImage from './probeImage.js';
+
+// Blank GIF data URL used by the disposer to cancel in-flight loads
+const BLANK_IMAGE =
+  "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
+
+function installMockDocument(naturalWidth) {
+  let img;
+  globalThis.document = {
+    createElement(tag) {
+      assert.equal(tag, 'img');
+      img = { onload: null, onerror: null, naturalWidth, src: null };
+      return img;
+    },
+  };
+  return () => img;
+}
+
+// onload path
+
+test('onload: naturalWidth === 0 calls onError', () => {
+  const getImg = installMockDocument(0);
+  let errorCalled = false;
+  probeImage('https://example.com/image.jpg', () => { errorCalled = true; });
+  getImg().onload();
+  assert.equal(errorCalled, true);
+});
+
+test('onload: naturalWidth > 0 does not call onError', () => {
+  const getImg = installMockDocument(50);
+  let errorCalled = false;
+  probeImage('https://example.com/image.jpg', () => { errorCalled = true; });
+  getImg().onload();
+  assert.equal(errorCalled, false);
+});
+
+// onerror path
+
+test('onerror calls onError', () => {
+  const getImg = installMockDocument(100);
+  let errorCalled = false;
+  probeImage('https://example.com/image.jpg', () => { errorCalled = true; });
+  getImg().onerror();
+  assert.equal(errorCalled, true);
+});
+
+// disposer
+
+test('disposer: sets src to BLANK_IMAGE and clears handlers', () => {
+  const getImg = installMockDocument(0);
+  const dispose = probeImage('https://example.com/image.jpg', () => {});
+  dispose();
+  const img = getImg();
+  assert.equal(img.src, BLANK_IMAGE);
+  assert.equal(img.onload, null);
+  assert.equal(img.onerror, null);
+});
+
+test('disposer: suppresses onError even if onload fires after disposal', () => {
+  const getImg = installMockDocument(0);
+  let errorCalled = false;
+  const dispose = probeImage('https://example.com/image.jpg', () => { errorCalled = true; });
+  const savedOnload = getImg().onload; // capture before disposal clears it
+  dispose();
+  savedOnload(); // simulate late-firing onload
+  assert.equal(errorCalled, false);
+});
+
+test('disposer: suppresses onError even if onerror fires after disposal', () => {
+  const getImg = installMockDocument(100);
+  let errorCalled = false;
+  const dispose = probeImage('https://example.com/image.jpg', () => { errorCalled = true; });
+  const savedOnerror = getImg().onerror; // capture before disposal clears it
+  dispose();
+  savedOnerror(); // simulate late-firing onerror
+  assert.equal(errorCalled, false);
+});

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "docker:run": "docker run -p 3000:3000 -d --name dpla-frontend dpla-frontend:latest",
     "docker:logs": "docker logs -f dpla-frontend",
     "analyze": "yarn && ANALYZE=true yarn build",
-    "test": "node scripts/check-favicons.js",
+    "test": "node --test lib/*.test.mjs && node scripts/check-favicons.js",
     "lint": "next lint",
     "prepare": "husky"
   },


### PR DESCRIPTION
## Summary

- `ItemImage` and `ListImage` both probe the thumbnail URL with a hidden `<img>` element and fall back to the placeholder icon on `onerror`. But `onerror` only fires on network errors and 4xx responses — 5xx responses (e.g. 504 Gateway Timeout from `thumb.dp.la`) deliver a valid HTTP body that the browser accepts as a "successful" load, so `onerror` never fires. The result is an empty broken image viewer instead of the placeholder icon.
- Adds an `onload` check for `naturalWidth === 0`: if the body loaded but isn't decodable as an image, the placeholder is shown instead.
- Extracts the probe logic into `lib/probeImage.js` so the fix and its explanation live in one place rather than duplicated across both components.

## Context

`thumb.dp.la` is currently returning ~1,700 504s/day for items whose `object` URLs point to a stale IP (`67.111.179.146`) that no longer responds. A companion PR on the thumbnail-api repo reduces the fetch timeout so these fail faster, but they will still produce 504s until the upstream metadata is corrected. This PR ensures users see the placeholder rather than an empty viewer in the meantime.

## Test plan

- [ ] Load an item page for an item with a broken thumbnail — should show the type placeholder icon, not an empty box
- [ ] Load search results containing items with broken thumbnails — same
- [ ] Verify items with working thumbnails are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared image-probing utility and made it available for reuse.

* **Refactor**
  * Image components now cancel in-flight probes when image URLs change or components unmount.

* **Bug Fixes**
  * Reduced broken/blank image flashes; fallback images apply only when the probed URL still matches the currently rendered image.

* **Tests**
  * Added tests covering probe behavior, disposal, and suppression of late callbacks.

* **Chores**
  * Test script updated to include the new probe tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->