### PR TITLE
Fix DepictAssist CSP violation and Wikimedia OAuth endpoint

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -59,7 +59,7 @@ const CSP = [
   "default-src 'self'",
   "script-src 'self' 'sha256-sYQvVdNrbb2ldJRpproLbB3h5LhCcbCA1SUM1wTfomI=' 'sha256-uZYgrdXqFswjbPEZxW2e6bv+djcz8D4kcJKjWyznRmk=' 'sha256-R7BycX6lCwOq9x3CZpytPnOyYvDNpLs38i6qKfpCcVY=' *.google-analytics.com *.googletagmanager.com *.sentry.io https://*.awswaf.com https://www.gstatic.com",
   "img-src 'self' http: https:",
-  `connect-src 'self' https://dp.la https://*.dp.la ${CLOUDFRONT_MEDIA} *.google-analytics.com *.analytics.google.com *.sentry.io https://*.awswaf.com https://gitlab.wikimedia.org https://commons.wikimedia.org https://wikimedia.org https://wikidata.reconci.link https://raw.githubusercontent.com https://meta.wikimedia.org https://www.wikidata.org`,
+  `connect-src 'self' https://dp.la https://*.dp.la ${CLOUDFRONT_MEDIA} *.google-analytics.com *.analytics.google.com *.sentry.io https://*.awswaf.com https://gitlab.wikimedia.org https://commons.wikimedia.org https://wikimedia.org https://wikidata.reconci.link https://wikidata-reconciliation.wmcloud.org https://raw.githubusercontent.com https://meta.wikimedia.org https://www.wikidata.org`,
   "style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://www.gstatic.com",
   "font-src 'self' https://cdnjs.cloudflare.com",
   `media-src 'self' *.dp.la ${CLOUDFRONT_MEDIA}`,

--- a/pages/api/wikimedia/oauth.js
+++ b/pages/api/wikimedia/oauth.js
@@ -3,9 +3,10 @@ import { setCookie } from 'lib/setCookie';
 
 const CLIENT_ID = process.env.WIKIMEDIA_OAUTH_CLIENT_ID;
 const CLIENT_SECRET = process.env.WIKIMEDIA_OAUTH_CLIENT_SECRET;
-const AUTH_ENDPOINT = 'https://meta.wikimedia.org/w/rest.php/oauth2/authorize';
-const TOKEN_ENDPOINT = 'https://meta.wikimedia.org/w/rest.php/oauth2/access_token';
-const COMMONS_API = 'https://commons.wikimedia.org/w/api.php';
+const COMMONS_BASE = 'https://commons.wikimedia.org/w';
+const AUTH_ENDPOINT = `${COMMONS_BASE}/rest.php/oauth2/authorize`;
+const TOKEN_ENDPOINT = `${COMMONS_BASE}/rest.php/oauth2/access_token`;
+const COMMONS_API = `${COMMONS_BASE}/api.php`;
 const TOKEN_COOKIE = 'wm_access_token';
 const STATE_COOKIE = 'wm_oauth_state';
 const FETCH_TIMEOUT_MS = 5000;


### PR DESCRIPTION
## Summary
- Adds `https://wikidata-reconciliation.wmcloud.org` to the CSP `connect-src` directive — the reconciliation API calls were being blocked by the browser
- Fixes the OAuth login 401 by switching auth/token endpoints from `meta.wikimedia.org` to `commons.wikimedia.org` — the OAuth consumer is registered scoped to commons, so meta rejects it as an unknown client
- Extracts a `COMMONS_BASE` constant in `oauth.js` to avoid repeating the commons base URL across three endpoint definitions

## Test plan
- [ ] Log in via the DepictAssist login button — should redirect to commons.wikimedia.org and complete OAuth successfully
- [ ] After login, confirm image reconciliation API calls succeed without CSP errors in the browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes two related issues with the DepictAssist Wikimedia integration: a Content-Security-Policy (CSP) violation and incorrect OAuth endpoint configuration.

### Key Changes

**next.config.js**
- Added `https://wikidata-reconciliation.wmcloud.org` to the CSP `connect-src` directive to allow browser-side calls to the Wikimedia reconciliation API without CSP violations.

**pages/api/wikimedia/oauth.js**
- Introduced a `COMMONS_BASE` constant (`https://commons.wikimedia.org/w`) to centralize the Commons base URL.
- Updated OAuth `AUTH_ENDPOINT` and `TOKEN_ENDPOINT` to use `commons.wikimedia.org` instead of `meta.wikimedia.org` (via template strings using the new constant).
- Updated `COMMONS_API` to derive from the same `COMMONS_BASE` constant.
- The change addresses OAuth 401 errors caused by the OAuth consumer being registered for Commons rather than meta.wikimedia.org.

### Security Implications

- **OAuth endpoint switch**: Migrates authentication from meta.wikimedia.org to commons.wikimedia.org, which is the correct endpoint where the OAuth consumer is registered. This fixes repeated 401 authentication failures.
- **New external data source**: Adds wikidata-reconciliation.wmcloud.org to CSP allowlist, enabling the browser to make reconciliation API calls to this external service. This introduces a new trusted external data input for image reconciliation functionality.
- **No credential or secret changes**: Existing environment variables (`WIKIMEDIA_OAUTH_CLIENT_ID`, `WIKIMEDIA_OAUTH_CLIENT_SECRET`) remain unchanged, and OAuth token handling logic (cookies, state verification, timeout handling) is unmodified.

### Deployment Impact

No special deployment procedures required beyond standard build and deployment. The CSP changes take effect on the next deploy, and no manual pipeline triggers or environment variable updates are needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->