### PR TITLE
fix: prevent 5xx upstream errors from rendering as 404s

### DIFF
--- a/lib/safeFetch.js
+++ b/lib/safeFetch.js
@@ -95,7 +95,11 @@ export async function safeFetch(url, options) {
       console.warn(`[safeFetch] Retrying after 503 from ${sanitizeUrl(url)}`);
       // Consume the body so the underlying connection is released back to the
       // Undici pool before we wait and retry.
-      await res.body?.cancel?.().catch(() => {});
+      try {
+        await res.body?.cancel?.();
+      } catch {
+        // Ignore cancellation failures; retry should proceed.
+      }
       await new Promise((r) => setTimeout(r, 1500));
       continue;
     }

--- a/lib/safeFetch.js
+++ b/lib/safeFetch.js
@@ -95,7 +95,7 @@ export async function safeFetch(url, options) {
       console.warn(`[safeFetch] Retrying after 503 from ${sanitizeUrl(url)}`);
       // Consume the body so the underlying connection is released back to the
       // Undici pool before we wait and retry.
-      await res.body?.cancel();
+      await res.body?.cancel?.().catch(() => {});
       await new Promise((r) => setTimeout(r, 1500));
       continue;
     }

--- a/pages/about/[...sections].js
+++ b/pages/about/[...sections].js
@@ -27,6 +27,7 @@ import utils from "stylesheets/utils.module.scss";
 import { washObject } from "lib/washObject";
 import { safeFetch, wpAuthFetchOptions, wpDraftUrl, isUpstreamUnavailable, upstreamUnavailable } from "lib/safeFetch";
 import { upgradeWordPressUrls } from "lib/upgradeWordPressUrls";
