### PR TITLE
fix(guides): replace plain fetch() with cachedSafeFetch/safeFetch + draft mode

### DIFF
--- a/pages/guides/index.js
+++ b/pages/guides/index.js
@@ -88,6 +88,10 @@ export async function getServerSideProps(context) {
     (item) => item.url === endpoint,
   );
 
+  if (!indexPageItem) {
+    return { notFound: true };
+  }
+
   const guides = (
     await Promise.all(
       aboutMenuJson.items

--- a/pages/guides/index.js
+++ b/pages/guides/index.js
@@ -101,7 +101,7 @@ export async function getServerSideProps(context) {
           const guideJson = await guideRes.json();
           return {
             ...guide,
-            slug: guide.post_name,
+            slug: guideJson.slug ?? guide.post_name,
             summary: guideJson.acf.summary,
             title: guideJson.title.rendered,
             displayTitle: guideJson.acf.display_title,

--- a/pages/guides/index.js
+++ b/pages/guides/index.js
@@ -3,6 +3,7 @@ import React from "react";
 import MainLayout from "components/MainLayout";
 import ContentPagesSidebar from "shared/ContentPagesSidebar";
 import GuideLink from "shared/GuideLink";
+import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
 import { getMenuItemUrl } from "lib";
 
@@ -14,9 +15,18 @@ import contentCss from "stylesheets/content-pages.module.scss";
 import css from "stylesheets/guides.module.scss";
 import utils from "stylesheets/utils.module.scss";
 import { washObject } from "lib/washObject";
+import {
+  safeFetch,
+  wpAuthFetchOptions,
+  wpDraftUrl,
+  isUpstreamUnavailable,
+  upstreamUnavailable,
+} from "lib/safeFetch";
+import { cachedSafeFetch } from "lib/wpCache";
 
 function Guides(props) {
-  const { guides, sidebarItems, activeItemId } = props;
+  const { guides, sidebarItems, activeItemId, temporarilyUnavailable } = props;
+  if (temporarilyUnavailable) return <ServiceUnavailable />;
   if (!Array.isArray(guides)) return null;
   return (
     <MainLayout pageTitle={TITLE}>
@@ -55,21 +65,24 @@ function Guides(props) {
   );
 }
 
-export async function getServerSideProps() {
-  // fetch page info
-  // 1. fetch the settings from WP
-  const settingsRes = await fetch(API_SETTINGS_ENDPOINT);
-  if (!settingsRes.ok) {
-    return { notFound: true };
-  }
-  const settingsJson = await settingsRes.json();
-  // 2. get the corresponding value
-  const endpoint = `${PAGES_ENDPOINT}/${settingsJson.acf.guides_endpoint}`;
+export async function getServerSideProps(context) {
+  const { draftMode } = context;
+  const authOptions = wpAuthFetchOptions(draftMode);
 
-  const aboutMenuRes = await fetch(ABOUT_MENU_ENDPOINT);
-  if (!aboutMenuRes.ok) {
+  const [settingsRes, aboutMenuRes] = await Promise.all([
+    cachedSafeFetch(API_SETTINGS_ENDPOINT),
+    cachedSafeFetch(ABOUT_MENU_ENDPOINT),
+  ]);
+
+  if (isUpstreamUnavailable(settingsRes) || isUpstreamUnavailable(aboutMenuRes)) {
+    return upstreamUnavailable(context.res, settingsRes, aboutMenuRes);
+  }
+  if (!settingsRes.ok || !aboutMenuRes.ok) {
     return { notFound: true };
   }
+
+  const settingsJson = await settingsRes.json();
+  const endpoint = `${PAGES_ENDPOINT}/${settingsJson.acf.guides_endpoint}`;
   const aboutMenuJson = await aboutMenuRes.json();
   const indexPageItem = aboutMenuJson.items.find(
     (item) => item.url === endpoint,
@@ -80,8 +93,11 @@ export async function getServerSideProps() {
       aboutMenuJson.items
         .filter((item) => item.menu_item_parent === indexPageItem.object_id)
         .map(async (guide) => {
-          const guideRes = await fetch(getMenuItemUrl(guide));
-          if (!guideRes.ok) return null;
+          const guideUrl = draftMode
+            ? wpDraftUrl(getMenuItemUrl(guide))
+            : getMenuItemUrl(guide);
+          const guideRes = await safeFetch(guideUrl, authOptions);
+          if (!guideRes?.ok) return null;
           const guideJson = await guideRes.json();
           return {
             ...guide,

--- a/pages/index.js
+++ b/pages/index.js
@@ -166,7 +166,7 @@ export async function getServerSideProps(context) {
               const guideJson = await guideRes.json();
               return {
                 ...guide,
-                slug: guide.post_name,
+                slug: guideJson.slug ?? guide.post_name,
                 summary: guideJson.acf.summary,
                 title: guideJson.title.rendered,
                 displayTitle: guideJson.acf.display_title,


### PR DESCRIPTION
## Summary

- **Root cause (Sentry DPLA-FRONTEND-TN):** `pages/guides/index.js` used raw `fetch()` for all WPEngine calls with no retry or fallback. WPEngine's hourly maintenance windows produce `ConnectTimeoutError` (undici `UND_ERR_CONNECT_TIMEOUT`), which raw `fetch()` propagates as an unhandled exception — 117 occurrences since June 2025. The preview PR (#1398) updated `[guideSlug].js` but missed the index page; the wpCache PR (#1428) covered pro pages but also missed it.
- **Switch to `cachedSafeFetch`** for `API_SETTINGS_ENDPOINT` and `ABOUT_MENU_ENDPOINT` — serves stale in-memory data during network failures (same fix applied to pro pages in #1428)
- **Run both top-level fetches in parallel** via `Promise.all` — they are independent; was previously sequential, doubling latency
- **Switch individual guide fan-out to `safeFetch`** — retries once on `UND_ERR_CONNECT_TIMEOUT`; returns `null` on persistent failure so `filter(Boolean)` degrades gracefully rather than throwing
- **Add `isUpstreamUnavailable` / `upstreamUnavailable` guards** — persistent upstream failure now returns HTTP 503 + `Retry-After` and renders `ServiceUnavailable` instead of an unhandled 500
- **Add Draft Mode support** — `getServerSideProps` now accepts `context`, reads `draftMode`, and passes `wpDraftUrl` + `wpAuthFetchOptions` to guide fetches so WP preview works on the index page (was completely absent)

## Test plan

- [ ] `/guides` renders normally in production
- [ ] Sentry DPLA-FRONTEND-TN stops receiving new events after deploy
- [ ] WP admin Preview on a guide page redirects to `/guides/[slug]` correctly (existing behaviour unchanged — this PR only adds the missing auth wiring on the index)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes unhandled connection timeout errors during WPEngine maintenance windows by replacing raw fetch() calls with safer fetch utilities, adding graceful degradation and retry logic, upstream-unavailable guards, and Draft Mode (preview) support for the /guides index page.

Key changes
- Safer top-level fetches: API_SETTINGS_ENDPOINT and ABOUT_MENU_ENDPOINT now use cachedSafeFetch (can serve stale in-memory data during network failures) and are awaited in parallel via Promise.all to reduce latency.
- Safer guide fetches: per-guide fan-out uses safeFetch, which retries once on undici UND_ERR_CONNECT_TIMEOUT and returns null on persistent failure; nulls are filtered so individual guide failures don’t crash the page.
- Upstream-unavailable handling: added isUpstreamUnavailable / upstreamUnavailable guards. Persistent upstream failure now returns HTTP 503 with Retry-After and renders ServiceUnavailable (temporarilyUnavailable prop) instead of causing an unhandled 500.
- Draft Mode / preview support: getServerSideProps in pages/guides/index.js now accepts context, reads draftMode, derives wpAuthFetchOptions, rewrites guide URLs with wpDraftUrl when needed, and passes auth options so WordPress preview works on the /guides index.
- Slug handling fix: pages/index.js and pages/guides/index.js now prefer guideJson.slug with fallback to guide.post_name so homepage guide cards use canonical slugs (follow-up commit f8dc2cb).
- Guard for cache skew: handles missing indexPageItem when cachedSafeFetch returns stale/skewed content for settings and about-menu endpoints to avoid runtime TypeError.
- Observability: targets Sentry issue DPLA-FRONTEND-TN (undici UND_ERR_CONNECT_TIMEOUT) — 117 occurrences recorded since June 2025; expected to cease after deploy.

Security & environment
- Uses existing env vars WP_PREVIEW_USER and WP_PREVIEW_APP_PASSWORD for draftMode; no new environment variables or AWS Secrets Manager keys added.
- sanitizeUrl is used in safeFetch logging to avoid leaking sensitive query params or credentials.

Infrastructure, APIs, and migrations
- No infrastructure/config changes required: no manual pipeline trigger, no ECS redeploy specified, and no changes to CodePipeline/CodeBuild/ECS task definitions or IAM policies.
- No database migrations.
- No changes to public-facing API response shapes or endpoints. The only new response condition is returning HTTP 503 for upstream-unavailable scenarios (previously would surface as a 500/unhandled error).

Tests / reviewer notes
- Verify /guides renders normally in production and that Sentry DPLA-FRONTEND-TN stops receiving new events after deploy.
- Confirm WP admin Preview for a guide redirects to /guides/[slug] correctly (index page preview auth wiring).
- Confirm homepage guide cards use API-provided canonical slugs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->