### PR TITLE
Fix DepictAssist Commons proxy 502 (spurious origin param)

### DIFF
--- a/pages/api/wikimedia/commons.js
+++ b/pages/api/wikimedia/commons.js
@@ -17,20 +17,16 @@ export default async function handler(req, res) {
     return res.status(401).json({ error: 'Not authenticated' });
   }
 
-  const origin = req.headers['x-forwarded-proto']
-    ? req.headers['x-forwarded-proto'] + '://' + (req.headers['x-forwarded-host'] || req.headers.host)
-    : 'https://' + req.headers.host;
-
   if (req.method === 'GET') {
-    return handleGet(req, res, token, origin);
+    return handleGet(req, res, token);
   }
   if (req.method === 'POST') {
-    return handlePost(req, res, token, origin);
+    return handlePost(req, res, token);
   }
   return res.status(405).json({ error: 'Method not allowed' });
 }
 
-async function handleGet(req, res, token, origin) {
+async function handleGet(req, res, token) {
   const { _proxy, ...params } = req.query;
 
   if (!ALLOWED_GET_ACTIONS.has(params.action)) {
@@ -39,7 +35,6 @@ async function handleGet(req, res, token, origin) {
 
   const qs = new URLSearchParams(params);
   qs.set('format', 'json');
-  qs.set('origin', origin);
 
   try {
     const apiResp = await fetch(COMMONS_API + '?' + qs.toString(), {
@@ -54,7 +49,7 @@ async function handleGet(req, res, token, origin) {
   }
 }
 
-async function handlePost(req, res, token, origin) {
+async function handlePost(req, res, token) {
   const bodyParams = typeof req.body === 'string'
     ? Object.fromEntries(new URLSearchParams(req.body))
     : req.body;
@@ -64,7 +59,7 @@ async function handlePost(req, res, token, origin) {
   }
 
   try {
-    const apiResp = await fetch(COMMONS_API + '?origin=' + encodeURIComponent(origin), {
+    const apiResp = await fetch(COMMONS_API, {
       method: 'POST',
       headers: {
         Authorization: 'Bearer ' + token,

--- a/pages/api/wikimedia/commons.js
+++ b/pages/api/wikimedia/commons.js
@@ -41,8 +41,7 @@ async function handleGet(req, res, token) {
       headers: { Authorization: 'Bearer ' + token },
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)
     });
-    const data = await apiResp.json();
-    return res.status(apiResp.ok ? 200 : apiResp.status).json(data);
+    return await forwardCommonsResponse(apiResp, res);
   } catch (err) {
     console.error('Commons proxy GET error:', err);
     return res.status(502).json({ error: 'Commons API request failed' });
@@ -68,10 +67,20 @@ async function handlePost(req, res, token) {
       body: new URLSearchParams(bodyParams).toString(),
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)
     });
-    const data = await apiResp.json();
-    return res.status(apiResp.ok ? 200 : apiResp.status).json(data);
+    return await forwardCommonsResponse(apiResp, res);
   } catch (err) {
     console.error('Commons proxy POST error:', err);
     return res.status(502).json({ error: 'Commons API request failed' });
   }
+}
+
+async function forwardCommonsResponse(apiResp, res) {
+  const contentType = apiResp.headers.get('content-type') || '';
+  if (contentType.includes('application/json')) {
+    const data = await apiResp.json();
+    return res.status(apiResp.ok ? 200 : apiResp.status).json(data);
+  }
+  const text = await apiResp.text();
+  console.error('Commons API returned non-JSON response:', apiResp.status, text.slice(0, 200));
+  return res.status(apiResp.status).json({ error: 'Commons API returned non-JSON response' });
 }


### PR DESCRIPTION
## Summary

- Removes the `origin` query parameter from server-side calls in the Wikimedia Commons proxy (`/api/wikimedia/commons`)
- The `origin` param is for browser CORS requests only; MediaWiki rejects it on authenticated OAuth Bearer requests unless it matches an allowed domain
- Our proxy was sending `origin=https://pro-internal.dp.la` (the CloudFront-internal hostname), which Commons rejected with a plain-text error — causing `apiResp.json()` to throw and the proxy to return 502

Root-cause confirmed in ECS logs:
```
Commons proxy GET error: SyntaxError: Unexpected token ''', "'origin' p"... is not valid JSON
```

## Test plan

- [ ] Log in to DepictAssist at https://pro.dp.la/projects/dpla-wikimedia/depictassist with a Wikimedia account
- [ ] Select an institution and click "Find images"
- [ ] Queue a depicts tag on an image
- [ ] Click "Submit batch" — should succeed without a 502 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes a 502 error in the Wikimedia Commons proxy endpoint (pages/api/wikimedia/commons.js) by removing the server-sent origin query parameter and hardening response handling. The proxy no longer appends an origin query param to server-to-server requests (origin was derived from forwarded/host headers). It also inspects Content-Type before parsing upstream responses: JSON responses are parsed and forwarded, while non-JSON responses are logged (truncated preview) and forwarded with the upstream HTTP status instead of converting parse failures into an opaque 502.

## Changes

- Removed origin computation and use in proxied requests.
- Simplified function signatures:
  - handleGet(req, res, token) (removed origin parameter)
  - handlePost(req, res, token) (removed origin parameter)
- Added forwardCommonsResponse(apiResp, res) to:
  - Only call apiResp.json() when Content-Type includes application/json.
  - On non-JSON responses, read text (log a truncated preview) and respond with the upstream status and a non-JSON error payload.
- Both GET and POST flows now route responses through forwardCommonsResponse.
- No change to authentication (Bearer token from httpOnly cookie), action allowlists, timeouts, or endpoint routes.

## Deployment & infra impact

- Requires redeployment (application build/pipeline and ECS service) for the fix to take effect.
- No new or removed environment variables or AWS Secrets Manager keys.
- No database migrations.
- No changes to shared infrastructure (CodePipeline/CodeBuild/ECS task definitions/IAM).

## API & security notes

- The public endpoint path remains the same (/api/wikimedia/commons).
- Response behavior changed for upstream non-JSON errors: instead of returning an opaque 502, the proxy now returns the actual upstream HTTP status and a JSON error payload indicating a non-JSON response (and logs a truncated preview). This is a change in error-surface behavior but not a new endpoint or success-response shape.
- No new security-sensitive inputs or credential handling changes beyond existing Bearer token usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->