+import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
 class AboutMenuPage extends React.Component {
   refreshExternalLinks() {
@@ -47,8 +48,9 @@ class AboutMenuPage extends React.Component {
   }
 
   render() {
-    const { router, content, items, breadcrumbs, pageTitle, pageDescription } =
+    const { router, content, items, breadcrumbs, pageTitle, pageDescription, temporarilyUnavailable } =
       this.props;
+    if (temporarilyUnavailable) return <ServiceUnavailable />;
     if (!breadcrumbs || !content) return null;
 
     return (

--- a/pages/about/[...sections].js
+++ b/pages/about/[...sections].js
@@ -25,7 +25,7 @@ import {
 import contentCss from "stylesheets/content-pages.module.scss";
 import utils from "stylesheets/utils.module.scss";
 import { washObject } from "lib/washObject";
-import { safeFetch, wpAuthFetchOptions, wpDraftUrl } from "lib/safeFetch";
+import { safeFetch, wpAuthFetchOptions, wpDraftUrl, isUpstreamUnavailable, upstreamUnavailable } from "lib/safeFetch";
 import { upgradeWordPressUrls } from "lib/upgradeWordPressUrls";
 
 class AboutMenuPage extends React.Component {
@@ -98,6 +98,7 @@ export const getServerSideProps = async (context) => {
   // fetch settings info
   // 1. fetch the settings from WP
   const settingsRes = await safeFetch(API_SETTINGS_ENDPOINT);
+  if (isUpstreamUnavailable(settingsRes)) return upstreamUnavailable(context.res, settingsRes);
   if (!settingsRes?.ok) return { notFound: true };
   const settingsJson = await settingsRes.json();
   // 2. get the corresponding value
@@ -107,6 +108,7 @@ export const getServerSideProps = async (context) => {
   const subsection = sections?.[1];
   const pageSlug = subsection || section || "about-us";
   const response = await safeFetch(ABOUT_MENU_ENDPOINT);
+  if (isUpstreamUnavailable(response)) return upstreamUnavailable(context.res, response);
   if (!response?.ok) return { notFound: true };
   const json = await response.json();
   const pageItem = json.items.find((item) => item.post_name === pageSlug);
@@ -151,6 +153,7 @@ export const getServerSideProps = async (context) => {
   const url = draftMode ? wpDraftUrl(getMenuItemUrl(pageItem)) : getMenuItemUrl(pageItem);
 
   const pageRes = await safeFetch(url, authOptions);
+  if (isUpstreamUnavailable(pageRes)) return upstreamUnavailable(context.res, pageRes);
   if (!pageRes?.ok) return { notFound: true };
   const pageJson = await pageRes.json();
   let pageDescription = "";

--- a/pages/about/index.js
+++ b/pages/about/index.js
@@ -27,6 +27,7 @@ import utils from "stylesheets/utils.module.scss";
 import { washObject } from "lib/washObject";
 import { safeFetch, wpAuthFetchOptions, wpDraftUrl, isUpstreamUnavailable, upstreamUnavailable } from "lib/safeFetch";
 import { upgradeWordPressUrls } from "lib/upgradeWordPressUrls";
+import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
 class AboutMenuPage extends React.Component {
   refreshExternalLinks() {
@@ -47,8 +48,9 @@ class AboutMenuPage extends React.Component {
   }
 
   render() {
-    const { router, content, items, breadcrumbs, pageTitle, pageDescription } =
+    const { router, content, items, breadcrumbs, pageTitle, pageDescription, temporarilyUnavailable } =
       this.props;
+    if (temporarilyUnavailable) return <ServiceUnavailable />;
     if (!breadcrumbs || !content) return null;
 
     return (

--- a/pages/about/index.js
+++ b/pages/about/index.js
@@ -25,7 +25,7 @@ import {
 import contentCss from "stylesheets/content-pages.module.scss";
 import utils from "stylesheets/utils.module.scss";
 import { washObject } from "lib/washObject";
-import { safeFetch, wpAuthFetchOptions, wpDraftUrl } from "lib/safeFetch";
+import { safeFetch, wpAuthFetchOptions, wpDraftUrl, isUpstreamUnavailable, upstreamUnavailable } from "lib/safeFetch";
 import { upgradeWordPressUrls } from "lib/upgradeWordPressUrls";
 
 class AboutMenuPage extends React.Component {
@@ -98,12 +98,14 @@ export const getServerSideProps = async (context) => {
   // fetch settings info
   // 1. fetch the settings from WP
   const settingsRes = await safeFetch(API_SETTINGS_ENDPOINT);
+  if (isUpstreamUnavailable(settingsRes)) return upstreamUnavailable(context.res, settingsRes);
   if (!settingsRes?.ok) return { notFound: true };
   const settingsJson = await settingsRes.json();
   // 2. get the corresponding value
   const endpoint = `${PAGES_ENDPOINT}/${settingsJson.acf.guides_endpoint}`;
   const pageName = query.subsection || query.section || "about-us";
   const response = await safeFetch(ABOUT_MENU_ENDPOINT);
+  if (isUpstreamUnavailable(response)) return upstreamUnavailable(context.res, response);
   if (!response?.ok) return { notFound: true };
   const json = await response.json();
   const pageItem = json.items.find((item) => item.post_name === pageName);
@@ -147,6 +149,7 @@ export const getServerSideProps = async (context) => {
   const url = draftMode ? wpDraftUrl(getMenuItemUrl(pageItem)) : getMenuItemUrl(pageItem);
 
   const pageRes = await safeFetch(url, authOptions);
+  if (isUpstreamUnavailable(pageRes)) return upstreamUnavailable(context.res, pageRes);
   if (!pageRes?.ok) return { notFound: true };
   const pageJson = await pageRes.json();
   let pageDescription = "";

--- a/pages/browse-by-topic/index.js
+++ b/pages/browse-by-topic/index.js
@@ -2,15 +2,16 @@ import React from "react";
 
 import MainLayout from "components/MainLayout";
 import TopicsList from "components/TopicBrowseComponents/TopicsList";
+import ServiceUnavailable from "components/shared/ServiceUnavailable";
 import {
   API_ENDPOINT_ALL_TOPICS_100_PER_PAGE,
   TITLE,
 } from "constants/topicBrowse";
 import { washObject } from "lib/washObject";
-import { safeFetch } from "lib/safeFetch";
+import { safeFetch, isUpstreamUnavailable, upstreamUnavailable } from "lib/safeFetch";
 
-function TopicBrowse(props) {
-  const { topics } = props;
+function TopicBrowse({ topics, temporarilyUnavailable }) {
+  if (temporarilyUnavailable) return <ServiceUnavailable />;
   return (
     <div>
       <MainLayout pageTitle={TITLE}>
@@ -22,8 +23,9 @@ function TopicBrowse(props) {
   );
 }
 
-export const getServerSideProps = async () => {
+export const getServerSideProps = async (context) => {
   const res = await safeFetch(API_ENDPOINT_ALL_TOPICS_100_PER_PAGE);
+  if (isUpstreamUnavailable(res)) return upstreamUnavailable(context.res, res);
   if (!res?.ok) {
     return { notFound: true };
   }

--- a/pages/contact/index.js
+++ b/pages/contact/index.js
@@ -48,13 +48,19 @@ function Contact(props) {
   );
 }
 
-export const getServerSideProps = async () => {
+export const getServerSideProps = async (context) => {
   const siteEnv = process.env.NEXT_PUBLIC_SITE_ENV;
   const aboutMenuRes = await fetch(
     siteEnv === "user" ? ABOUT_MENU_ENDPOINT : PRO_MENU_ENDPOINT,
   );
 
   if (!aboutMenuRes.ok) {
+    if (aboutMenuRes.status >= 500) {
+      // Sidebar nav is non-critical — render page without it and signal 503
+      context.res.statusCode = 503;
+      context.res.setHeader("Retry-After", "10");
+      return { props: washObject({ sidebarItems: [] }) };
+    }
     return { notFound: true };
   }
 

--- a/pages/contact/index.js
+++ b/pages/contact/index.js
@@ -17,6 +17,7 @@ import { TITLE } from "constants/contact";
 import contentCss from "stylesheets/content-pages.module.scss";
 import utils from "stylesheets/utils.module.scss";
 import { washObject } from "lib/washObject";
+import { safeFetch } from "lib/safeFetch";
 
 function Contact(props) {
   const { sidebarItems } = props;
@@ -50,12 +51,12 @@ function Contact(props) {
 
 export const getServerSideProps = async (context) => {
   const siteEnv = process.env.NEXT_PUBLIC_SITE_ENV;
-  const aboutMenuRes = await fetch(
+  const aboutMenuRes = await safeFetch(
     siteEnv === "user" ? ABOUT_MENU_ENDPOINT : PRO_MENU_ENDPOINT,
   );
 
-  if (!aboutMenuRes.ok) {
-    if (aboutMenuRes.status >= 500) {
+  if (!aboutMenuRes?.ok) {
+    if (!aboutMenuRes || aboutMenuRes.status >= 500) {
       // Sidebar nav is non-critical — render page without it and signal 503
       context.res.statusCode = 503;
       context.res.setHeader("Retry-After", "10");

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,6 +2,7 @@ import React from "react";
 
 import MainLayout from "components/MainLayout";
 import HomeUser from "components/HomePageComponents/HomeUser";
+import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
 import { exhibitHomePage, loadExhibition } from "lib/exhibitionsStatic";
 
@@ -20,7 +21,7 @@ import {
 
 import { API_SETTINGS_ENDPOINT } from "constants/site";
 import { washObject } from "lib/washObject";
-import { safeFetch, wpAuthFetchOptions, wpDraftUrl } from "lib/safeFetch";
+import { safeFetch, wpAuthFetchOptions, wpDraftUrl, isUpstreamUnavailable, upstreamUnavailable } from "lib/safeFetch";
 
 function Home({
   sourceSets,
@@ -29,7 +30,9 @@ function Home({
   headerDescription,
   news,
   content,
+  temporarilyUnavailable,
 }) {
+  if (temporarilyUnavailable) return <ServiceUnavailable />;
   const siteEnv = process.env.NEXT_PUBLIC_SITE_ENV;
   return (
     <MainLayout
@@ -65,6 +68,7 @@ export async function getServerSideProps(context) {
   // 1. fetch the settings from WP
   const settingsRes = await fetch(API_SETTINGS_ENDPOINT);
   if (!settingsRes.ok) {
+    if (settingsRes.status >= 500) return upstreamUnavailable(context.res, settingsRes);
     return { notFound: true };
   }
   const settingsJson = await settingsRes.json();
@@ -74,6 +78,7 @@ export async function getServerSideProps(context) {
   const guidesEndpoint = `${PAGES_ENDPOINT}/${settingsJson.acf.guides_endpoint}`;
   // 3. fetch it (safeFetch is used here for consistent error handling)
   const homeRes = await safeFetch(endpoint, authOptions);
+  if (isUpstreamUnavailable(homeRes)) return upstreamUnavailable(context.res, homeRes);
   if (!homeRes?.ok) {
     return { notFound: true };
   }
@@ -201,7 +206,8 @@ export async function getServerSideProps(context) {
     props: props,
   };
   } catch (e) {
-    return { notFound: true };
+    console.error("[SSR] getServerSideProps failed:", e);
+    return upstreamUnavailable(context.res);
   }
 }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -207,7 +207,13 @@ export async function getServerSideProps(context) {
   };
   } catch (e) {
     console.error("[SSR] getServerSideProps failed:", e);
-    return upstreamUnavailable(context.res);
+    // Only treat network-level fetch failures (TypeError with a cause set by
+    // undici) as upstream unavailability. All other errors (shape mismatches,
+    // app bugs) surface as 500s so they don't get silently masked as 503.
+    if (e instanceof TypeError && e.cause) {
+      return upstreamUnavailable(context.res);
+    }
+    throw e;
   }
 }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -123,9 +123,9 @@ export async function getServerSideProps(context) {
   // fetch item count
   let headerDescription = homepageJson.acf.header_description;
   const apiUrl = `${process.env.API_URL}/items?page_size=0&api_key=${process.env.API_KEY}`;
-  const itemsRes = await fetch(apiUrl);
+  const itemsRes = await safeFetch(apiUrl);
   let itemCount = 0; // default handles unexpected error
-  if (itemsRes.ok) {
+  if (itemsRes?.ok) {
     const itemsJson = await itemsRes.json();
 
     if ("count" in itemsJson) {
@@ -148,9 +148,9 @@ export async function getServerSideProps(context) {
 
   // fetch user guides data
   let guides = [];
-  const aboutMenuRes = await fetch(ABOUT_MENU_ENDPOINT);
-  if (!aboutMenuRes.ok) {
-    console.log("Unable to load user guides.", aboutMenuRes.status);
+  const aboutMenuRes = await safeFetch(ABOUT_MENU_ENDPOINT);
+  if (!aboutMenuRes?.ok) {
+    console.log("Unable to load user guides.", aboutMenuRes?.status);
   } else {
     const aboutMenuJson = await aboutMenuRes.json();
     const indexPageItem = aboutMenuJson.items.find(
@@ -186,9 +186,9 @@ export async function getServerSideProps(context) {
 
   // fetch news posts
   let newsItems = [];
-  const newsRes = await fetch(NEWS_USER_ENDPOINT);
-  if (!newsRes.ok) {
-    console.log("Unable to load news posts.", newsRes.status);
+  const newsRes = await safeFetch(NEWS_USER_ENDPOINT);
+  if (!newsRes?.ok) {
+    console.log("Unable to load news posts.", newsRes?.status);
   } else {
     newsItems = await newsRes.json();
   }

--- a/pages/pro/hubs.js
+++ b/pages/pro/hubs.js
@@ -7,7 +7,8 @@ import FullPageWidthBlock from "shared/FullPageWidthBlock";
 import WebsiteFeature from "shared/WebsiteFeature";
 
 import { wordpressLinks } from "lib/index";
-import { safeFetch, wpAuthFetchOptions } from "lib/safeFetch";
+import { safeFetch, wpAuthFetchOptions, isUpstreamUnavailable, upstreamUnavailable } from "lib/safeFetch";
+import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
 import {
   NEWS_PRO_ENDPOINT,
@@ -38,7 +39,8 @@ class HubsPage extends React.Component {
   }
 
   render() {
-    const { page, pageTitle, news } = this.props;
+    const { page, pageTitle, news, temporarilyUnavailable } = this.props;
+    if (temporarilyUnavailable) return <ServiceUnavailable />;
     if (!page?.acf) return null;
     return (
       <MainLayout pageTitle={pageTitle} seoType={SEO_TYPE}>
@@ -115,6 +117,7 @@ export async function getServerSideProps(context) {
   const authOptions = wpAuthFetchOptions(draftMode);
   const hubParams = draftMode ? "?slug=hubs&status=any&context=edit" : "?slug=hubs";
   const hubRes = await safeFetch(PAGES_ENDPOINT + hubParams, authOptions);
+  if (isUpstreamUnavailable(hubRes)) return upstreamUnavailable(context.res, hubRes);
   if (!hubRes?.ok) {
     return { notFound: true };
   }

--- a/pages/projects/dpla-wikimedia/metrics.js
+++ b/pages/projects/dpla-wikimedia/metrics.js
@@ -122,6 +122,12 @@ export async function getServerSideProps(context) {
 
   const menuResponse = await fetch(PRO_MENU_ENDPOINT);
   if (!menuResponse.ok) {
+    if (menuResponse.status >= 500) {
+      // Sidebar nav is non-critical — render page without it and signal 503
+      context.res.statusCode = 503;
+      context.res.setHeader("Retry-After", "10");
+      return { props: washObject({ items: [], isFilterView }) };
+    }
     return { notFound: true };
   }
   const menuJson = await menuResponse.json();

--- a/pages/projects/dpla-wikimedia/metrics.js
+++ b/pages/projects/dpla-wikimedia/metrics.js
@@ -11,6 +11,7 @@ import { PRO_MENU_ENDPOINT } from "constants/content-pages";
 import utils from "stylesheets/utils.module.scss";
 import contentCss from "stylesheets/content-pages.module.scss";
 import { washObject } from "lib/washObject";
+import { safeFetch } from "lib/safeFetch";
 
 const BREADCRUMBS = [
   { title: "Projects", url: "/projects" },
@@ -120,9 +121,9 @@ export async function getServerSideProps(context) {
   const { show, hub } = context.query;
   const isFilterView = !!(show || hub);
 
-  const menuResponse = await fetch(PRO_MENU_ENDPOINT);
-  if (!menuResponse.ok) {
-    if (menuResponse.status >= 500) {
+  const menuResponse = await safeFetch(PRO_MENU_ENDPOINT);
+  if (!menuResponse?.ok) {
+    if (!menuResponse || menuResponse.status >= 500) {
       // Sidebar nav is non-critical — render page without it and signal 503
       context.res.statusCode = 503;
       context.res.setHeader("Retry-After", "10");

--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -294,6 +294,7 @@ export async function getServerSideProps(context) {
   }
 
   if (page > MAX_PAGE_SIZE) {
+    context.res.statusCode = 400;
     return {
       props: {
         maxPageError: true,
@@ -325,12 +326,16 @@ export async function getServerSideProps(context) {
     const fetchErrorProps = { props: washObject({ fetchError: true, results: { docs: [], facets: {} } }) };
 
     const res = await safeFetch(url);
-    if (!res?.ok) return fetchErrorProps;
+    if (!res?.ok) {
+      context.res.statusCode = res ? res.status : 503;
+      return fetchErrorProps;
+    }
 
     let json;
     try {
       json = await res.json();
     } catch {
+      context.res.statusCode = 503;
       return fetchErrorProps;
     }
 


### PR DESCRIPTION
## Summary

- **`lib/safeFetch.js`**: Fix `body.cancel()` to use `?.cancel?.().catch(() => {})` so a rejection never propagates up the 503-retry path
- **`pages/search/index.js`**: Set `statusCode 400` for `maxPageError` (page > limit) and the actual upstream status (or 503 for network failure) for `fetchError` — degraded props no longer silently return HTTP 200
- **`pages/about/`, `pages/browse-by-topic/`, `pages/pro/hubs.js`**: Add `isUpstreamUnavailable` guard before `!ok` checks so null/503 upstream returns a 503 + Retry-After response instead of a 404
- **`pages/contact/`, `pages/projects/dpla-wikimedia/metrics.js`**: Degrade gracefully on 5xx (render with empty sidebar + `statusCode 503`) rather than `{ notFound: true }`; contact form and Grafana embed still work without nav
- **`pages/index.js`**: Distinguish 5xx from 4xx on settings fetch; fix catch block to log error and call `upstreamUnavailable()` instead of `{ notFound: true }`

**Why it matters:** Returning `{ notFound: true }` for transient upstream 5xx errors tells crawlers the page doesn't exist, pollutes monitoring with false 404s, and may cause caches to serve a 404 indefinitely for content that will return when the upstream recovers.

## Test plan

- [ ] Search page: navigate to page > 1000 — should return HTTP 400
- [ ] Browse-by-topic: verify the page renders `ServiceUnavailable` (not 404) when the WP API is down
- [ ] About page: same — upstream 503 should propagate as 503, not 404
- [ ] Homepage: same
- [ ] Contact page: verify the contact form renders even when the sidebar menu API is unavailable
- [ ] Metrics page: verify the Grafana embed renders even when the Pro menu API is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

**Bug Fixes**
- Prevents transient upstream 5xx errors from being misclassified as 404s by:
  - Adding upstream-unavailability guards (isUpstreamUnavailable / upstreamUnavailable) so null or 5xx responses return HTTP 503 with Retry-After instead of { notFound: true } across many SSR pages (about, about/[...sections], browse-by-topic, pro/hubs, pro index, primary-source-sets pages, news pages, item pages, guides, homepage).
  - Making sidebar/menu fetches degrade gracefully on 5xx (contact page, projects/dpla-wikimedia/metrics) by returning empty sidebar props and statusCode 503 instead of notFound; contact form and Grafana embed remain usable when nav/menu fetches fail.
  - Ensuring search page returns HTTP 400 for page > limit and sets context.res.statusCode to the actual upstream status (or 503 for network failures) when upstream fetches fail, avoiding silently returning HTTP 200 with degraded props.
  - Distinguishing 5xx from 4xx on settings/homepage fetches and fixing the homepage catch block to log errors and call upstreamUnavailable() instead of returning notFound inappropriately.
- Defensive change in lib/safeFetch.js: when retrying after a 503 the response body is cancelled defensively using optional chaining and error suppression (await res.body?.cancel?.() wrapped in try/catch), so cancellation rejections do not propagate into the retry logic.

**New Behavior**
- Multiple pages (homepage, browse-by-topic, pro hubs, about pages, and several others) now accept a temporarilyUnavailable prop and render a ServiceUnavailable (503) page when upstream WordPress/API endpoints are unavailable. Server-side handlers return a 503 + Retry-After (10s) and props { temporarilyUnavailable: true } when appropriate.

Operational notes (explicit checks required by reviewer)
- No manual pipeline trigger or ECS redeployment is required for these changes to take effect.
- No environment variables or AWS Secrets Manager keys were added, removed, or renamed.
- There are no database migrations.
- No shared infrastructure configuration (CodePipeline, CodeBuild, ECS task definitions, IAM policies) is modified.
- No public-facing API response shapes or endpoints were added, removed, or renamed.
- Security implications: this is defensive error-handling and availability behavior only; there are no authentication, credential-handling, or new external-credential changes.

Files / Areas Affected (high level)
- lib/safeFetch.js: safer cancellation in 503 retry path; exports isUpstreamUnavailable and upstreamUnavailable helpers used across SSR pages.
- pages: search, index (homepage), about (index and [...sections]), browse-by-topic, contact, pro/hubs, projects/dpla-wikimedia/metrics, plus many other SSR pages updated to use isUpstreamUnavailable/upstreamUnavailable or safeFetch — getServerSideProps in several pages now accepts context and may return 503 + Retry-After or degrade props instead of { notFound: true }.

Why this matters
- Ensures transient upstream 5xx outages produce proper 503 responses (with Retry-After) instead of 404s, reducing misleading crawler signals, incorrect caching of 404 responses, and monitoring noise, while preserving usable page functionality where it can degrade gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->