### PR TITLE
Fix remaining CodeQL code quality findings

### DIFF
--- a/components/ListComponents/ListNameModal/index.js
+++ b/components/ListComponents/ListNameModal/index.js
@@ -21,11 +21,11 @@ class ListNameModal extends React.Component {
 
   openForm = (e) => {
     e.preventDefault();
-    this.setState({
+    this.setState((_prevState, props) => ({
       active: true,
       timestamp: Date.now(),
-      value: this.props.value,
-    });
+      value: props.value,
+    }));
   };
 
   closeForm = (e) => {

--- a/components/PrimarySourceSetsComponents/AllSets/components/FiltersBar/index.js
+++ b/components/PrimarySourceSetsComponents/AllSets/components/FiltersBar/index.js
@@ -21,11 +21,10 @@ class FiltersBar extends React.Component {
         prevProps.router.query.timePeriod ||
       this.props.router.query.subject !== prevProps.router.query.subject
     ) {
-      this.setState({
-        timePeriodValue:
-          this.props.router.query.timePeriod || "all-time-periods",
-        subjectValue: this.props.router.query.subject || "all-subjects",
-      });
+      this.setState((_prevState, props) => ({
+        timePeriodValue: props.router.query.timePeriod || "all-time-periods",
+        subjectValue: props.router.query.subject || "all-subjects",
+      }));
     }
   }
 

--- a/components/PrimarySourceSetsComponents/SingleSet/SourceSetSources/index.js
+++ b/components/PrimarySourceSetsComponents/SingleSet/SourceSetSources/index.js
@@ -4,7 +4,7 @@ import Markdown from "react-markdown";
 
 import Link from "next/link";
 
-import { removeQueryParams, extractSourceId } from "lib";
+import { extractSourceId } from "lib";
 
 import css from "./SourceSetSources.module.scss";
 import utils from "stylesheets/utils.module.scss";

--- a/components/PrimarySourceSetsComponents/SingleSet/TeachersGuide/index.js
+++ b/components/PrimarySourceSetsComponents/SingleSet/TeachersGuide/index.js
@@ -15,7 +15,7 @@ class TeachersGuide extends React.Component {
   state = { routePath: null };
 
   componentDidMount() {
-    this.setState({ routePath: this.props.router.asPath });
+    this.setState((_prevState, props) => ({ routePath: props.router.asPath }));
   }
 
   render() {

--- a/components/SearchComponents/MainContent/Sidebar/index.js
+++ b/components/SearchComponents/MainContent/Sidebar/index.js
@@ -89,10 +89,10 @@ class DateFacet extends React.Component {
       this.props.after !== prevProps.after ||
       this.props.before !== prevProps.before
     ) {
-      this.setState({
-        after: this.props.after || "",
-        before: this.props.before || "",
-      });
+      this.setState((_prevState, props) => ({
+        after: props.after || "",
+        before: props.before || "",
+      }));
     }
   }
 

--- a/components/shared/Accordion/index.js
+++ b/components/shared/Accordion/index.js
@@ -19,9 +19,9 @@ class Accordion extends React.Component {
 
   componentDidMount() {
     // now collapse accordions for realz
-    if (Array.isArray(this.props.items)) {
-      this.setState({ items: this.props.items });
-    }
+    this.setState((_prevState, props) =>
+      Array.isArray(props.items) ? { items: props.items } : null
+    );
   }
 
   componentDidUpdate(prevProps) {

--- a/pages/about/[...sections].js
+++ b/pages/about/[...sections].js
@@ -134,7 +134,6 @@ export const getServerSideProps = async (context) => {
   if (JSON.stringify(breadcrumbObject) !== "{}") {
     Object.values(breadcrumbObject).forEach((crumb) => {
       let slug = "/";
-      let url = "/about?section=" + crumb.post_name;
       // if this is a child item the url is /:topsection/:thisitem
       if (crumb.menu_item_parent !== "0") {
         const parent = getItemWithId({

--- a/pages/api/items/[idListString].js
+++ b/pages/api/items/[idListString].js
@@ -28,10 +28,18 @@ export default async function handler(req, res) {
         return;
     }
 
+    const apiUrl = process.env.API_URL;
+    const apiKey = process.env.API_KEY;
+    if (!apiUrl || !apiKey) {
+        console.error("API configuration missing: API_URL or API_KEY not set");
+        res.status(500).json({ error: "Server configuration error." });
+        return;
+    }
+
     try {
-        const baseUrl = new URL(`${process.env.API_URL}/items/`);
-        baseUrl.searchParams.set('api_key', process.env.API_KEY);
-        baseUrl.pathname += validIds.join(",");
+        const baseUrl = new URL(apiUrl);
+        baseUrl.pathname = `/items/${validIds.join(",")}`;
+        baseUrl.searchParams.set("api_key", apiKey);
         const fetchRes = await fetch(baseUrl);
         if (fetchRes.ok) {
             if (isSingle) {

--- a/pages/api/items/[idListString].js
+++ b/pages/api/items/[idListString].js
@@ -38,7 +38,7 @@ export default async function handler(req, res) {
 
     try {
         const baseUrl = new URL(apiUrl);
-        baseUrl.pathname = `/items/${validIds.join(",")}`;
+        baseUrl.pathname = baseUrl.pathname.replace(/\/$/, "") + `/items/${validIds.join(",")}`;
         baseUrl.searchParams.set("api_key", apiKey);
         const fetchRes = await fetch(baseUrl);
         if (fetchRes.ok) {

--- a/pages/qa/index.js
+++ b/pages/qa/index.js
@@ -6,7 +6,6 @@ import HomeHero from "components/HomePageComponents/HomeHero";
 import WebsiteFeature from "shared/WebsiteFeature";
 
 function QA() {
-  const siteEnv = process.env.NEXT_PUBLIC_SITE_ENV;
   return (
     <MainLayout hidePageHeader={true} hideSearchBar={true}>
       <div id="main" role="main">

--- a/scripts/dpla_ingest_update.py
+++ b/scripts/dpla_ingest_update.py
@@ -1,16 +1,21 @@
-import html, json, os, re, requests
+import html
+import os
+import re
+import requests
 from datetime import datetime, timedelta
 from urllib.parse import quote
 
-WP_USER     = os.environ['DPLA_WP_USER']
-WP_PASSWORD = os.environ['DPLA_WP_APP_PASSWORD']
-DPLA_KEY    = os.environ['DPLA_API_KEY']
-SLACK_URL   = os.environ['DPLA_SLACK_WEBHOOK']
+WP_USER = os.environ["DPLA_WP_USER"]
+WP_PASSWORD = os.environ["DPLA_WP_APP_PASSWORD"]
+DPLA_KEY = os.environ["DPLA_API_KEY"]
+SLACK_URL = os.environ["DPLA_SLACK_WEBHOOK"]
 
-auth    = (WP_USER, WP_PASSWORD)
-headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36'}
-now       = datetime.now()
-yesterday = (now - timedelta(days=1)).strftime('%Y-%m-%d')
+auth = (WP_USER, WP_PASSWORD)
+headers = {
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+}
+now = datetime.now()
+yesterday = (now - timedelta(days=1)).strftime("%Y-%m-%d")
 
 
 def get_json(url, params=None):
@@ -21,22 +26,32 @@ def get_json(url, params=None):
 
 # --- Fetch DPLA data ---
 providernames = get_json(
-    'https://api.dp.la/v2/items',
-    params={'facets': 'provider.name', 'api_key': DPLA_KEY, 'page_size': 0, 'facet_size': 100}
-)['facets']['provider.name']['terms']
+    "https://api.dp.la/v2/items",
+    params={
+        "facets": "provider.name",
+        "api_key": DPLA_KEY,
+        "page_size": 0,
+        "facet_size": 100,
+    },
+)["facets"]["provider.name"]["terms"]
 
 ingestdates = {}
 for provider in providernames:
     data = get_json(
-        'https://api.dp.la/v2/items',
-        params={'provider.name': f'"{provider["term"]}"', 'api_key': DPLA_KEY, 'page_size': 1, 'fields': 'ingestDate'}
+        "https://api.dp.la/v2/items",
+        params={
+            "provider.name": f'"{provider["term"]}"',
+            "api_key": DPLA_KEY,
+            "page_size": 1,
+            "fields": "ingestDate",
+        },
     )
-    ingestdates[provider['term']] = data['docs'][0]['ingestDate'][:10]
+    ingestdates[provider["term"]] = data["docs"][0]["ingestDate"][:10]
 
 # --- Sort into 4 groups ---
 g30, g90, g365, gold = {}, {}, {}, {}
 for hub, date in ingestdates.items():
-    dt = datetime.strptime(date, '%Y-%m-%d')
+    dt = datetime.strptime(date, "%Y-%m-%d")
     if dt > now - timedelta(days=30):
         g30[hub] = date
     elif dt > now - timedelta(days=90):
@@ -46,72 +61,86 @@ for hub, date in ingestdates.items():
     else:
         gold[hub] = date
 
-g30  = dict(sorted(g30.items(),  key=lambda x: x[1], reverse=True))
-g90  = dict(sorted(g90.items(),  key=lambda x: x[1], reverse=True))
+g30 = dict(sorted(g30.items(), key=lambda x: x[1], reverse=True))
+g90 = dict(sorted(g90.items(), key=lambda x: x[1], reverse=True))
 g365 = dict(sorted(g365.items(), key=lambda x: x[1], reverse=True))
 gold = dict(sorted(gold.items(), key=lambda x: x[1], reverse=True))
 
-print(f'30 days:  {len(g30)} hubs')
-print(f'90 days:  {len(g90)} hubs')
-print(f'365 days: {len(g365)} hubs')
-print(f'Older:    {len(gold)} hubs')
+print(f"30 days:  {len(g30)} hubs")
+print(f"90 days:  {len(g90)} hubs")
+print(f"365 days: {len(g365)} hubs")
+print(f"Older:    {len(gold)} hubs")
 
 
 # --- Generate table blocks ---
 def make_table(hubs):
-    rows = ''
+    rows = ""
     for hub, date in hubs.items():
-        url         = 'https://dp.la/search?partner=%22' + quote(hub) + '%22'
+        url = "https://dp.la/search?partner=%22" + quote(hub) + "%22"
         escaped_hub = html.escape(hub)
         rows += f'<tr><td><strong><a href="{url}">{escaped_hub}</a></strong></td><td>{date}</td></tr>'
     return (
-        '<!-- wp:table -->\n'
+        "<!-- wp:table -->\n"
         f'<figure class="wp-block-table"><table class="has-fixed-layout"><tbody>{rows}</tbody></table></figure>\n'
-        '<!-- /wp:table -->'
+        "<!-- /wp:table -->"
     )
 
-table_30  = make_table(g30)
-table_90  = make_table(g90)
+
+table_30 = make_table(g30)
+table_90 = make_table(g90)
 table_365 = make_table(g365)
 table_old = make_table(gold)
 
 # --- Fetch current page raw content ---
-resp    = requests.get('https://dpla.wpengine.com/wp-json/wp/v2/pages/27879?context=edit', auth=auth, headers=headers, timeout=20)
+resp = requests.get(
+    "https://dpla.wpengine.com/wp-json/wp/v2/pages/27879?context=edit",
+    auth=auth,
+    headers=headers,
+    timeout=20,
+)
 resp.raise_for_status()
-content = resp.json()['content']['raw']
+content = resp.json()["content"]["raw"]
 
 # --- Only publish if data has changed ---
-table_pattern   = re.compile(r'<!-- wp:table -->.*?<!-- /wp:table -->', re.DOTALL)
+table_pattern = re.compile(r"<!-- wp:table -->.*?<!-- /wp:table -->", re.DOTALL)
 existing_tables = table_pattern.findall(content)
-new_tables      = [table_30, table_90, table_365, table_old]
+new_tables = [table_30, table_90, table_365, table_old]
 
 if existing_tables == new_tables:
-    print('No changes detected. WordPress update skipped.')
+    print("No changes detected. WordPress update skipped.")
 elif len(existing_tables) != len(new_tables):
-    print(f'ERROR: expected {len(new_tables)} table blocks on page, found {len(existing_tables)}. Aborting update.')
+    print(
+        f"ERROR: expected {len(new_tables)} table blocks on page, found {len(existing_tables)}. Aborting update."
+    )
     raise SystemExit(1)
 else:
+
     def replacer(tables):
         it = iter(tables)
+
         def _replace(m):
             return next(it)
+
         return _replace
 
-    new_content  = table_pattern.sub(replacer(new_tables), content)
-    update_resp  = requests.post(
-        'https://dpla.wpengine.com/wp-json/wp/v2/pages/27879',
-        auth=auth, headers=headers, json={'content': new_content}, timeout=20
+    new_content = table_pattern.sub(replacer(new_tables), content)
+    update_resp = requests.post(
+        "https://dpla.wpengine.com/wp-json/wp/v2/pages/27879",
+        auth=auth,
+        headers=headers,
+        json={"content": new_content},
+        timeout=20,
     )
     update_resp.raise_for_status()
-    print('Data changed — page updated successfully!')
+    print("Data changed — page updated successfully!")
 
 # --- Slack alert if any hub ingested yesterday ---
 yesterday_hubs = {k: v for k, v in ingestdates.items() if v == yesterday}
 if yesterday_hubs:
-    lines = [f'*DPLA hubs ingested on {yesterday}:*']
+    lines = [f"*DPLA hubs ingested on {yesterday}:*"]
     for hub in sorted(yesterday_hubs, key=yesterday_hubs.get, reverse=True):
-        lines.append(f'• {hub}: {yesterday_hubs[hub]}')
-    requests.post(SLACK_URL, json={'text': '\n'.join(lines)}, timeout=10)
-    print(f'Slack alert sent for {len(yesterday_hubs)} hub(s).')
+        lines.append(f"• {hub}: {yesterday_hubs[hub]}")
+    requests.post(SLACK_URL, json={"text": "\n".join(lines)}, timeout=10)
+    print(f"Slack alert sent for {len(yesterday_hubs)} hub(s).")
 else:
-    print(f'No hubs ingested on {yesterday}. No Slack alert sent.')
+    print(f"No hubs ingested on {yesterday}. No Slack alert sent.")

--- a/scripts/dpla_ingest_update.py
+++ b/scripts/dpla_ingest_update.py
@@ -46,7 +46,11 @@ for provider in providernames:
             "fields": "ingestDate",
         },
     )
-    ingestdates[provider["term"]] = data["docs"][0]["ingestDate"][:10]
+    docs = data.get("docs", [])
+    if not docs:
+        print(f"Warning: no docs returned for provider {provider['term']!r}")
+        continue
+    ingestdates[provider["term"]] = docs[0]["ingestDate"][:10]
 
 # --- Sort into 4 groups ---
 g30, g90, g365, gold = {}, {}, {}, {}
@@ -140,7 +144,8 @@ if yesterday_hubs:
     lines = [f"*DPLA hubs ingested on {yesterday}:*"]
     for hub in sorted(yesterday_hubs, key=yesterday_hubs.get, reverse=True):
         lines.append(f"• {hub}: {yesterday_hubs[hub]}")
-    requests.post(SLACK_URL, json={"text": "\n".join(lines)}, timeout=10)
+    slack_resp = requests.post(SLACK_URL, json={"text": "\n".join(lines)}, timeout=10)
+    slack_resp.raise_for_status()
     print(f"Slack alert sent for {len(yesterday_hubs)} hub(s).")
 else:
     print(f"No hubs ingested on {yesterday}. No Slack alert sent.")

--- a/scripts/generate-hub-sitemaps.py
+++ b/scripts/generate-hub-sitemaps.py
@@ -151,7 +151,9 @@ def _api_get(api_url, api_key, tag, extra_params, timeout=30, retries=5):
                     time.sleep(5 * (attempt + 1))
                 continue
             raise
-    raise last_exc  # retries exhausted on transient server error
+    if last_exc is not None:
+        raise last_exc  # retries exhausted on transient server error
+    raise RuntimeError("retries exhausted without a captured exception")
 
 
 MAX_API_WINDOW = 49_800  # ES max_result_window is 50K; stay safely under it

--- a/scripts/generate-hub-sitemaps.py
+++ b/scripts/generate-hub-sitemaps.py
@@ -133,6 +133,7 @@ def _api_get(api_url, api_key, tag, extra_params, timeout=30, retries=5):
     """
     url = f"{api_url}/v2/items?api_key={api_key}&tags={tag}&{extra_params}"
     req = urllib.request.Request(url, headers={"Accept": "application/json"})  # noqa: S310
+    last_exc = None
     for attempt in range(retries):
         try:
             with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
@@ -144,10 +145,13 @@ def _api_get(api_url, api_key, tag, extra_params, timeout=30, retries=5):
                 raise RateLimitError(
                     f"API rate limit reached (HTTP 403): {exc.url}"
                 ) from exc
-            if exc.code in (500, 502, 503, 504) and attempt < retries - 1:
-                time.sleep(5 * (attempt + 1))
+            if exc.code in (500, 502, 503, 504):
+                last_exc = exc
+                if attempt < retries - 1:
+                    time.sleep(5 * (attempt + 1))
                 continue
             raise
+    raise last_exc  # retries exhausted on transient server error
 
 
 MAX_API_WINDOW = 49_800  # ES max_result_window is 50K; stay safely under it


### PR DESCRIPTION
## Summary

- Remove unused variables (`url` in `about/[...sections].js`, `siteEnv` in `qa/index.js`) and unused `removeQueryParams` import in `SourceSetSources`
- Fix 5 potentially-inconsistent state updates: use `setState((_prevState, props) => ...)` form in `FiltersBar`, `ListNameModal`, `TeachersGuide`, `Accordion`, and `Sidebar`
- Add `API_URL`/`API_KEY` env var validation and fix `baseUrl.pathname` construction in the items API route
- Fix mixed-return in `_api_get` (`generate-hub-sitemaps.py`): track `last_exc` and raise after loop when retries exhausted
- Remove unused `json` import from `dpla_ingest_update.py`

Reduces CodeQL Standard findings from 52 to ~8 (the remaining ones are all in vendored `public/static/pdfjs/` files which will be dismissed separately).

## Test plan

- [ ] All 19 unit tests pass (pre-commit hook verified)
- [ ] `next lint` clean
- [ ] `ruff check` clean on Python scripts
- [ ] Build checks pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes CodeQL Standard code quality findings, reducing issues from 52 to approximately 8 (remaining findings are in vendored public/static/pdfjs/ files and will be dismissed separately).

### Key Changes

- Removed unused variables/imports:
  - Removed `url` from pages/about/[...sections].js
  - Removed `siteEnv` from pages/qa/index.js
  - Removed `removeQueryParams` import from components/PrimarySourceSetsComponents/SingleSet/SourceSetSources/index.js
  - Removed unused `json` import from scripts/dpla_ingest_update.py

- Fixed React state update consistency by switching to the functional setState updater in five components:
  - components/ListComponents/ListNameModal/index.js (openForm)
  - components/PrimarySourceSetsComponents/AllSets/components/FiltersBar/index.js (componentDidUpdate)
  - components/PrimarySourceSetsComponents/SingleSet/TeachersGuide/index.js (componentDidMount)
  - components/SearchComponents/MainContent/Sidebar/index.js (DateFacet.componentDidUpdate)
  - components/shared/Accordion/index.js (componentDidMount)

- API handler validation and URL construction:
  - pages/api/items/[idListString].js now reads and validates API_URL and API_KEY early; returns a 500 JSON response ("Server configuration error.") if missing.
  - Upstream URL construction uses new URL(apiUrl), preserves existing API_URL path segments by trimming trailing slash(s) and appending /items/{id1,...}, and sets api_key from the validated variable.

- Python scripts / error handling improvements:
  - scripts/generate-hub-sitemaps.py: _api_get now records transient 5xx HTTPError as last_exc during retries and raises the captured exception after retry exhaustion (with a fallback RuntimeError if none captured).
  - scripts/dpla_ingest_update.py: guard against empty docs in provider loop (prints a warning and skips), restructured imports/strings for consistency, and calls raise_for_status() on Slack webhook POSTs to surface HTTP errors.

### Commits / Minor fixes
- Preserve API_URL path when building base pathname and strip trailing slashes instead of overwriting.
- Guard against empty DPLA docs to avoid IndexError.
- Ensure Slack POSTs raise on HTTP errors.
- Guard against raising None in generate-hub-sitemaps.py retry logic.

### Testing
- All 19 unit tests pass (pre-commit verified).
- next lint clean.
- ruff check clean on Python scripts.
- CI build checks pass.

### High-level impact notes (explicit)
- Pipeline / deployment: No manual pipeline trigger or ECS redeploy required by these code changes.
- Environment variables / secrets: No new environment variables or Secrets Manager keys are introduced or renamed. The change only adds runtime validation for existing API_URL and API_KEY (both already documented in .env.example).
- Database migrations: None.
- Shared infrastructure (CodePipeline/CodeBuild/ECS/IAM): No changes.
- Public API surface: No public-facing API response shapes were added/removed. The pages/api/items handler now returns a 500 error when upstream credentials/config are missing (an internal server configuration validation), but otherwise upstream request behavior is preserved.
- Security implications: Positive hardening — the PR adds validation for API credentials, stricter error surfacing for Slack POSTs, and safer retry/exception handling in scripts. No new external credential exposure or new external data inputs were introduced.

### Remaining findings
- Remaining CodeQL findings are in vendored public/static/pdfjs/ files and will be dismissed separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->