### PR TITLE
feat: add /item/:id.json shortcut endpoint

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -106,6 +106,7 @@ let config = {
       const local = LOCALS[localId];
       const results = [
         rewrite("/", "/local"),
+        rewrite("/item/:id([0-9a-f]{32}).json", "/api/items/:id?single=1"),
         fourOhFour("/qa"),
         fourOhFour("/exhibitions"),
         fourOhFour("/exhibitions/:slugs*"),

--- a/next.config.js
+++ b/next.config.js
@@ -180,7 +180,7 @@ let config = {
     } else if (siteEnv === "user") {
       return {
         beforeFiles: [
-          rewrite("/item/:id([0-9a-f]{32}).json", "/api/items/:id"),
+          rewrite("/item/:id([0-9a-f]{32}).json", "/api/items/:id?single=1"),
           fourOhFour("/qa"),
           fourOhFour("/pro"),
           fourOhFour("/pro/hubs"),
@@ -194,7 +194,7 @@ let config = {
     } else if (siteEnv === "cqa") {
       return {
         beforeFiles: [
-          rewrite("/item/:id([0-9a-f]{32}).json", "/api/items/:id"),
+          rewrite("/item/:id([0-9a-f]{32}).json", "/api/items/:id?single=1"),
           rewrite("/", "/qa"),
           fourOhFour("/about"),
           fourOhFour("/about/:slugs*"),

--- a/next.config.js
+++ b/next.config.js
@@ -180,6 +180,7 @@ let config = {
     } else if (siteEnv === "user") {
       return {
         beforeFiles: [
+          rewrite("/item/:id([0-9a-f]{32}).json", "/api/items/:id"),
           fourOhFour("/qa"),
           fourOhFour("/pro"),
           fourOhFour("/pro/hubs"),
@@ -193,6 +194,7 @@ let config = {
     } else if (siteEnv === "cqa") {
       return {
         beforeFiles: [
+          rewrite("/item/:id([0-9a-f]{32}).json", "/api/items/:id"),
           rewrite("/", "/qa"),
           fourOhFour("/about"),
           fourOhFour("/about/:slugs*"),

--- a/pages/api/items/[idListString].js
+++ b/pages/api/items/[idListString].js
@@ -5,7 +5,7 @@ import {DPLA_ITEM_ID_REGEX} from "constants/items";
 
 export default async function handler(req, res) {
 
-    const { idListString } = req.query
+    const { idListString, single } = req.query
     const idList = idListString ? idListString.split(",") : []
     const validIds = idList.filter(id => !!id && DPLA_ITEM_ID_REGEX.test(id));
 
@@ -21,12 +21,21 @@ export default async function handler(req, res) {
         baseUrl.pathname += validIds.join(",");
         const fetchRes = await fetch(baseUrl);
         if (fetchRes.ok) {
-            const contentType = fetchRes.headers.get("Content-Type") || "application/json";
-            res.setHeader("Content-Type", contentType);
             res.setHeader("Cache-Control", "public, max-age=86400");
-            res.status(200);
-            await pipeline(Readable.fromWeb(fetchRes.body), res);
-
+            if (single === "1") {
+                const data = await fetchRes.json();
+                const doc = data?.docs?.[0];
+                if (!doc) {
+                    res.status(404).send("Not found.");
+                    return;
+                }
+                res.status(200).json(doc);
+            } else {
+                const contentType = fetchRes.headers.get("Content-Type") || "application/json; charset=utf-8";
+                res.setHeader("Content-Type", contentType);
+                res.status(200);
+                await pipeline(Readable.fromWeb(fetchRes.body), res);
+            }
         } else {
             res.status(404).send("Not found.");
         }

--- a/pages/api/items/[idListString].js
+++ b/pages/api/items/[idListString].js
@@ -23,6 +23,7 @@ export default async function handler(req, res) {
         if (fetchRes.ok) {
             const contentType = fetchRes.headers.get("Content-Type") || "application/json";
             res.setHeader("Content-Type", contentType);
+            res.setHeader("Cache-Control", "public, max-age=86400");
             res.status(200);
             await pipeline(Readable.fromWeb(fetchRes.body), res);
 

--- a/pages/api/items/[idListString].js
+++ b/pages/api/items/[idListString].js
@@ -4,6 +4,11 @@ import {DPLA_ITEM_ID_REGEX} from "constants/items";
 
 
 export default async function handler(req, res) {
+    if (req.method !== "GET") {
+        res.setHeader("Allow", "GET");
+        res.status(405).json({ error: "Method not allowed" });
+        return;
+    }
 
     const { idListString, single } = req.query
     const idList = idListString ? idListString.split(",") : []
@@ -11,7 +16,7 @@ export default async function handler(req, res) {
 
     if (validIds.length === 0) {
         console.log("Zero valid ids");
-        res.status(404).json({});
+        res.status(404).json({ error: "Not found." });
         return
     }
 
@@ -21,27 +26,29 @@ export default async function handler(req, res) {
         baseUrl.pathname += validIds.join(",");
         const fetchRes = await fetch(baseUrl);
         if (fetchRes.ok) {
-            res.setHeader("Cache-Control", "public, max-age=86400");
             if (single === "1") {
                 const data = await fetchRes.json();
                 const doc = data?.docs?.[0];
                 if (!doc) {
-                    res.status(404).send("Not found.");
+                    res.status(404).json({ error: "Not found." });
                     return;
                 }
+                res.setHeader("Cache-Control", "public, max-age=86400");
                 res.status(200).json(doc);
             } else {
                 const contentType = fetchRes.headers.get("Content-Type") || "application/json; charset=utf-8";
+                res.setHeader("Cache-Control", "public, max-age=86400");
                 res.setHeader("Content-Type", contentType);
                 res.status(200);
                 await pipeline(Readable.fromWeb(fetchRes.body), res);
             }
         } else {
-            res.status(404).send("Not found.");
+            fetchRes.body?.cancel?.().catch(() => {});
+            res.status(404).json({ error: "Not found." });
         }
 
     } catch (err) {
         console.log("Error proxying request to DPLA API.", err);
-        res.status(404).json({});
+        res.status(404).json({ error: "Not found." });
     }
 }

--- a/pages/api/items/[idListString].js
+++ b/pages/api/items/[idListString].js
@@ -44,7 +44,11 @@ export default async function handler(req, res) {
             }
         } else {
             fetchRes.body?.cancel?.().catch(() => {});
-            res.status(404).json({ error: "Not found." });
+            if (fetchRes.status === 404) {
+                res.status(404).json({ error: "Not found." });
+            } else {
+                res.status(fetchRes.status).json({ error: "Upstream service error." });
+            }
         }
 
     } catch (err) {

--- a/pages/api/items/[idListString].js
+++ b/pages/api/items/[idListString].js
@@ -49,6 +49,6 @@ export default async function handler(req, res) {
 
     } catch (err) {
         console.log("Error proxying request to DPLA API.", err);
-        res.status(404).json({ error: "Not found." });
+        res.status(502).json({ error: "Upstream service error." });
     }
 }


### PR DESCRIPTION
## Summary

- Adds a `beforeFiles` rewrite in `next.config.js` so that appending `.json` to any item URL returns the raw item metadata JSON — e.g. `https://dp.la/item/452eaab716d4160d1bb7f0298d79449e.json`
- The rewrite maps `/item/:id([0-9a-f]{32}).json` → `/api/items/:id`, reusing the existing proxy route. The regex parameter ensures only valid 32-char hex IDs match; anything else falls through to the normal 404 path.
- Adds `Cache-Control: public, max-age=86400` to successful responses from the `/api/items/` handler, so CDN and browsers cache item lookups for 24 hours. Applies to both the direct `/api/items/` path and the new `.json` rewrite.
- Applied to both `user` (dp.la) and `cqa` (staging) environments.

## Notes

A Cloudflare rate limiting rule (60 req/60s per IP, Block) covering `/api/items/*` and `/item/*.json` should be created in the dashboard before this is publicized — the WAF token in secrets doesn't have Zone Rulesets Edit permission.

## Test plan

- [ ] Visit `https://dp.la/item/<id>.json` — should return raw JSON with `Content-Type: application/json` and `Cache-Control: public, max-age=86400`
- [ ] Visit with an invalid/non-hex ID suffix — should 404
- [ ] Visit `https://dp.la/api/items/<id>` directly — should also include `Cache-Control` header now
- [ ] Verify the existing item page at `https://dp.la/item/<id>` (no `.json`) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a JSON shortcut endpoint for individual item metadata, tightens the items API handler, and enables 24-hour caching for item lookups.

### Changes
- next.config.js
  - Adds a beforeFiles rewrite so requests matching /item/:id([0-9a-f]{32}).json are rewritten to /api/items/:id?single=1. Applied to user (dp.la), cqa (staging), and local environments. The regex restricts matches to 32-character hexadecimal IDs so other suffixes fall through to normal 404 handling.
- pages/api/items/[idListString].js
  - Enforces GET-only requests: non-GET methods return 405 with Allow: GET and JSON { "error": "Method not allowed" }.
  - Adds support for single=1: when single === "1" the handler parses upstream JSON and returns only the first document (data.docs[0]) or 404 if missing.
  - For non-single requests, preserves proxy/streaming behavior but now sets Cache-Control and Content-Type before piping the upstream body.
  - Successful responses now include Cache-Control: public, max-age=86400 (applies to direct /api/items/ and requests routed via the .json rewrite).
  - Error handling changes: upstream 404 → client 404 with { "error": "Not found." }; other upstream non-OK statuses are proxied to the client (previous behavior clarified) and unexpected exceptions return 502 with { "error": "Upstream service error." }.
  - Commit note: “fix: propagate upstream status for non-404 errors from DPLA API” documents the upstream-status propagation behavior.

### Public API impact
- New public-facing shortcut endpoint: /item/<id>.json returns raw item metadata JSON with Content-Type: application/json and Cache-Control: public, max-age=86400.
- Requests using single=1 (including the .json rewrite) now return a single document object (data.docs[0]) rather than streaming the full upstream body — this changes the response shape for single=1 consumers.
- Non-hex or otherwise non-matching .json suffixes will continue to 404.
- Non-GET requests to /api/items/* now receive 405 with a JSON error body.

### Security and operational notes
- No authentication changes, no new credentials, no database migrations.
- No changes to environment variables, AWS Secrets Manager keys, CodePipeline/CodeBuild/ECS task definitions, or IAM policies.
- Operational requirement before public rollout: create a Cloudflare rate-limiting rule (suggested: 60 req / 60s per IP, Block) covering /api/items/* and /item/*.json. The current WAF token in secrets lacks Zone Rulesets Edit permission, so that rule cannot be deployed via CI with existing credentials.

### Deployment notes
- Changes take effect after deploying the updated Next.js frontend via the normal pipeline. No separate ECS redeployment or other infrastructure modification is required. No manual pipeline trigger beyond a normal deploy is indicated.

### Test checklist
- Visit https://dp.la/item/<id>.json — expect raw JSON, Content-Type: application/json, Cache-Control: public, max-age=86400.
- Visit https://dp.la/item/<id> (without .json) — existing item page must remain unaffected.
- Visit https://dp.la/item/<invalid-suffix>.json — expect 404 (non-hex ID falls through).
- Visit https://dp.la/api/items/<id> directly — expect Cache-Control header present.
- Non-GET to /api/items/* — expect 405 with Allow: GET and JSON error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->