### PR TITLE
Fix DepictAssist submit: CF cache bypass, robust JSON parsing, full failure coverage

### DIFF
--- a/pages/api/wikimedia/commons.js
+++ b/pages/api/wikimedia/commons.js
@@ -17,6 +17,8 @@ export default async function handler(req, res) {
     return res.status(401).json({ error: 'Not authenticated' });
   }
 
+  console.log(`Commons proxy: ${req.method}`);
+
   if (req.method === 'GET') {
     return handleGet(req, res, token);
   }

--- a/public/static/depictassist/depictassist.js
+++ b/public/static/depictassist/depictassist.js
@@ -486,10 +486,17 @@
     $batchError.style.display = 'none';
 
     try {
-      // Get CSRF token via server-side proxy (token is in httpOnly cookie)
-      const tokenResp = await fetch(COMMONS_PROXY + '?action=query&meta=tokens');
-      if (!tokenResp.ok) throw new Error('Failed to get CSRF token');
-      const tokenData = await tokenResp.json();
+      // _proxy=<timestamp> makes each URL unique so CloudFront never serves a
+      // stale cached response; the proxy strips the parameter before forwarding.
+      const tokenResp = await fetch(COMMONS_PROXY + '?action=query&meta=tokens&_proxy=' + Date.now());
+      if (!tokenResp.ok) throw new Error('Failed to get CSRF token (HTTP ' + tokenResp.status + ')');
+      const tokenText = await tokenResp.text();
+      let tokenData;
+      try {
+        tokenData = JSON.parse(tokenText);
+      } catch {
+        throw new Error('CSRF token response was not valid JSON (HTTP ' + tokenResp.status + '): "' + tokenText.slice(0, 200) + '"');
+      }
       const csrfToken = tokenData.query?.tokens?.csrftoken;
 
       // +\ is the valid OAuth 2.0 pseudotoken — do not reject it
@@ -556,13 +563,24 @@
           failures.push(mid);
           continue;
         }
-        const editData = await editResp.json();
+        const editText = await editResp.text();
+        let editData;
+        try {
+          editData = JSON.parse(editText);
+        } catch {
+          console.warn('DepictAssist: edit response not JSON for', mid, ':', editText.slice(0, 200));
+          failures.push(mid);
+          continue;
+        }
 
         if (editData.entity?.lastrevid) {
           diffs.push({ id: editData.entity.id, revid: editData.entity.lastrevid });
           succeededMids.add(mid);
-        } else if (editData.error) {
+        } else {
           failures.push(mid);
+          if (editData.error) {
+            console.warn('DepictAssist: edit API error for', mid, ':', JSON.stringify(editData.error).slice(0, 200));
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

- **CloudFront cache bypass**: adds `_proxy=Date.now()` to the CSRF token GET so each submit attempt is a unique URL — CloudFront can't serve a stale cached response; the proxy already strips `_proxy` before forwarding to Commons
- **Robust JSON parsing**: reads both the CSRF token response and the edit response as text first, then parses with `JSON.parse` in a try/catch — if the body is ever empty or non-JSON, the error message now includes the HTTP status and up to 200 chars of the actual body, making the next failure diagnosable
- **Full edit failure coverage**: any `wbeditentity` response that lacks `entity.lastrevid` (including malformed/unexpected responses) now goes to `failures` instead of being silently dropped from both success and failure lists
- **Server-side logging**: `console.log` in the commons proxy (authenticated requests only, after the 401 check) so CloudWatch shows whether requests are reaching Next.js

## Test plan

- [ ] Log in via Wikimedia OAuth
- [ ] Select an institution, find an image, queue 1–2 tag suggestions
- [ ] Click "Submit batch" — verify edits post to Commons and diff links appear
- [ ] Check CloudWatch `/ecs/frontend-pro-production` logs for `Commons proxy: GET` and `Commons proxy: POST` lines confirming the route is being reached

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes the DepictAssist submit flow with three core improvements:

### CloudFront Cache Bypass
- CSRF token fetch now appends a unique `&_proxy=<Date.now()>` query parameter to ensure CloudFront always fetches fresh from origin instead of serving stale cached responses
- Server-side proxy (`pages/api/wikimedia/commons.js`) strips the `_proxy` parameter before forwarding to Commons, so Commons never sees it

### Robust JSON Parsing
- CSRF token and edit API response handling changed from direct `.json()` calls to reading as text first, then explicitly calling `JSON.parse()` inside try/catch blocks
- Failed JSON parsing now throws a detailed error including HTTP status and up to 200 characters of the response body to aid diagnosis

### Full Edit Failure Coverage
- Edit responses now checked for `entity.lastrevid` presence; any response lacking it (including malformed or unexpected responses) is now recorded in the `failures` array rather than being silently omitted
- API errors present in the response are logged when detected

### Server-Side Logging
- New `console.log` statements added in the Commons proxy handler (authenticated requests only, after the 401 auth check) to record incoming HTTP methods, enabling CloudWatch visibility of whether requests reach the Next.js server

## Important Notes

**ECS Redeployment Required:** A new Next.js API route (`pages/api/wikimedia/commons.js`) has been added. This server-side code handles proxying authenticated requests to Wikimedia Commons and requires ECS redeployment to take effect in production. The route will not be available to clients until the updated code is deployed.

**No Infrastructure Changes:** No environment variables, AWS Secrets Manager keys, database migrations, CodePipeline modifications, or IAM policy changes are included.

**Security:** The new proxy includes authentication checks (401 if OAuth token is missing from httpOnly cookie), restricts allowed actions to a whitelist (`query` for GET, `wbeditentity` for POST), and uses Bearer token authentication with Commons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->