### PR TITLE
Fix DepictAssist CSRF token check, OAuth scope, and Commons error logging

### DIFF
--- a/pages/api/wikimedia/commons.js
+++ b/pages/api/wikimedia/commons.js
@@ -78,6 +78,11 @@ async function forwardCommonsResponse(apiResp, res) {
   const contentType = apiResp.headers.get('content-type') || '';
   if (contentType.includes('application/json')) {
     const data = await apiResp.json();
+    if (!apiResp.ok) {
+      console.error('Commons API error response:', apiResp.status, JSON.stringify(data).slice(0, 500));
+    } else if (data.error) {
+      console.warn('Commons API returned error in body:', JSON.stringify(data.error).slice(0, 500));
+    }
     return res.status(apiResp.ok ? 200 : apiResp.status).json(data);
   }
   const text = await apiResp.text();

--- a/pages/api/wikimedia/oauth.js
+++ b/pages/api/wikimedia/oauth.js
@@ -55,6 +55,7 @@ function handleLogin(req, res) {
     response_type: 'code',
     client_id: CLIENT_ID,
     redirect_uri: getCallbackUrl(req),
+    scope: 'editpage',
     state: state
   });
 

--- a/public/static/depictassist/README.md
+++ b/public/static/depictassist/README.md
@@ -188,9 +188,11 @@ The proxy strips the internal `_proxy` query parameter (added by client code to
 avoid caching) before forwarding. It does not forward the `origin` parameter,
 which Commons rejects on OAuth Bearer requests.
 
-Errors from Commons are always HTTP 200 with an `error` field in the JSON body
-(MediaWiki never returns 4xx/5xx for API-level errors). The proxy logs these to
-ECS stdout so they appear in CloudWatch.
+MediaWiki API-level errors (bad token, permission denied, invalid entity) are
+returned as HTTP 200 with an `error` field in the JSON body; the proxy logs
+these via `console.warn`. HTTP-level errors (rate limiting, server faults) are
+forwarded with their original status code and logged via `console.error`. Both
+appear in CloudWatch via ECS stdout.
 
 ## Institution data
 

--- a/public/static/depictassist/README.md
+++ b/public/static/depictassist/README.md
@@ -1,85 +1,260 @@
 # DepictAssist
 
