### PR TITLE
fix: catch unhandled Router.push rejections across search and lists

### DIFF
--- a/components/PrimarySourceSetsComponents/AllSets/components/FiltersBar/index.js
+++ b/components/PrimarySourceSetsComponents/AllSets/components/FiltersBar/index.js
@@ -29,28 +29,25 @@ class FiltersBar extends React.Component {
     }
   }
 
-  onSubjectChange = async (val) => {
-    await Router.push({
-      pathname: "/primary-source-sets",
-      query: { ...this.props.router.query, subject: val.target.value },
-    });
+  _navigateToPSS = async (query) => {
+    try {
+      await Router.push({ pathname: "/primary-source-sets", query });
+    } catch {}
   };
 
-  onTimePeriodChange = async (val) => {
-    await Router.push({
-      pathname: "/primary-source-sets",
-      query: {
-        ...this.props.router.query,
-        timePeriod: val.target.value,
-      },
+  onSubjectChange = (val) =>
+    this._navigateToPSS({
+      ...this.props.router.query,
+      subject: val.target.value,
     });
-  };
 
-  onClearFilters = async () => {
-    await Router.push({
-      pathname: "/primary-source-sets",
+  onTimePeriodChange = (val) =>
+    this._navigateToPSS({
+      ...this.props.router.query,
+      timePeriod: val.target.value,
     });
-  };
+
+  onClearFilters = () => this._navigateToPSS({});
 
   render() {
     const timePeriod = this.props.router.query.timePeriod;

--- a/components/SearchComponents/MainContent/Sidebar/index.js
+++ b/components/SearchComponents/MainContent/Sidebar/index.js
@@ -147,23 +147,25 @@ class DateFacet extends React.Component {
     });
   };
 
-  async handleKeyDown(e) {
+  handleKeyDown(e) {
     if (e.keyCode === 13) {
-      await this.handleDateSubmit(e);
+      this.handleDateSubmit(e);
     }
   }
 
   async handleDateSubmit(e) {
     e.preventDefault();
     const dateProps = this.getDateProps();
-    await Router.push({
-      pathname: this.props.router.pathname,
-      query: {
-        ...removeQueryParams(this.props.router.query, ["after", "before"]),
-        ...dateProps,
-        page: 1,
-      },
-    });
+    try {
+      await Router.push({
+        pathname: this.props.router.pathname,
+        query: {
+          ...removeQueryParams(this.props.router.query, ["after", "before"]),
+          ...dateProps,
+          page: 1,
+        },
+      });
+    } catch {}
   }
 
   getDateProps() {

--- a/components/SearchComponents/OptionsBar/index.js
+++ b/components/SearchComponents/OptionsBar/index.js
@@ -53,28 +53,23 @@ class OptionsBar extends React.Component {
     }
   }
 
-  onPageSizeChange = async (val) => {
-    await Router.push({
-      pathname: "/search",
-      query: {
-        ...this.props.router.query,
-        page_size: val.target.value,
-        page: 1,
-      },
-    });
+  _navigateToSearch = async (queryUpdates) => {
+    try {
+      await Router.push({
+        pathname: "/search",
+        query: { ...this.props.router.query, ...queryUpdates, page: 1 },
+      });
+    } catch {}
   };
 
-  onSortChange = async (val) => {
-    await Router.push({
-      pathname: "/search",
-      query: {
-        ...this.props.router.query,
-        sort_by: mapSortOptionsToParams[val.target.value].sort_by,
-        sort_order: mapSortOptionsToParams[val.target.value].sort_order,
-        page: 1,
-      },
+  onPageSizeChange = (val) =>
+    this._navigateToSearch({ page_size: val.target.value });
+
+  onSortChange = (val) =>
+    this._navigateToSearch({
+      sort_by: mapSortOptionsToParams[val.target.value].sort_by,
+      sort_order: mapSortOptionsToParams[val.target.value].sort_order,
     });
-  };
 
   render() {
     const {

--- a/pages/lists/[listId].js
+++ b/pages/lists/[listId].js
@@ -135,10 +135,12 @@ const List = () => {
 
   const handleConfirmDelete = useCallback(async () => {
     await removeLocalForageItem(listId);
-    await Router.push({
-      pathname: "/lists",
-      query: "",
-    });
+    try {
+      await Router.push({
+        pathname: "/lists",
+        query: "",
+      });
+    } catch {}
   }, [listId]);
 
   if (initialized && storageUnavailable) {

--- a/pages/lists/index.js
+++ b/pages/lists/index.js
@@ -64,7 +64,9 @@ const ListsPage = () => {
       });
 
       // Redirect to the new list
-      await Router.push({ pathname: `/lists/${uuid}` });
+      try {
+        await Router.push({ pathname: `/lists/${uuid}` });
+      } catch {}
 
     } finally {
       isCreatingRef.current = false;


### PR DESCRIPTION
## Summary

- Fixes Sentry issue DPLA-FRONTEND-1GX: unhandled promise rejections from `await Router.push()` on the `/search` page
- Next.js rejects awaited `Router.push()` calls with an empty `{}` object when a navigation is cancelled (e.g. user changes a filter while a previous navigation is still in-flight). With no `try/catch`, these fire `onunhandledrejection` and show up as errors in Sentry
- Applied to all five affected call sites across the codebase

**Files changed:**
- `SearchComponents/OptionsBar` — extracted `_navigateToSearch` helper; `onPageSizeChange` and `onSortChange` delegate to it
- `SearchComponents/MainContent/Sidebar` — wrapped `handleDateSubmit`; simplified `handleKeyDown` to synchronous (no longer needs to await since errors are handled internally)
- `PrimarySourceSetsComponents/AllSets/FiltersBar` — extracted `_navigateToPSS` helper; all three filter handlers delegate to it
- `pages/lists/index.js` — scoped try/catch to just the `Router.push` (the outer `try/finally` resets the in-flight ref regardless)
- `pages/lists/[listId].js` — scoped try/catch to just the `Router.push`, so `removeLocalForageItem` failures still propagate

## Test plan

- [ ] Change sort order or page size on `/search` — no console errors
- [ ] Apply or clear a subject/time period filter on `/primary-source-sets` — no console errors
- [ ] Submit a date range filter on `/search` — no console errors
- [ ] Create a new list on `/lists` — redirects correctly
- [ ] Delete a list on `/lists/[id]` — redirects to `/lists` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved application stability by enhancing navigation error handling across filters, search controls, date selection, and list management operations to prevent interruptions during page transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->