### PR TITLE
feat: add Metadata links widget on item pages

### DIFF
--- a/components/ItemComponents/itemComponent.module.scss
+++ b/components/ItemComponents/itemComponent.module.scss
@@ -29,6 +29,30 @@
   background-color: var(--colderBackgroundColor);
 }
 
+.metadataLinks {
+  background-color: var(--colderBackgroundColor);
+  border-radius: 3px;
+  margin-bottom: 0.5rem;
+  padding: 0.75rem;
+  width: 100%;
+
+  h2 {
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 0 0 0.5rem;
+  }
+
+  ul {
+    font-size: 0.9rem;
+    margin: 0;
+    padding-left: 1.25rem;
+  }
+
+  a, a:visited {
+    color: var(--subLinkColor);
+  }
+}
+
 .notFound {
   margin: 0 0 3rem;
 }

--- a/components/ItemComponents/itemComponent.module.scss
+++ b/components/ItemComponents/itemComponent.module.scss
@@ -51,6 +51,11 @@
   a, a:visited {
     color: var(--subLinkColor);
   }
+
+  a:hover,
+  a:focus-visible {
+    color: var(--subLinkColorHover);
+  }
 }
 
 .notFound {

--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -78,6 +78,7 @@ export default function ItemDetail({ item, temporarilyUnavailable, randomItemId,
   }
 
   if (!item) return null;
+  const metadataBase = `/item/${item.id}`;
   return (
     <MainLayout pageTitle={item.title} pageImage={item.thumbnailUrl} pageDescription={pageDescription} canonicalUrl={canonicalUrl}>
       <BreadcrumbsModule
@@ -116,8 +117,8 @@ export default function ItemDetail({ item, temporarilyUnavailable, randomItemId,
           <div className={css.metadataLinks}>
             <h2>Metadata</h2>
             <ul>
-              <li><a href={`/item/${item.id}.raw`}>Original record</a></li>
-              <li><a href={`/item/${item.id}.json`}>Enriched JSON-LD</a></li>
+              <li><a href={`${metadataBase}.raw`}>Original record</a></li>
+              <li><a href={`${metadataBase}.json`}>Enriched JSON-LD</a></li>
             </ul>
           </div>
           <CiteButton

--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -113,6 +113,13 @@ export default function ItemDetail({ item, temporarilyUnavailable, randomItemId,
       >
         <Content item={item} />
         <div className={css.faveAndCiteButtons}>
+          <div className={css.metadataLinks}>
+            <h2>Metadata</h2>
+            <ul>
+              <li><a href={`/item/${item.id}.raw`}>Original record</a></li>
+              <li><a href={`/item/${item.id}.json`}>Enriched JSON-LD</a></li>
+            </ul>
+          </div>
           <CiteButton
             creator={item.creator}
             displayDate={item.date ? item.date.displayDate : item.date}


### PR DESCRIPTION
## Summary

- Adds a \"Metadata\" widget above the Cite button on item detail pages
- Links to \"Original record\" (`/item/:id.raw`) and \"Enriched JSON-LD\" (`/item/:id.json`) — the endpoints added in PRs #1451 and #1453
- Styled with `--colderBackgroundColor` and `--subLinkColor` CSS custom properties to match the surrounding sidebar elements
- Uses plain `<a>` tags (not Next.js `<Link>`) to avoid prefetching API route rewrites

## Test plan

- [ ] Visit any item page (e.g. `/item/452eaab716d4160d1bb7f0298d79449e`) and confirm the Metadata widget appears above the Cite button
- [ ] Click \"Original record\" — should return the raw XML or JSON for the item
- [ ] Click \"Enriched JSON-LD\" — should return the enriched JSON-LD for the item
- [ ] Verify styling matches the Cite button background (cold background, subdued link color)
- [ ] Confirm widget renders correctly on mobile (stacked) and desktop (sidebar) layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR adds a new "Metadata" widget to item detail pages, positioned above the Cite button. The widget provides direct access to raw and enriched data representations for items.

## Changes

### UI Component
- Added a new Metadata links widget to item detail pages (`pages/item/[itemId].js`)
- Widget contains two anchor links:
  - "Original record" pointing to `/item/:id.raw`
  - "Enriched JSON-LD" pointing to `/item/:id.json`
- Plain `<a>` tags used instead of Next.js Link to avoid prefetching API route rewrites
- Links are derived from the item ID via a `metadataBase` variable

### Styling
- New `.metadataLinks` CSS module class added to `components/ItemComponents/itemComponent.module.scss`
- Styling includes:
  - Full-width container with background color, border radius, and padding
  - Typography rules for headings and lists
  - Link styling using CSS custom properties (`--subLinkColor`, `--subLinkColorHover`)
  - Interactive states for `:hover` and `:focus-visible`
- Styling matches the surrounding Cite button and sidebar elements

## Testing
The PR includes a test plan requesting reviewers to verify:
- Widget appears on item detail pages
- Each link returns the expected raw/enriched data responses
- Styling consistency with the Cite button
- Correct rendering on mobile (stacked) and desktop (sidebar) layouts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->