### PR TITLE
Pretty-print /item/:id.json endpoint output

### DIFF
--- a/pages/api/items/[idListString].js
+++ b/pages/api/items/[idListString].js
@@ -33,8 +33,9 @@ export default async function handler(req, res) {
                     res.status(404).json({ error: "Not found." });
                     return;
                 }
+                res.setHeader("Content-Type", "application/json; charset=utf-8");
                 res.setHeader("Cache-Control", "public, max-age=86400");
-                res.status(200).json(doc);
+                res.status(200).send(JSON.stringify(doc, null, 2));
             } else {
                 const contentType = fetchRes.headers.get("Content-Type") || "application/json; charset=utf-8";
                 res.setHeader("Cache-Control", "public, max-age=86400");


### PR DESCRIPTION
## Summary

- Switches the single-item `.json` endpoint from `res.json()` (minified) to `res.send(JSON.stringify(doc, null, 2))` with an explicit `Content-Type: application/json; charset=utf-8` header
- Makes the output render formatted in the browser, consistent with the `.raw` endpoint's JSON handling

## Test plan

- [ ] Visit `/item/<32-char-id>.json` in a browser and confirm output is indented
- [ ] Confirm the response still has `Content-Type: application/json; charset=utf-8`
- [ ] Confirm `Cache-Control: public, max-age=86400` is still present
- [ ] Confirm a nonexistent ID still returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR modifies the single-item JSON endpoint (`/item/:id.json`) to return pretty-printed JSON instead of minified output, improving readability when viewing the response in a browser.

## Changes
- **File modified:** `pages/api/items/[idListString].js`
- For single-item requests (`single === "1"`), the endpoint now:
  - Explicitly sets the `Content-Type` header to `application/json; charset=utf-8`
  - Returns pretty-printed JSON using `JSON.stringify(doc, null, 2)` instead of the framework's default `res.json()` method
  - Preserves the existing `Cache-Control: public, max-age=86400` header
  - Maintains the same error handling and status codes for invalid or missing items

## Public API Impact
⚠️ **This modifies the public-facing API response format**: While the JSON content structure remains identical, the response is now formatted with indentation (2-space indent) rather than being minified. This is a cosmetic change that improves browser readability but does not affect the data structure or content.

## Testing Considerations
- Verify `/item/<id>.json` returns indented JSON in a browser
- Confirm response headers include `Content-Type: application/json; charset=utf-8` and the existing cache control header
- Verify 404 responses still work for nonexistent IDs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->