### PR TITLE
Fix Express catch-all to forward POST requests to Next.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -84,7 +84,7 @@ function follower() {
       expressApp.post("/g/feedback", feedback());
     }
 
-    expressApp.get("*", catchall(handle));
+    expressApp.all("*", catchall(handle));
 
     const server = expressApp.listen(PORT, (err) => {
       if (err) throw err;


### PR DESCRIPTION
## Summary

- `expressApp.get("*")` only matched GET requests — any POST that didn't match a specific route (`/mailchimp`, `/g/contact`, `/g/feedback`) fell through to Express with no handler and returned a 404 HTML page
- Changed to `expressApp.all("*")` so all HTTP methods are forwarded to Next.js
- Root cause of `POST /api/wikimedia/commons 404` in DepictAssist submit flow

## Test plan

- [ ] Log in via Wikimedia OAuth on DepictAssist
- [ ] Select an institution, find an image, queue 1–2 tag suggestions
- [ ] Click "Submit batch" — verify edits post to Commons and diff links appear
- [ ] Verify `/mailchimp`, `/g/contact`, `/g/feedback` POST routes still work (they are registered before the catch-all and are unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes Express routing to forward all HTTP methods (not just GET) to Next.js, resolving a bug where POST requests to unmatched routes fell through and returned Express 404 responses instead of being handled by Next.js.

### Changes

**server.js:** Changed the catch-all route handler from `expressApp.get("*")` to `expressApp.all("*")`. This ensures requests of all HTTP methods are forwarded to Next.js, rather than only GET requests.

### Impact

- Fixes POST requests to `/api/wikimedia/commons` in the DepictAssist submit flow, which were returning 404 errors
- Specific POST routes (`/mailchimp`, `/g/contact`, `/g/feedback`) registered before the catch-all remain unaffected
- No infrastructure, environment variables, database migrations, or API changes required
- Does not require manual pipeline trigger or ECS redeployment to take effect

<!-- end of auto-generated comment: release notes by coderabbit.ai -->