### PR TITLE
Revert OAuth scope parameter — breaks token exchange

### DIFF
--- a/pages/api/wikimedia/oauth.js
+++ b/pages/api/wikimedia/oauth.js
@@ -55,7 +55,6 @@ function handleLogin(req, res) {
     response_type: 'code',
     client_id: CLIENT_ID,
     redirect_uri: getCallbackUrl(req),
-    scope: 'editpage',
     state: state
   });
 

--- a/public/static/depictassist/README.md
+++ b/public/static/depictassist/README.md
@@ -71,17 +71,18 @@ and register a new consumer with these settings:
 |---------|-------|
 | Version | OAuth 2.0 |
 | Project | `commons.wikimedia.org` |
-| Grants | `editpage` |
+| Grants | Whatever grants the consumer was registered with (e.g. `editpage`) |
 | Callback URL | `https://pro.dp.la/api/wikimedia/oauth?action=callback` |
 | Consumer type | Confidential (server-side) |
 
 The callback URL must match exactly including the `?action=callback` query string.
 Wikimedia will provide a **Client ID** and a **Client Secret**.
 
-> **Re-authentication note:** If users encounter permission errors after the
-> `editpage` grant was added, they need to log out and log back in. Existing
-> tokens issued before the scope was requested will lack write permission and
-> cannot be upgraded in place.
+The authorization request does **not** send a `scope` parameter — the token
+inherits whatever grants the consumer was registered with on Wikimedia. Do not
+add a `scope` parameter to the authorization URL unless you have confirmed it
+exactly matches the consumer's registered grants; a mismatch causes Wikimedia to
+reject the authorization code exchange.
 
 ### 2. Set environment variables
 


### PR DESCRIPTION
## Summary

Reverts the `scope: 'editpage'` addition from PR #1467. Adding a `scope` parameter to the Wikimedia authorization URL caused the token exchange to fail: Wikimedia rejects the code exchange when the requested scope doesn't match what the consumer was registered with.

The token already inherits all grants from the consumer registration automatically — no `scope` parameter is needed. Also updates the README to document this constraint explicitly so it doesn't get re-introduced.

## Test plan

- [ ] Log out of DepictAssist and log back in via "Login with Wikimedia"
- [ ] Confirm redirect to Commons and back with username shown (no 502)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR reverts the `scope: 'editpage'` parameter from the Wikimedia OAuth authorization request (originally added in PR #1467). The parameter was causing token exchange failures because Wikimedia rejects authorization code exchanges when the requested scope mismatches the consumer's registered scopes. Since issued tokens automatically inherit all grants from the consumer registration, the scope parameter is unnecessary.

## Changes

- **pages/api/wikimedia/oauth.js**: Removed the `scope: 'editpage'` parameter from the OAuth authorization URL in the login flow. The authorization request now sends only `response_type`, `client_id`, `redirect_uri`, and `state`.
- **public/static/depictassist/README.md**: Updated OAuth consumer registration guidance to clarify that the authorization request omits a scope parameter, that tokens inherit registered grants automatically, and that adding a scope parameter can cause Wikimedia to reject the authorization code exchange.

## Security Implications

This PR fixes a broken OAuth authentication flow that was preventing successful token exchange with Wikimedia. The revert restores proper functionality for the "Login with Wikimedia" flow in DepictAssist.

## Test Coverage

Users should be able to log out and log back in via "Login with Wikimedia", be redirected to Commons, and return with the username displayed (no 502 errors).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->