### PR TITLE
Fix dead state and form-reset key bugs in modal components

### DIFF
--- a/components/ListComponents/ListNameModal/index.js
+++ b/components/ListComponents/ListNameModal/index.js
@@ -24,6 +24,7 @@ class ListNameModal extends React.Component {
     this.setState({
       active: true,
       timestamp: Date.now(),
+      value: this.props.value,
     });
   };
 

--- a/components/ListComponents/ListNameModal/index.js
+++ b/components/ListComponents/ListNameModal/index.js
@@ -15,7 +15,7 @@ class ListNameModal extends React.Component {
     this.state = {
       active: false,
       value: props.value,
-      onChange: props.onChange,
+      timestamp: null,
     };
   }
 
@@ -23,6 +23,7 @@ class ListNameModal extends React.Component {
     e.preventDefault();
     this.setState({
       active: true,
+      timestamp: Date.now(),
     });
   };
 

--- a/components/shared/ConfirmModal/index.js
+++ b/components/shared/ConfirmModal/index.js
@@ -14,7 +14,8 @@ class ConfirmModal extends React.Component {
     confirmText: DEFAULT_CONFIRM_TEXT,
     buttonText: DEFAULT_BUTTON_TEXT,
     confirmButtonText: DEFAULT_CONFIRM_BUTTON_TEXT,
-    onConfirm: null
+    onConfirm: null,
+    timestamp: null,
   };
 
   componentDidMount() {
@@ -29,7 +30,8 @@ class ConfirmModal extends React.Component {
   openConfirm = e => {
     e.preventDefault();
     this.setState({
-      active: true
+      active: true,
+      timestamp: Date.now(),
     });
   };
 
@@ -64,7 +66,7 @@ class ConfirmModal extends React.Component {
             <h2 className={utils.modalTitle}>
               {confirmText}
             </h2>
-            <div className={'.modalContinueCancelButtons'}>
+            <div className={utils.modalContinueCancelButtons}>
               <Button
                 className={utils.modalCancelButton}
                 type="ghost"

--- a/components/shared/ListView/ListImage.js
+++ b/components/shared/ListView/ListImage.js
@@ -8,7 +8,6 @@ import css from "./ListView.module.scss";
 class ListImage extends React.Component {
   state = {
     updateToDefaultImage: false,
-    item: this.props.item,
   };
 
   componentDidMount() {


### PR DESCRIPTION
## Summary

- **ListNameModal**: Replaced dead `onChange: props.onChange` state field (the callback was always called as `this.props.onChange` directly, never via state) with `timestamp: null`. Now writes `Date.now()` on `openForm` so the existing `key={this.state.timestamp}` on the form actually forces a remount between openings, clearing stale input values.
- **ConfirmModal**: Same timestamp fix. Also corrects a stringly-typed CSS class reference (`'.modalContinueCancelButtons'` → `utils.modalContinueCancelButtons`) that was silently broken.
- **ListImage**: Removed `item: this.props.item` dead state — the render method always reads `item` from `this.props` directly, so the state copy was never used and could silently drift from props.

These issues were surfaced by the GitHub `/security/quality` standard findings.

## Test plan

- [ ] Open a list name modal, type something, submit — open again and verify the input is blank (timestamp key fix)
- [ ] Open a confirm modal, verify it renders correctly with correct CSS (utils class fix)
- [ ] Verify list view images render correctly (ListImage state removal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixes dead state and form-reset key bugs in modal components to address GitHub /security/quality standard findings.

## Changes

**ListNameModal** (components/ListComponents/ListNameModal/index.js)
- Removed storing an unused prop callback in state.
- Added `timestamp` state (initialized null).
- `openForm()` now sets `timestamp = Date.now()` and snapshots `value` from props.
- Form now uses `key={this.state.timestamp}` so the form subtree remounts on each open, clearing stale input values.

**ConfirmModal** (components/shared/ConfirmModal/index.js)
- Added `timestamp` state (initialized null).
- `openConfirm()` sets `timestamp = Date.now()` and `active: true`.
- Form now uses `key={this.state.timestamp}` to force remounting on open.
- Fixed CSS module reference: replaced the incorrect string `'.modalContinueCancelButtons'` with `utils.modalContinueCancelButtons`.

**ListImage** (components/shared/ListView/ListImage.js)
- Removed a stale state copy of `item`; component reads `item` directly from props and retains only `updateToDefaultImage` in state.

## Testing

- ListNameModal: Open, type and submit or cancel, reopen — input should be reset/blank (or reflect current prop for rename).
- ConfirmModal: Open and verify modal renders with correct button container styling and confirm behavior.
- ListImage: Verify list view images render correctly and default thumbnail fallback still works.

## Impact and Notes

- No manual pipeline trigger or ECS redeploy required.
- No environment variable or AWS Secrets Manager changes.
- No database migrations.
- No changes to shared infrastructure (CodePipeline/CodeBuild/ECS/IAM).
- No public API response changes or new/removed endpoints.
- No security-sensitive changes (no auth/credential handling or new external data inputs beyond UI state fixes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->