### PR TITLE
Fix DepictAssist OAuth callback URL (wrong hostname via CloudFront)

### DIFF
--- a/pages/api/wikimedia/oauth.js
+++ b/pages/api/wikimedia/oauth.js
@@ -11,7 +11,7 @@ const TOKEN_COOKIE = 'wm_access_token';
 const STATE_COOKIE = 'wm_oauth_state';
 const FETCH_TIMEOUT_MS = 5000;
 const CALLBACK_PATH = '/api/wikimedia/oauth?action=callback';
-const REDIRECT_BASE = process.env.WIKIMEDIA_OAUTH_REDIRECT_BASE;
+const REDIRECT_BASE = process.env.WIKIMEDIA_OAUTH_REDIRECT_BASE?.trim().replace(/\/+$/, '');
 
 function getCallbackUrl(req) {
   if (REDIRECT_BASE) return REDIRECT_BASE + CALLBACK_PATH;

--- a/pages/api/wikimedia/oauth.js
+++ b/pages/api/wikimedia/oauth.js
@@ -10,11 +10,14 @@ const COMMONS_API = `${COMMONS_BASE}/api.php`;
 const TOKEN_COOKIE = 'wm_access_token';
 const STATE_COOKIE = 'wm_oauth_state';
 const FETCH_TIMEOUT_MS = 5000;
+const CALLBACK_PATH = '/api/wikimedia/oauth?action=callback';
+const REDIRECT_BASE = process.env.WIKIMEDIA_OAUTH_REDIRECT_BASE;
 
 function getCallbackUrl(req) {
+  if (REDIRECT_BASE) return REDIRECT_BASE + CALLBACK_PATH;
   const proto = req.headers['x-forwarded-proto'] || 'https';
   const host = req.headers['x-forwarded-host'] || req.headers.host;
-  return proto + '://' + host + '/api/wikimedia/oauth?action=callback';
+  return proto + '://' + host + CALLBACK_PATH;
 }
 
 export default async function handler(req, res) {


### PR DESCRIPTION
## Summary
- CloudFront forwards requests to the ALB using `pro-internal.dp.la` as the `Host` header, so `getCallbackUrl()` was building `redirect_uri=https://pro-internal.dp.la/...` — which doesn't match the registered callback `https://pro.dp.la/...`, causing Wikimedia to reject the authorization with an Application Connection Error
- Adds `WIKIMEDIA_OAUTH_REDIRECT_BASE` env var support so the correct public hostname is set explicitly in ECS rather than inferred from request headers (which are unreliable behind CloudFront)
- Also hoists the env var read to module level and extracts the duplicate callback path suffix

## ECS config change required
After merging, add to the `frontend-pro-production` task definition:
```
WIKIMEDIA_OAUTH_REDIRECT_BASE = https://pro.dp.la
```
This must be in place before the new deploy for the fix to take effect.

## Test plan
- [ ] Click Login on https://pro.dp.la/projects/dpla-wikimedia/depictassist — should redirect to Wikimedia authorization page (not Application Connection Error)
- [ ] Complete authorization and confirm redirect back to DepictAssist with logged-in state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes an OAuth callback URL mismatch that caused Wikimedia to reject authorization requests. CloudFront forwarded requests to the ALB with an internal Host (pro-internal.dp.la), which led the app to build redirect_uri values using the internal hostname (https://pro-internal.dp.la/...) instead of the registered public hostname (https://pro.dp.la/...).

Changes
- Add support for a new environment variable WIKIMEDIA_OAUTH_REDIRECT_BASE which, when set, is used as the absolute base for Wikimedia redirect URIs instead of deriving host/proto from request headers.
- Hoist the env-var read to module level and extract the callback path into a module-level CALLBACK_PATH constant to remove duplicated construction.
- Normalize WIKIMEDIA_OAUTH_REDIRECT_BASE by stripping trailing slashes so the redirect base is consistent.

Deployment & infra notes
- Requires an ECS task definition update: add WIKIMEDIA_OAUTH_REDIRECT_BASE=https://pro.dp.la to the frontend-pro-production task definition. This environment variable must be present before deploying the new image for the fix to take effect (i.e., update the task definition and redeploy).
- No database migrations.
- Changes a shared infrastructure configuration (ECS task definition environment variables). No other CodePipeline/CodeBuild/IAM changes are included.

Public API & security
- Does not add/remove endpoints or change public API response shapes; the OAuth callback route remains the same.
- Security/Authentication: fixes a critical OAuth authentication flow bug so Wikimedia authorization completes successfully (resolves redirect_uri mismatch).

Testing
- Click Login on https://pro.dp.la/projects/dpla-wikimedia/depictassist — should redirect to Wikimedia authorization (no Application Connection Error).
- Complete authorization and confirm redirect back to DepictAssist with logged-in state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->