### PR TITLE
Fix /v2/items/undefined requests from browse-by-topic pages

### DIFF
--- a/lib/addLinkInfoToResults.js
+++ b/lib/addLinkInfoToResults.js
@@ -2,7 +2,7 @@ import extractItemId from "./extractItemId";
 
 const addLinkInfoToResults = (results) =>
   results.map((item) => {
-    const id = item.id || extractItemId(item["@id"]);
+    const id = extractItemId(item.id) || extractItemId(item["@id"]);
     return Object.assign({}, item, {
       linkHref: id ? { pathname: `/item/${id}` } : null,
     });

--- a/lib/addLinkInfoToResults.js
+++ b/lib/addLinkInfoToResults.js
@@ -2,10 +2,9 @@ import extractItemId from "./extractItemId";
 
 const addLinkInfoToResults = (results) =>
   results.map((item) => {
+    const id = item.id || extractItemId(item["@id"]);
     return Object.assign({}, item, {
-      linkHref: {
-        pathname: `/item/${item.id ? item.id : extractItemId(item["@id"])}`,
-      },
+      linkHref: id ? { pathname: `/item/${id}` } : null,
     });
   });
 

--- a/lib/extractItemId.js
+++ b/lib/extractItemId.js
@@ -1,4 +1,5 @@
 const extractItemId = url => {
+  if (!url) return null;
   const item = /\/(?:api\/)?items?\/(\w+)/.exec(url);
   return item ? item[1] : url;
 };

--- a/lib/getItemId.js
+++ b/lib/getItemId.js
@@ -9,7 +9,7 @@ const getItemId = source => {
       source.mainEntity[0]["dct:references"].filter(
         ref => ref["@type"] === "ore:Aggregation"
       )[0]["@id"]
-    );
+    ) ?? "";
   } catch (e) {}
   return id;
 };

--- a/pages/browse-by-topic/[topicSlug]/[subtopicSlug]/index.js
+++ b/pages/browse-by-topic/[topicSlug]/[subtopicSlug]/index.js
@@ -12,6 +12,7 @@ import {
   API_ENDPOINT_ALL_TOPICS,
   API_ENDPOINT_SUBTOPICS_FOR_TOPIC,
 } from "constants/topicBrowse";
+import { DPLA_ITEM_ID_REGEX } from "constants/items";
 
 import css from "components/TopicBrowseComponents/SubtopicItemsList/SubtopicItemsList.module.scss";
 import utils from "stylesheets/utils.module.scss";
@@ -137,6 +138,7 @@ export const getServerSideProps = async (context) => {
 
   const fetchItem = async (item) => {
     const itemDplaId = extractItemId(item.acf.dpla_url);
+    if (!itemDplaId || !DPLA_ITEM_ID_REGEX.test(itemDplaId)) return null;
     const itemUrl =
       `${process.env.API_URL}/items/${itemDplaId}` +
       `?api_key=${process.env.API_KEY}`;


### PR DESCRIPTION
## Summary

- `extractItemId` was coercing falsy inputs (e.g. a missing `acf.dpla_url` field) to the string `"undefined"` via JavaScript's implicit type coercion, which then interpolated into the API fetch URL as `/v2/items/undefined`
- Added a falsy-input guard to `extractItemId` so it returns `null` instead
- Added a `DPLA_ITEM_ID_REGEX` validation guard in the browse-by-topic `fetchItem` before the API call, catching both the null case and any URL that doesn't extract a valid 32-char hex DPLA ID — items with no valid ID are already filtered from results at the `allItems.filter` step

## Test plan

- [ ] Verify browse-by-topic subtopic pages load normally
- [ ] Confirm `/v2/items/undefined` no longer appears in Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Fix /v2/items/undefined requests from browse-by-topic pages

## Overview
This PR prevents browse-by-topic subtopic pages from issuing requests to /v2/items/undefined by making extractItemId and its callers handle missing or invalid DPLA URLs explicitly, and by validating extracted IDs before building DPLA API requests.

## Changes

- lib/extractItemId.js
  - Early guard: if (!url) return null;
  - Prevents falsy inputs (undefined/empty) from being coerced into the string "undefined".
  - Signature unchanged; returns null for missing inputs, otherwise returns the matched item ID or the original url when no match.

- pages/browse-by-topic/[topicSlug]/[subtopicSlug]/index.js
  - Import DPLA_ITEM_ID_REGEX and validate extracted IDs in fetchItem():
    - const itemDplaId = extractItemId(item.acf.dpla_url);
    - if (!itemDplaId || !DPLA_ITEM_ID_REGEX.test(itemDplaId)) return null;
  - Skips items without a valid 32-character hex DPLA ID so no /items/undefined requests are built.

- lib/addLinkInfoToResults.js
  - Normalize id using extractItemId(item.id) || extractItemId(item["@id"]);
  - Set linkHref to { pathname: `/item/${id}` } when id is truthy, otherwise null — avoids invalid link paths.

- lib/getItemId.js
  - Use nullish coalescing (?? "") when passing aggregation @id into extractItemId so callers that expect an empty-string contract continue to work:
    - id = extractItemId(...["@id"]) ?? "";

## Test plan
- Browse-by-topic subtopic pages should load normally.
- Confirm Sentry (or other error tracking) no longer shows /v2/items/undefined requests.

## Impact / Notes
- No changes to public API response shapes, endpoints, environment variables, AWS Secrets Manager keys, database migrations, or shared infrastructure (CodePipeline/CodeBuild/ECS/IAM).
- No manual pipeline trigger or special ECS redeploy required beyond the normal deployment of the application build.
- No security implications introduced (no new secrets, credential handling, or auth changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->