-A tool for adding structured data "depicts" (P180) claims to Wikimedia Commons
-images contributed by DPLA institutions. Hosted at
+A volunteer contribution tool for adding structured data "depicts" (P180) claims to
+Wikimedia Commons images contributed by DPLA institutions. Hosted at
 [pro.dp.la/projects/dpla-wikimedia/depictassist](https://pro.dp.la/projects/dpla-wikimedia/depictassist).
 
-## How it works
+## What it does
 
-1. Users select a DPLA contributing institution from the dropdown
-2. The tool finds a random Wikimedia Commons image from that institution that
-   has subjects (P4272) but no depicts (P180) claims yet
-3. Subject terms are sent to the Wikidata reconciliation API for tag suggestions
-4. Users click tags to queue P180 claims, then submit the batch
-5. Edits are posted to Commons under the user's own Wikimedia account via OAuth
+1. A volunteer selects a DPLA contributing institution from the dropdown
+2. The tool finds a random Commons image from that institution that has subject
+   terms (P4272) but no depicts claims (P180) yet
+3. Those subject terms are sent to the Wikidata Reconciliation API to generate
+   tag suggestions
+4. The volunteer clicks tags to queue P180 claims, then submits the batch
+5. Edits are posted to Commons under the volunteer's own Wikimedia account via
+   OAuth 2.0, with each claim citing "based on heuristic" (P887 = Q114065533) as
+   its reference
 
 ## File inventory
 
 | File | Purpose |
 |------|---------|
-| `depictassist.js` | Client-side application logic (image fetching, tag suggestions, batch writes) |
-| `depictassist.css` | Scoped styles (all under `.depictassist-wrapper`) |
+| `depictassist.js` | Client-side app — image search, tag suggestions, batch queue, edit submission |
+| `depictassist.css` | Scoped styles (all selectors under `.depictassist-wrapper`) |
 | `README.md` | This file |
-| `../../../pages/projects/dpla-wikimedia/depictassist.js` | Next.js page component |
-| `../../../pages/api/wikimedia/oauth.js` | OAuth 2.0 token exchange API route |
-| `../../../pages/api/wikimedia/commons.js` | Server-side proxy for authenticated Commons API calls |
+| `pages/projects/dpla-wikimedia/depictassist.js` | Next.js page component — HTML shell, server-side menu fetch |
+| `pages/api/wikimedia/oauth.js` | OAuth 2.0 server route — login, callback, whoami, logout |
+| `pages/api/wikimedia/commons.js` | Server-side proxy for authenticated Commons API calls |
+| `lib/setCookie.js` | Shared cookie-serialization utility used by the OAuth route |
+
+## Architecture: why the proxy exists
+
+Browser JavaScript cannot hold OAuth tokens safely — anything in JS is readable by
+XSS. Instead:
+
+- The server exchanges the OAuth code for an access token and stores it in an
+  **httpOnly** cookie (`wm_access_token`). Browser JS never sees the token value.
+- All authenticated Commons API calls (fetching CSRF tokens, submitting edits) go
+  through `/api/wikimedia/commons`, a Next.js API route that reads the token from
+  the cookie and forwards requests to Commons with `Authorization: Bearer <token>`.
+- The client only ever talks to its own origin (`pro.dp.la`); Commons is contacted
+  only from the server.
+
+This also avoids CORS problems: server-to-server calls do not need a Commons CORS
+`origin` parameter (which Commons rejects on authenticated OAuth requests anyway).
 
 ## External APIs
 
-| API | Purpose | Auth required | CORS |
-|-----|---------|---------------|------|
-| Wikimedia Commons Action API | CirrusSearch for images, entity data, image info, CSRF tokens, edit submission | Bearer token (for writes) | Yes (`origin=*`) |
-| Wikidata Reconciliation API | Tag suggestions from subject text | No | Yes |
-| GitHub Raw (`ingestion3`) | Institution list with Wikidata QIDs | No | Yes |
-| Wikimedia OAuth 2.0 (`meta.wikimedia.org`) | User authentication | Server-side client_secret | N/A (server-side) |
+| API | Called from | Auth | Purpose |
+|-----|-------------|------|---------|
+| Wikimedia Commons Action API (`commons.wikimedia.org/w/api.php`) | **Server** (via proxy) | Bearer token | CSRF tokens, `wbeditentity` edits |
+| Wikimedia Commons Action API | **Client** (unauthenticated) | None | CirrusSearch for images, image info |
+| Wikidata Reconciliation API (`wikidata.reconci.link/en/api`) | **Client** | None | Tag suggestions from subject text |
+| GitHub Raw (`raw.githubusercontent.com`) | **Client** | None | Institution list (`institutions_v2.json`) |
+| Wikimedia OAuth 2.0 (`commons.wikimedia.org/w/rest.php/oauth2/*`) | **Server** | Client secret | Authorization code exchange |
 
-## Institution data
-
-Institutions are fetched at runtime from the `institutions_v2.json` file in the
-[dpla/ingestion3](https://github.com/dpla/ingestion3) repository. Only
-institutions with `"upload": true` and a non-empty `"Wikidata"` QID are shown.
-The dropdown groups institutions by hub.
+Note: the unauthenticated Commons calls (image search, image info) are made
+directly from the browser, not through the proxy, because they don't need the token
+and are read-only.
 
 ## OAuth setup
 
-DepictAssist uses Wikimedia OAuth 2.0. To configure:
+### 1. Register a Wikimedia OAuth consumer
 
-1. Register an OAuth consumer at
-   [meta.wikimedia.org/wiki/Special:OAuthConsumerRegistration](https://meta.wikimedia.org/wiki/Special:OAuthConsumerRegistration)
-   - Version: OAuth 2.0
-   - Project: `commons.wikimedia.org`
-   - Grants: `editpage`, `createeditmovepage`
-   - Callback URL: `https://pro.dp.la/api/wikimedia/oauth?action=callback`
+Go to
+[meta.wikimedia.org/wiki/Special:OAuthConsumerRegistration](https://meta.wikimedia.org/wiki/Special:OAuthConsumerRegistration)
+and register a new consumer with these settings:
 
-2. Set environment variables on the server:
-   - `WIKIMEDIA_OAUTH_CLIENT_ID` — from consumer registration
-   - `WIKIMEDIA_OAUTH_CLIENT_SECRET` — from consumer registration (server-only, never exposed to client)
+| Setting | Value |
+|---------|-------|
+| Version | OAuth 2.0 |
+| Project | `commons.wikimedia.org` |
+| Grants | `editpage` |
+| Callback URL | `https://pro.dp.la/api/wikimedia/oauth?action=callback` |
+| Consumer type | Confidential (server-side) |
 
-The OAuth flow:
-- User clicks "Log in with Wikimedia" → redirects to meta.wikimedia.org
-- After approval, callback exchanges the authorization code for an access token
-- Token is stored in an httpOnly secure cookie — never exposed to client-side JS
-- Authenticated Commons API calls (CSRF tokens, edits) go through
-  `/api/wikimedia/commons`, which reads the token from the httpOnly cookie
-  and forwards requests to Commons with Bearer auth
+The callback URL must match exactly including the `?action=callback` query string.
+Wikimedia will provide a **Client ID** and a **Client Secret**.
+
+### 2. Set environment variables
+
+Add to the server environment (not committed to git):
+
+```
+WIKIMEDIA_OAUTH_CLIENT_ID=<from Wikimedia registration>
+WIKIMEDIA_OAUTH_CLIENT_SECRET=<from Wikimedia registration>
+```
+
+Optional override if the server cannot detect its own public hostname:
+
+```
+WIKIMEDIA_OAUTH_REDIRECT_BASE=https://pro.dp.la
+```
+
+If `WIKIMEDIA_OAUTH_REDIRECT_BASE` is not set, the callback URL is inferred from
+the incoming request's `x-forwarded-proto` and `x-forwarded-host` headers. This
+works correctly behind the CloudFront + ALB setup, but if it ever breaks (e.g.
+staging or local dev), set the explicit override.
+
+### 3. CloudFront cookie forwarding
+
+CloudFront's default cache behavior strips cookies before forwarding requests to
+the origin. The `/api/wikimedia/*` paths must have a custom cache behavior that:
+
+- **Whitelists these cookies for forwarding**: `wm_access_token`, `wm_oauth_state`
+- **Allows all HTTP methods** (HEAD, GET, DELETE, POST, PUT, PATCH, OPTIONS)
+- **Disables caching** (MinTTL = DefaultTTL = MaxTTL = 0)
+- **Forwards the query string** (needed by the OAuth and commons proxy routes)
+
+Without this, the Next.js API routes receive empty `req.cookies` and every
+authenticated request returns 401.
+
+## The OAuth flow, step by step
+
+```
+User                 pro.dp.la (Next.js)          Commons (Wikimedia)
+ |                         |                              |
+ |-- click "Log in" ------>|                              |
+ |                         |-- generate state, set -----> |
+ |                         |   wm_oauth_state cookie      |
+ |<-- 302 redirect --------|                              |
+ |                         |                              |
+ |-- GET /w/rest.php/oauth2/authorize ----------------->  |
+ |<-- Wikimedia login + approve dialog ----------------   |
+ |-- approve ------------------------------------------>  |
+ |<-- 302 redirect to /api/wikimedia/oauth?action=callback&code=X&state=Y
+ |                         |                              |
+ |-- GET callback -------->|                              |
+ |                         |-- validate state vs cookie   |
+ |                         |-- POST /oauth2/access_token->|
+ |                         |<-- { access_token: "..." } --|
+ |                         |-- set wm_access_token cookie |
+ |                         |-- clear wm_oauth_state cookie|
+ |<-- 302 to /depictassist-|                              |
+ |                         |                              |
+ |-- submit batch -------->|                              |
+ |   POST /api/wikimedia/commons                          |
+ |   (cookie sent automatically)                          |
+ |                         |-- read wm_access_token cookie|
+ |                         |-- POST wbeditentity -------> |
+ |                         |<-- edit result --------------|
+ |<-- edit result (JSON) --|                              |
+```
+
+### Cookies
+
+| Cookie | httpOnly | Secure | SameSite | Max-Age | Purpose |
+|--------|----------|--------|----------|---------|---------|
+| `wm_oauth_state` | ✓ | ✓ | Lax | 300 s | CSRF protection for the OAuth callback |
+| `wm_access_token` | ✓ | ✓ | Strict | 4 hours | Bearer token for authenticated API calls |
+
+`SameSite=Lax` on the state cookie is intentional: the OAuth callback is a
+top-level navigation arriving from `commons.wikimedia.org`, and `SameSite=Strict`
+would suppress the cookie on that cross-site redirect, breaking state validation.
+
+`SameSite=Strict` on the token cookie ensures it is never sent in any cross-site
+context — only same-site requests from `pro.dp.la` can use it.
+
+### CSRF tokens and the OAuth pseudotoken
+
+Wikimedia's MediaWiki Action API requires a CSRF token for writes. To get one, the
+client calls `/api/wikimedia/commons?action=query&meta=tokens` through the proxy.
+
+For OAuth 2.0 Bearer-authenticated requests, MediaWiki always returns `+\` as the
+CSRF token. This is the **valid pseudotoken for OAuth flows** — it should be
+passed as-is in the `token` field of subsequent write requests. Do not reject it.
+(Earlier code had a check `csrfToken === '+\\'` that wrongly treated this as an
+error; it has been removed.)
+
+## The commons proxy in detail
+
+`pages/api/wikimedia/commons.js` is a narrow allowlist proxy:
+
+| Method | Allowed `action` values | What it's used for |
+|--------|------------------------|---------------------|
+| GET | `query` | Fetch CSRF token (`meta=tokens`), check userinfo |
+| POST | `wbeditentity` | Add P180 depicts claims to a Commons media file |
+
+Any other `action` value returns HTTP 400. Any request without a valid
+`wm_access_token` cookie returns HTTP 401.
+
+The proxy strips the internal `_proxy` query parameter (added by client code to
+avoid caching) before forwarding. It does not forward the `origin` parameter,
+which Commons rejects on OAuth Bearer requests.
+
+Errors from Commons are always HTTP 200 with an `error` field in the JSON body
+(MediaWiki never returns 4xx/5xx for API-level errors). The proxy logs these to
+ECS stdout so they appear in CloudWatch.
+
+## Institution data
+
+Fetched at runtime from:
+
+```
+https://raw.githubusercontent.com/dpla/ingestion3/main/src/main/resources/wiki/institutions_v2.json
+```
+
+Filtering: only institutions with `"upload": true` and a non-empty `"Wikidata"` QID
+are shown. The dropdown groups institutions by hub. If the URL contains `?id=Q…`,
+that institution is auto-selected once the dropdown finishes loading.
 
 ## URL parameters
 
 | Parameter | Example | Description |
 |-----------|---------|-------------|
-| `id` | `?id=Q105281139` | Pre-selects an institution by Wikidata QID |
+| `id` | `?id=Q105281139` | Pre-selects an institution by Wikidata QID and starts a search |
 
 ## CSP requirements
 
-The following external origins must be in the Content-Security-Policy `connect-src`
-directive (configured in `next.config.js`):
+Configured in `next.config.js`. DepictAssist requires these origins in `connect-src`:
 
-- `https://commons.wikimedia.org` — Commons Action API
-- `https://wikimedia.org` — Analytics API
-- `https://wikidata.reconci.link` — Reconciliation API
-- `https://raw.githubusercontent.com` — Institution data
-- `https://meta.wikimedia.org` — OAuth endpoints
-- `https://www.wikidata.org` — Entity links
+- `https://commons.wikimedia.org` — unauthenticated image search and info calls
+- `https://wikidata.reconci.link` — tag reconciliation
+- `https://raw.githubusercontent.com` — institution list
+- `https://meta.wikimedia.org` — required by some Wikimedia analytics
+- `https://www.wikidata.org` — entity page links shown in the UI
+- `https://wikimedia.org` — Wikimedia analytics
 
-The `form-action` directive must include `https://meta.wikimedia.org` for the
-OAuth redirect.
+The `form-action` directive must include `https://meta.wikimedia.org` for the OAuth
+authorization redirect (the browser navigates to Wikimedia to show the approval UI).
+
+After adding any new external URL to the code, run `node scripts/check-csp.js` to
+verify coverage.
+
+## Non-obvious implementation details
+
+### Image search is capped at 10,000
+
+Commons CirrusSearch refuses offsets above 10,000. When picking a random image the
+code gets the total hit count and caps it: `Math.min(totalHits, 10000)`. This means
+institutions with more than 10,000 untagged images will only ever surface images
+from the first 10,000 results.
+
+### Subject terms are narrowed before reconciliation
+
+DPLA subject terms often use the format `Broader topic--Narrower topic`. The code
+strips everything up to and including `--` before sending terms to the Wikidata
+Reconciliation API, so `"Politics--United States"` becomes `"United States"`. This
+improves match quality significantly.
+
+### Multiple depicts on one file use a single API call
+
+`wbeditentity` accepts an array of claims. When the batch contains multiple tags
+for the same Commons file (same M-ID), the proxy call groups them into one request
+rather than one request per tag.
+
+### All depicts claims cite "based on heuristic"
+
+Every P180 claim added by DepictAssist includes a reference: P887 (basis of
+knowledge) = Q114065533 (based on heuristic). This flags the claim as
+algorithmically suggested so other editors know it warrants human review.
+
+### SPA re-navigation guard
+
+`depictassist.js` is loaded as a static `<script>` tag. Next.js SPA navigation can
+re-mount the page component without reloading the script, so `initDepictAssist()`
+can be called more than once. The initialization function compares the wrapper DOM
+node to a stored reference (`boundWrapper`) and skips re-initialization if the node
+is the same mount. On a fresh navigation (new DOM node), it resets all module-level
+state before re-binding.

--- a/public/static/depictassist/README.md
+++ b/public/static/depictassist/README.md
@@ -77,6 +77,11 @@ and register a new consumer with these settings:
 The callback URL must match exactly including the `?action=callback` query string.
 Wikimedia will provide a **Client ID** and a **Client Secret**.
 
+> **Re-authentication note:** If users encounter permission errors after the
+> `editpage` grant was added, they need to log out and log back in. Existing
+> tokens issued before the scope was requested will lack write permission and
+> cannot be upgraded in place.
+
 ### 2. Set environment variables
 
 Add to the server environment (not committed to git):

--- a/public/static/depictassist/README.md
+++ b/public/static/depictassist/README.md
@@ -81,14 +81,14 @@ Wikimedia will provide a **Client ID** and a **Client Secret**.
 
 Add to the server environment (not committed to git):
 
-```
+```bash
 WIKIMEDIA_OAUTH_CLIENT_ID=<from Wikimedia registration>
 WIKIMEDIA_OAUTH_CLIENT_SECRET=<from Wikimedia registration>
 ```
 
 Optional override if the server cannot detect its own public hostname:
 
-```
+```bash
 WIKIMEDIA_OAUTH_REDIRECT_BASE=https://pro.dp.la
 ```
 
@@ -112,7 +112,7 @@ authenticated request returns 401.
 
 ## The OAuth flow, step by step
 
-```
+```text
 User                 pro.dp.la (Next.js)          Commons (Wikimedia)
  |                         |                              |
  |-- click "Log in" ------>|                              |
@@ -191,7 +191,7 @@ ECS stdout so they appear in CloudWatch.
 
 Fetched at runtime from:
 
-```
+```text
 https://raw.githubusercontent.com/dpla/ingestion3/main/src/main/resources/wiki/institutions_v2.json
 ```
 

--- a/public/static/depictassist/README.md
+++ b/public/static/depictassist/README.md
@@ -52,7 +52,8 @@ This also avoids CORS problems: server-to-server calls do not need a Commons COR
 | Wikimedia Commons Action API | **Client** (unauthenticated) | None | CirrusSearch for images, image info |
 | Wikidata Reconciliation API (`wikidata.reconci.link/en/api`) | **Client** | None | Tag suggestions from subject text |
 | GitHub Raw (`raw.githubusercontent.com`) | **Client** | None | Institution list (`institutions_v2.json`) |
-| Wikimedia OAuth 2.0 (`commons.wikimedia.org/w/rest.php/oauth2/*`) | **Server** | Client secret | Authorization code exchange |
+| Wikimedia OAuth 2.0 authorize (`/w/rest.php/oauth2/authorize`) | **Client** (browser redirect) | None | User login + consent UI |
+| Wikimedia OAuth 2.0 token (`/w/rest.php/oauth2/access_token`) | **Server** | Client secret | Authorization code → access token exchange |
 
 Note: the unauthenticated Commons calls (image search, image info) are made
 directly from the browser, not through the proxy, because they don't need the token

--- a/public/static/depictassist/README.md
+++ b/public/static/depictassist/README.md
@@ -255,6 +255,15 @@ Every P180 claim added by DepictAssist includes a reference: P887 (basis of
 knowledge) = Q114065533 (based on heuristic). This flags the claim as
 algorithmically suggested so other editors know it warrants human review.
 
+### Suggestion chips carry data attributes for queue management
+
+Each tag chip element is stamped with `data-mid` (the Commons M-ID, e.g. `M12345`)
+and `data-qid` (the Wikidata Q-ID, e.g. `Q67890`) when it is created. When the user
+clicks X on a queued item, the remove handler queries `$tagSuggestions` for a chip
+matching both attributes and re-enables it — restoring the visual selected state and
+allowing the tag to be re-added. Without the attributes the handler would have no
+way to find the right chip after the DOM has been rebuilt by `renderQueue()`.
+
 ### SPA re-navigation guard
 
 `depictassist.js` is loaded as a static `<script>` tag. Next.js SPA navigation can

--- a/public/static/depictassist/depictassist.js
+++ b/public/static/depictassist/depictassist.js
@@ -485,7 +485,8 @@
       const tokenData = await tokenResp.json();
       const csrfToken = tokenData.query?.tokens?.csrftoken;
 
-      if (!csrfToken || csrfToken === '+\\') {
+      // +\ is the valid OAuth 2.0 pseudotoken — do not reject it
+      if (!csrfToken) {
         throw new Error('Failed to obtain CSRF token. Please log in again.');
       }
 
@@ -583,7 +584,7 @@
       renderQueue();
     } catch (err) {
       console.error('DepictAssist: batch submit error', err);
-      $batchErrorMsg.textContent = 'Error submitting edits: ' + err.message;
+      $batchErrorMsg.textContent = 'Error submitting edits: ' + String(err?.message ?? err);
       $batchError.style.display = 'block';
     } finally {
       submittingBatch = false;

--- a/public/static/depictassist/depictassist.js
+++ b/public/static/depictassist/depictassist.js
@@ -329,6 +329,8 @@
       chip.type = 'button';
       chip.className = 'da-tag-chip';
       chip.setAttribute('aria-label', 'Add depicts tag: ' + tag.label);
+      chip.dataset.mid = mid;
+      chip.dataset.qid = tag.qid;
 
       const labelSpan = document.createElement('span');
       labelSpan.textContent = tag.label;
@@ -388,6 +390,11 @@
       removeBtn.addEventListener('click', function () {
         const idx = queue.indexOf(item);
         if (idx !== -1) queue.splice(idx, 1);
+        const chip = $tagSuggestions.querySelector('[data-mid="' + item.mid + '"][data-qid="' + item.qid + '"]');
+        if (chip) {
+          chip.classList.remove('da-tag-selected');
+          chip.disabled = false;
+        }
         renderQueue();
       });
       li.appendChild(removeBtn);


### PR DESCRIPTION
## Summary

- **Remove incorrect CSRF token rejection**: The check `csrfToken === '+\\'` was rejecting `+\`, which is the *valid* MediaWiki OAuth 2.0 pseudotoken. For Bearer-authenticated requests, Commons returns `+\` as the CSRF token and it must be passed back as-is when making edits. The incorrect check caused every submit attempt to throw "Failed to obtain CSRF token".
- **Add `editpage` scope to OAuth authorization request**: The login flow was not requesting any scope, so issued tokens may lack write permission on Commons. Users who already have a token without `editpage` scope will need to log out and log back in.
- **Log Commons API errors in body**: MediaWiki API calls always return HTTP 200 — errors are returned in the JSON body (`{"error": {...}}`). Added a `console.warn` for these so they appear in ECS logs when an edit is rejected.
- **Safe error message extraction in catch block**: Use `String(err?.message ?? err)` to avoid a potential TypeError if a non-Error value is thrown.

## Test plan

- [ ] Log out of DepictAssist (if logged in)
- [ ] Log in via the "Login with Wikimedia" button — confirm redirected to Commons and back with username shown
- [ ] Add a depicts tag to an image and click "Submit batch"
- [ ] Confirm no "Failed to obtain CSRF token" error
- [ ] Confirm a diff link appears in the results (edit was accepted by Commons)
- [ ] Confirm the submitted item is removed from the queue while any failed items remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fix DepictAssist CSRF token check, OAuth scope, and Commons error logging

### Overview
This PR fixes three DepictAssist Commons integration issues:
- Stops incorrectly rejecting the MediaWiki OAuth CSRF pseudotoken (+"\) so bearer-authenticated requests can obtain and reuse the CSRF token.
- Requests the editpage OAuth scope during login so newly issued tokens include Commons write permission.
- Improves visibility of Commons API errors by logging JSON-bodied API errors (MediaWiki often returns HTTP 200 with an `error` field) via console.warn/console.error and makes catch-block error-message extraction safer.

### Files changed (high-level)
- pages/api/wikimedia/commons.js
  - Logs HTTP-level non-ok responses with console.error (status + truncated JSON) and logs JSON-bodied API errors found in otherwise-OK responses with console.warn. Proxy response behavior otherwise unchanged.
- pages/api/wikimedia/oauth.js
  - Adds scope: 'editpage' to OAuth authorization parameters for the login flow.
- public/static/depictassist/depictassist.js
  - Removes the explicit rejection of the OAuth pseudotoken (+"\) when validating CSRF tokens (now only fails if token is missing).
  - Adds data-mid / data-qid attributes to suggestion chips to support reliable queue chip re-selection/unselecting.
  - Uses safe error-string extraction: String(err?.message ?? err).
- public/static/depictassist/README.md
  - Expanded operational and OAuth setup documentation, including re-authentication guidance for the added editpage scope, CloudFront cookie-forwarding guidance, CSRF pseudotoken explanation, and proxy error-handling notes.

### Security & auth implications
- OAuth scope change: login now requests editpage. New tokens include write permission; users with preexisting tokens lacking editpage must log out and log back in to obtain write-capable tokens. Attempts to edit with older tokens will fail.
- CSRF handling: fixes bug that rejected the valid pseudotoken (+"\), restoring correct CSRF handling for Bearer-authenticated write flows.
- Access tokens remain stored in an httpOnly cookie (wm_access_token); client JS does not expose token values.

### Infrastructure, env vars, and deployment impact
- No database migrations.
- No environment variables or AWS Secrets Manager keys were added, removed, or renamed. Required env vars remain:
  - WIKIMEDIA_OAUTH_CLIENT_ID
  - WIKIMEDIA_OAUTH_CLIENT_SECRET
  - (optional) WIKIMEDIA_OAUTH_REDIRECT_BASE
- CloudFront / caching operational note: README reiterates that CloudFront must forward cookies (wm_access_token, wm_oauth_state), allow all HTTP methods, disable caching, and forward query strings for /api/wikimedia/* to support authenticated requests. If CloudFront is not already configured this way, the distribution must be updated.
- Deployment: changes take effect after a normal application deployment. No special manual pipeline trigger or ECS redeployment is required beyond the usual pipeline; after deployment users must re-authenticate to get tokens with the new scope.

### Public API / backwards compatibility
- No public-facing API response shapes or endpoints were changed. The Next.js API routes continue to proxy Commons responses; only additional server-side logging was added.
- Client-side behavior: users must re-authenticate to obtain the added editpage permission for write operations.

### Testing guidance
- Deploy the changes.
- Log out (if needed) and log in via "Login with Wikimedia"; confirm redirect to Commons and username shown.
- Add a depicts tag and click "Submit batch"; confirm no "Failed to obtain CSRF token" error, accepted edits show diff links and are removed from the queue while failed items remain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->