### PR TITLE
Fix CodeQL code quality findings

### DIFF
--- a/components/ExhibitionsComponents/Exhibition/ImageAndCaption/index.js
+++ b/components/ExhibitionsComponents/Exhibition/ImageAndCaption/index.js
@@ -5,10 +5,7 @@ import Button from "shared/Button";
 
 import css from "./ImageAndCaption.module.scss";
 import utils from "stylesheets/utils.module.scss";
-import { useRouter } from "next/router";
-
 function ImageAndCaption({ title, thumbnailUrl, sectionSlug, slug, caption }) {
-  const router = useRouter();
   return (
     <figure className={css.wrapper}>
       <div className={`${utils.container} ${css.imageAndCaption}`}>

--- a/components/PrimarySourceSetsComponents/AllSets/components/SetsList/index.js
+++ b/components/PrimarySourceSetsComponents/AllSets/components/SetsList/index.js
@@ -4,7 +4,7 @@ import { useRouter } from "next/router";
 
 import Markdown from "react-markdown";
 
-import { extractSourceSetSlug, removeQueryParams } from "lib";
+import { extractSourceSetSlug } from "lib";
 
 import css from "./SetsList.module.scss";
 import utils from "stylesheets/utils.module.scss";

--- a/components/PrimarySourceSetsComponents/SingleSet/TeachersGuide/index.js
+++ b/components/PrimarySourceSetsComponents/SingleSet/TeachersGuide/index.js
@@ -3,7 +3,7 @@ import Link from "next/link";
 import Markdown from "react-markdown";
 import { withRouter } from "next/router";
 
-import { removeQueryParams, markdownLinks } from "lib";
+import { markdownLinks } from "lib";
 
 import contentCss from "stylesheets/content-pages.module.scss";
 import css from "./TeachersGuide.module.scss";

--- a/components/PrimarySourceSetsComponents/Source/components/SourceCarousel/CarouselSlider.js
+++ b/components/PrimarySourceSetsComponents/Source/components/SourceCarousel/CarouselSlider.js
@@ -6,7 +6,7 @@ import Markdown from "react-markdown";
 
 import { PrevArrow, NextArrow } from "components/shared/CarouselNavArrows";
 
-import { extractSourceId, removeQueryParams } from "lib";
+import { extractSourceId } from "lib";
 
 import css from "./SourceCarousel.module.scss";
 

--- a/components/shared/Accordion/index.js
+++ b/components/shared/Accordion/index.js
@@ -24,14 +24,15 @@ class Accordion extends React.Component {
     }
   }
 
-  componentDidUpdate(prevProps, prevState, snapshot) {
+  componentDidUpdate(prevProps) {
     if (prevProps.items !== this.props.items && Array.isArray(this.props.items)) {
-      this.setState({
-        items: this.props.items.map((item, i) => ({
+      const newItems = this.props.items;
+      this.setState((prevState) => ({
+        items: newItems.map((item, i) => ({
           ...item,
           active: prevState.items[i]?.active ?? true,
         })),
-      });
+      }));
     }
   }
 

--- a/components/shared/Accordion/index.js
+++ b/components/shared/Accordion/index.js
@@ -27,12 +27,17 @@ class Accordion extends React.Component {
   componentDidUpdate(prevProps) {
     if (prevProps.items !== this.props.items && Array.isArray(this.props.items)) {
       const newItems = this.props.items;
-      this.setState((prevState) => ({
-        items: newItems.map((item, i) => ({
-          ...item,
-          active: prevState.items[i]?.active ?? true,
-        })),
-      }));
+      this.setState((prevState) => {
+        const prevActiveByName = new Map(
+          prevState.items.map((prevItem) => [prevItem.name, prevItem.active]),
+        );
+        return {
+          items: newItems.map((item) => ({
+            ...item,
+            active: prevActiveByName.get(item.name) ?? item.active ?? true,
+          })),
+        };
+      });
     }
   }
 

--- a/components/shared/ConfirmModal/index.js
+++ b/components/shared/ConfirmModal/index.js
@@ -5,27 +5,14 @@ import Button from "shared/Button";
 
 const DEFAULT_CONFIRM_TEXT = "Are you sure?";
 const DEFAULT_BUTTON_TEXT = "Delete";
-const DEFAULT_CONFIRM_BUTTON_TEXT = "Delete";
 
 import utils from "stylesheets/utils.module.scss"
 
 class ConfirmModal extends React.Component {
   state = {
-    confirmText: DEFAULT_CONFIRM_TEXT,
-    buttonText: DEFAULT_BUTTON_TEXT,
-    confirmButtonText: DEFAULT_CONFIRM_BUTTON_TEXT,
-    onConfirm: null,
+    active: false,
     timestamp: null,
   };
-
-  componentDidMount() {
-    this.setState({
-      confirmText: this.props.text || DEFAULT_CONFIRM_TEXT,
-      buttonText: this.props.buttonText || DEFAULT_BUTTON_TEXT,
-      confirmButtonText: this.props.buttonText || DEFAULT_CONFIRM_BUTTON_TEXT,
-      onConfirm: this.props.onConfirm
-    });
-  }
 
   openConfirm = e => {
     e.preventDefault();
@@ -35,7 +22,7 @@ class ConfirmModal extends React.Component {
     });
   };
 
-  closeConfirm = e => {
+  closeConfirm = () => {
     this.setState({
       active: false
     });
@@ -43,12 +30,16 @@ class ConfirmModal extends React.Component {
 
   handleConfirm = e => {
     e.preventDefault();
-    this.state.onConfirm(e);
+    if (typeof this.props.onConfirm === "function") {
+      this.props.onConfirm(e);
+    }
   };
 
   render() {
-    const { active, confirmButtonText, buttonText, confirmText } = this.state;
-    const { className } = this.props;
+    const { active } = this.state;
+    const { className, text, buttonText: buttonTextProp } = this.props;
+    const confirmText = text || DEFAULT_CONFIRM_TEXT;
+    const buttonText = buttonTextProp || DEFAULT_BUTTON_TEXT;
     const modal = active
       ? <AriaModal
           titleText={confirmText}
@@ -81,7 +72,7 @@ class ConfirmModal extends React.Component {
                 mustSubmit={true}
                 className={utils.modalContinueButton}
               >
-                {confirmButtonText}
+                {buttonText}
               </Button>
             </div>
           </form>

--- a/components/shared/ListView/ListImage.js
+++ b/components/shared/ListView/ListImage.js
@@ -5,6 +5,8 @@ import { getDefaultThumbnail, probeImage } from "lib";
 
 import css from "./ListView.module.scss";
 
+const SOURCE_RESOURCE_ITEM_ID = "http://dp.la/api/items/#sourceResource";
+
 class ListImage extends React.Component {
   state = {
     updateToDefaultImage: false,
@@ -39,6 +41,7 @@ class ListImage extends React.Component {
     const { type, url, useDefaultImage, item, title, className } = this.props;
     const { updateToDefaultImage } = this.state;
     const useDefaultWrapper = updateToDefaultImage || useDefaultImage;
+    const imageSrc = updateToDefaultImage ? getDefaultThumbnail(type) : url;
 
     return (
       <div
@@ -46,24 +49,24 @@ class ListImage extends React.Component {
           ${useDefaultWrapper && css.defaultImageWrapper}`}
       >
         {/* see issue #869 for details on this hack */}
-        {item.id !== "http://dp.la/api/items/#sourceResource" && (
+        {item.id !== SOURCE_RESOURCE_ITEM_ID && (
           <Link
             href={item.linkHref}
             className={`${css.listItemImageLink} internalItemLink`}
             title={title}
           >
             <img
-              src={updateToDefaultImage ? getDefaultThumbnail(type) : url}
+              src={imageSrc}
               alt=""
               className={css.image}
             />
           </Link>
         )}
         {/* see issue #869 for details on this hack */}
-        {item.id === "http://dp.la/api/items/#sourceResource" && (
+        {item.id === SOURCE_RESOURCE_ITEM_ID && (
           <span className={css.listItemImageLink}>
             <img
-              src={updateToDefaultImage ? getDefaultThumbnail(type) : url}
+              src={imageSrc}
               alt=""
               className={css.image}
             />

--- a/components/shared/ListView/ListImage.js
+++ b/components/shared/ListView/ListImage.js
@@ -41,7 +41,8 @@ class ListImage extends React.Component {
     const { type, url, useDefaultImage, item, title, className } = this.props;
     const { updateToDefaultImage } = this.state;
     const useDefaultWrapper = updateToDefaultImage || useDefaultImage;
-    const imageSrc = updateToDefaultImage ? getDefaultThumbnail(type) : url;
+    const imageSrc = useDefaultWrapper ? getDefaultThumbnail(type) : url;
+    const itemId = item.itemDplaId || item.id;
 
     return (
       <div
@@ -49,7 +50,7 @@ class ListImage extends React.Component {
           ${useDefaultWrapper && css.defaultImageWrapper}`}
       >
         {/* see issue #869 for details on this hack */}
-        {item.id !== SOURCE_RESOURCE_ITEM_ID && (
+        {itemId !== SOURCE_RESOURCE_ITEM_ID && (
           <Link
             href={item.linkHref}
             className={`${css.listItemImageLink} internalItemLink`}
@@ -63,7 +64,7 @@ class ListImage extends React.Component {
           </Link>
         )}
         {/* see issue #869 for details on this hack */}
-        {item.id === SOURCE_RESOURCE_ITEM_ID && (
+        {itemId === SOURCE_RESOURCE_ITEM_ID && (
           <span className={css.listItemImageLink}>
             <img
               src={imageSrc}

--- a/components/shared/ListView/index.js
+++ b/components/shared/ListView/index.js
@@ -19,6 +19,8 @@ import { MAX_LIST_ITEMS, MESSAGE_DELAY, UNTITLED_TEXT } from "constants/site";
 import css from "./ListView.module.scss";
 import utils from "stylesheets/utils.module.scss";
 
+const SOURCE_RESOURCE_ITEM_ID = SOURCE_RESOURCE_ITEM_ID;
+
 function joinTruncate(str) {
   return truncateString(joinIfArray(str));
 }
@@ -381,7 +383,7 @@ export default function ListView({
             state?.currentList?.selectedHash?.[realId] !== undefined;
           const shouldDisable =
             (!checked && listCount > MAX_LIST_ITEMS) ||
-            realId === "http://dp.la/api/items/#sourceResource";
+            realId === SOURCE_RESOURCE_ITEM_ID;
           const disabledMessage = `Maximum ${MAX_LIST_ITEMS} items per list.`;
           let itemLinkText = "View Full Item";
           if (item.type === "image") itemLinkText = "View Full Image";
@@ -403,7 +405,7 @@ export default function ListView({
               <div className={css.itemInfo}>
                 <h2 className={`${utils.hoverUnderline} ${css.itemTitle}`}>
                   {/* see issue #869 for details on this hack */}
-                  {realId !== "http://dp.la/api/items/#sourceResource" && (
+                  {realId !== SOURCE_RESOURCE_ITEM_ID && (
                     <Link href={item.linkHref} className={"internalItemLink"}>
                       {item.title
                         ? truncateString(joinIfArray(item.title, ", "), 150)
@@ -411,7 +413,7 @@ export default function ListView({
                     </Link>
                   )}
                   {/* see issue #869 for details on this hack */}
-                  {realId === "http://dp.la/api/items/#sourceResource" && (
+                  {realId === SOURCE_RESOURCE_ITEM_ID && (
                     <span>
                       {item.title
                         ? truncateString(item.title, 150)

--- a/components/shared/ListView/index.js
+++ b/components/shared/ListView/index.js
@@ -19,7 +19,7 @@ import { MAX_LIST_ITEMS, MESSAGE_DELAY, UNTITLED_TEXT } from "constants/site";
 import css from "./ListView.module.scss";
 import utils from "stylesheets/utils.module.scss";
 
-const SOURCE_RESOURCE_ITEM_ID = SOURCE_RESOURCE_ITEM_ID;
+const SOURCE_RESOURCE_ITEM_ID = "http://dp.la/api/items/#sourceResource";
 
 function joinTruncate(str) {
   return truncateString(joinIfArray(str));

--- a/components/svg/placehoderImages/Video.jsx
+++ b/components/svg/placehoderImages/Video.jsx
@@ -13,3 +13,5 @@ function Video(props) {
     </svg>
   );
 }
+
+export default Video;

--- a/pages/primary-source-sets/[set]/sources/[source].js
+++ b/pages/primary-source-sets/[set]/sources/[source].js
@@ -7,7 +7,6 @@ import BreadcrumbsModule from "components/PrimarySourceSetsComponents/Breadcrumb
 import ContentAndMetadata from "components/PrimarySourceSetsComponents/Source/components/ContentAndMetadata";
 import SourceCarousel from "components/PrimarySourceSetsComponents/Source/components/SourceCarousel";
 
-import { removeQueryParams } from "lib";
 import { washObject } from "lib/washObject";
 import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
 import isValidPSSSlug from "lib/isValidPSSSlug";

--- a/scripts/generate-pages-sitemap.js
+++ b/scripts/generate-pages-sitemap.js
@@ -143,12 +143,11 @@ async function topicUrls() {
   return urls;
 }
 
-async function wpPostUrls(base, categoryId = null) {
+async function wpPostUrls(base) {
   const urls = [];
   let page = 1;
   while (true) {
-    let endpoint = `${WP_URL}/wp-json/wp/v2/posts?per_page=100&status=publish&page=${page}`;
-    if (categoryId) endpoint += `&categories=${categoryId}`;
+    const endpoint = `${WP_URL}/wp-json/wp/v2/posts?per_page=100&status=publish&page=${page}`;
     const res = await safeFetch(endpoint);
     if (!res) break;
     const posts = await res.json();


### PR DESCRIPTION
Addresses findings from the GitHub Code Quality standard and AI findings pages.

## Standard findings fixed

- **Unused imports**: removed `removeQueryParams` from `CarouselSlider.js`, `SetsList/index.js`, `TeachersGuide/index.js`, PSS `[source].js`
- **Unused variable**: removed `useRouter`/`router` from `ImageAndCaption/index.js`
- **Undefined export**: added `export default Video` to `Video.jsx` (function was defined but never exported)
- **Potentially inconsistent state update**: fixed `Accordion.componentDidUpdate` to use functional `setState` so `prevState` is the current state at update time, not the stale lifecycle arg
- **Useless conditional**: removed always-null `categoryId` parameter from `wpPostUrls` in `generate-pages-sitemap.js`; the `if (categoryId)` branch was dead code (only one call site: `wpPostUrls(USER_BASE)`)

## AI findings fixed

- **ConfirmModal**: removed `componentDidMount` that copied props into state; `text`/`buttonText` are now read from props directly in `render`; `handleConfirm` calls `props.onConfirm` with a `typeof` guard instead of `this.state.onConfirm`
- **ListImage + ListView**: extracted `SOURCE_RESOURCE_ITEM_ID` constant to replace the duplicated `"http://dp.la/api/items/#sourceResource"` literal across both files (6 occurrences)
- **ListImage**: extracted `imageSrc` variable to eliminate the duplicated `updateToDefaultImage ? getDefaultThumbnail(type) : url` expression

## Not fixed (intentional)

- PDF.js vendored files — third-party code
- `lib/index.js` `.mjs` import extension — intentional ES module
- DPLA API key as query param — required by the upstream API
- `FiltersBar` / `DateFacet` `componentDidUpdate` — sets state from props (not `this.state`); not a real inconsistency risk
- `ListNameModal` — PR #1461 already open for that file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR addresses GitHub CodeQL code quality and AI findings: removes unused imports/vars, fixes state-update anti-patterns, extracts duplicated constants, removes dead code, and ensures components are properly exported. No infra, deployment, environment variable, database migration, public API shape, or credential handling changes are included.

## Changes by Category

### Unused Imports / Variables Removed
- Removed unused `removeQueryParams` import from:
  - components/PrimarySourceSetsComponents/AllSets/components/SetsList/index.js
  - components/PrimarySourceSetsComponents/SingleSet/TeachersGuide/index.js
  - components/PrimarySourceSetsComponents/Source/components/SourceCarousel/CarouselSlider.js
  - pages/primary-source-sets/[set]/sources/[source].js
- Removed `useRouter` import and hook invocation from components/ExhibitionsComponents/Exhibition/ImageAndCaption/index.js.

### Missing Export Added
- Added `export default Video;` to components/svg/placehoderImages/Video.jsx.

### State Management / Behavioral Fixes
- ConfirmModal:
  - Removed derived-state copying in componentDidMount; now reads `text` and `buttonText` directly from props.
  - `handleConfirm` now guards `this.props.onConfirm` with `typeof` before calling.
- Accordion:
  - Rewrote componentDidUpdate to use functional setState and preserve each item’s `active` state by item.name (prevents index-instability issues when items are spliced).
  - State tracking changed to key by item.name instead of array index.

### Dead Code Removal
- scripts/generate-pages-sitemap.js:
  - Removed always-null `categoryId` parameter and conditional branch from wpPostUrls; function signature simplified to wpPostUrls(base) and always fetches published posts.

### Duplication / Constant Extraction
- Introduced SOURCE_RESOURCE_ITEM_ID constant ("http://dp.la/api/items/#sourceResource") in:
  - components/shared/ListView/index.js
  - components/shared/ListView/ListImage.js
  - Replaced six duplicated literal occurrences with the constant.
- ListImage:
  - Extracted `imageSrc` variable to remove duplicated conditional.
  - Use `item.itemDplaId || item.id` to compute itemId for sentinel checks (aligns with ListView realId logic).
  - Use useDefaultWrapper for image selection to respect prop-forced defaults.

### Additional Fixes
- Fixed a self-referential constant in ListView/index.js causing a TDZ ReferenceError and build failure.
- Adjusted Accordion open/closed state preservation to use item.name (addresses instability from a spliced-in date facet).

## Files Changed (high level)
- components/ExhibitionsComponents/Exhibition/ImageAndCaption/index.js
- components/PrimarySourceSetsComponents/AllSets/components/SetsList/index.js
- components/PrimarySourceSetsComponents/SingleSet/TeachersGuide/index.js
- components/PrimarySourceSetsComponents/Source/components/SourceCarousel/CarouselSlider.js
- components/shared/Accordion/index.js
- components/shared/ConfirmModal/index.js
- components/shared/ListView/index.js
- components/shared/ListView/ListImage.js
- components/svg/placehoderImages/Video.jsx
- pages/primary-source-sets/[set]/sources/[source].js
- scripts/generate-pages-sitemap.js

## Not addressed (intentional)
- PDF.js vendored files (left unchanged).
- lib/index.js `.mjs` extension (intentional ESM import).
- DPLA API key passed as query param (required by upstream API).
- FiltersBar / DateFacet componentDidUpdate pattern (intentional).
- ListNameModal (handled in PR #1461).

## Impact & Actions Required
- No manual pipeline trigger, ECS redeployment, environment variable changes, DB migrations, shared infra config changes, or public API modifications required.
- No special security actions required beyond normal review; changes reduce duplicated literals and remove dead/unused code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->