### PR TITLE
Fix unmatched routes returning 502 instead of 404 on user site

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -188,6 +188,7 @@ let config = {
           fourOhFour("/local/markdown"),
           fourOhFour("/projects/dpla-wikimedia/:slugs*"),
         ],
+        fallback: [fourOhFour("/:slugs*")],
       };
     } else if (siteEnv === "cqa") {
       return {


### PR DESCRIPTION
## Summary

- Adds a `fallback` rewrite catch-all to the user site (`siteEnv === "user"`) in `next.config.js`
- Any path not matched by a page file is now explicitly routed to `/404`, producing a proper 404 response
- Previously, unrecognized paths (e.g. `/pro-site/hubs/our-hubs/`) fell through to Next.js internal error handling, which can produce a 502 via `_error.js`/Sentry rather than a clean 404

The `fallback` position (vs `beforeFiles`) is intentional: it runs after all page files are checked, so valid routes like `/search`, `/item/[id]`, `/news/[slug]`, etc. are unaffected.

## Test plan

- [ ] Navigate to an invalid path on the user site (e.g. `/pro-site/anything`) — should get a 404 page, not a 502
- [ ] Verify valid routes (`/search`, `/item/[id]`, `/news/[slug]`, `/about`, etc.) continue to work normally
- [ ] Verify the existing `beforeFiles` blocks (`/pro`, `/qa`, etc.) still return 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds a catch-all fallback rewrite to the user site's routing configuration so unmatched user-site routes return a proper 404 instead of falling through to Next.js internal error handling and producing 502 responses.

This change does not require a manual pipeline trigger or ECS redeployment, does not add/remove/rename environment variables or AWS Secrets Manager keys, includes no database migrations, does not change shared infrastructure (CodePipeline/CodeBuild/ECS/IAM), does not modify any public-facing API response shapes or endpoints, and has no direct security or credential implications.

## Changes

- next.config.js — For `siteEnv === "user"`, the `rewrites()` now includes:
  - fallback: [ fourOhFour("/:slugs*") ]
- Any unmatched user-site path (`/:slugs*`) is rewritten to `/404`.
- The rewrite is placed in the `fallback` phase so it runs after Next.js checks for page files; valid routes are unaffected.
- Existing explicit 404 `beforeFiles` mappings (e.g. `/pro`, `/qa`, `/local`) remain unchanged and continue to behave as before.

## Behavior / Test plan

- Navigate to an invalid path on the user site (e.g. `/pro-site/anything`) — should show 404, not 502.
- Verify valid routes continue to work (e.g. `/search`, `/item/[id]`, `/news/[slug]`, `/about`).
- Verify existing `beforeFiles` 404 mappings still return 404.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->