### PR TITLE
Guard idListString query param against array type

### DIFF
--- a/pages/api/items/[idListString].js
+++ b/pages/api/items/[idListString].js
@@ -10,14 +10,16 @@ export default async function handler(req, res) {
         return;
     }
 
-    const { idListString, single } = req.query
-    const idList = idListString ? idListString.split(",") : []
-    const validIds = idList.filter(id => !!id && DPLA_ITEM_ID_REGEX.test(id));
+    const { idListString, single } = req.query;
+    if (typeof idListString !== "string") {
+        res.status(404).json({ error: "Not found." });
+        return;
+    }
+    const validIds = idListString.split(",").filter(id => !!id && DPLA_ITEM_ID_REGEX.test(id));
 
     if (validIds.length === 0) {
-        console.log("Zero valid ids");
         res.status(404).json({ error: "Not found." });
-        return
+        return;
     }
 
     try {


### PR DESCRIPTION
## Summary

- Next.js query params are `string | string[]`; the existing code called `.split(",")` directly on the value, which would throw a `TypeError` if the same param appeared more than once in the query string
- Add `typeof idListString !== "string"` guard (consistent with the same check already in `pages/api/items/raw/[id].js`)
- Remove the stale `console.log("Zero valid ids")` from the zero-valid-ids path

Caught by CodeRabbit on the parallel BWS port (PR dpla/black-womens-suffrage#152).

## Test plan

- [ ] `/item/<valid-id>.json` still resolves correctly
- [ ] A request with a repeated param (e.g. `?idListString=abc&idListString=def`) returns 404 instead of a 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds a runtime type guard to the `/api/items/[idListString]` endpoint to handle cases where Next.js query parameters are arrays instead of strings. When a query parameter is repeated (e.g., `?idListString=abc&idListString=def`), Next.js represents it as an array, which would previously cause a TypeError when calling `.split(",")` on the array value.

## Changes

**pages/api/items/[idListString].js**
- Added `typeof idListString !== "string"` guard before calling `.split()`, returning a `404 { error: "Not found." }` response if the parameter is not a string (consistent with the pattern already used in `pages/api/items/raw/[id].js`)
- Removed a stale `console.log("Zero valid ids")` statement from the zero-valid-ids path
- Simplified the code by directly applying `.split(",").filter()` to `idListString` instead of using an intermediate `idList` variable

The fix ensures that repeated query parameters result in proper 404 responses instead of unhandled 500 errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->