### PR TITLE
Add User-Agent to server-side Wikimedia API calls

### DIFF
--- a/lib/wikimediaUserAgent.js
+++ b/lib/wikimediaUserAgent.js
@@ -1,0 +1,2 @@
+export const WIKIMEDIA_USER_AGENT =
+  'DPLA-DepictAssist/1.0 (https://pro.dp.la/projects/dpla-wikimedia/depictassist; tech@dp.la) Node.js';

--- a/pages/api/wikimedia/commons.js
+++ b/pages/api/wikimedia/commons.js
@@ -3,6 +3,8 @@
 // client JS). This route reads the token and forwards requests to Commons
 // with Bearer auth.
 
+import { WIKIMEDIA_USER_AGENT } from 'lib/wikimediaUserAgent';
+
 const COMMONS_API = 'https://commons.wikimedia.org/w/api.php';
 const TOKEN_COOKIE = 'wm_access_token';
 const FETCH_TIMEOUT_MS = 10000;
@@ -40,7 +42,7 @@ async function handleGet(req, res, token) {
 
   try {
     const apiResp = await fetch(COMMONS_API + '?' + qs.toString(), {
-      headers: { Authorization: 'Bearer ' + token },
+      headers: { Authorization: 'Bearer ' + token, 'User-Agent': WIKIMEDIA_USER_AGENT },
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)
     });
     return await forwardCommonsResponse(apiResp, res);
@@ -64,7 +66,8 @@ async function handlePost(req, res, token) {
       method: 'POST',
       headers: {
         Authorization: 'Bearer ' + token,
-        'Content-Type': 'application/x-www-form-urlencoded'
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'User-Agent': WIKIMEDIA_USER_AGENT
       },
       body: new URLSearchParams(bodyParams).toString(),
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)

--- a/pages/api/wikimedia/oauth.js
+++ b/pages/api/wikimedia/oauth.js
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 import { setCookie } from 'lib/setCookie';
+import { WIKIMEDIA_USER_AGENT } from 'lib/wikimediaUserAgent';
 
 const CLIENT_ID = process.env.WIKIMEDIA_OAUTH_CLIENT_ID;
 const CLIENT_SECRET = process.env.WIKIMEDIA_OAUTH_CLIENT_SECRET;
@@ -84,7 +85,7 @@ async function handleCallback(req, res) {
 
     const tokenResp = await fetch(TOKEN_ENDPOINT, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'User-Agent': WIKIMEDIA_USER_AGENT },
       body: body.toString(),
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)
     });
@@ -132,7 +133,7 @@ async function handleWhoAmI(req, res) {
   try {
     const apiUrl = COMMONS_API + '?action=query&meta=userinfo&format=json';
     const apiResp = await fetch(apiUrl, {
-      headers: { 'Authorization': 'Bearer ' + token },
+      headers: { 'Authorization': 'Bearer ' + token, 'User-Agent': WIKIMEDIA_USER_AGENT },
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)
     });
 


### PR DESCRIPTION
## Summary

- Wikimedia's Cloudflare infrastructure was returning `429 <!DOCTYPE html>` for server-side API calls because Node.js `fetch()` sends no `User-Agent` header by default
- Adds a descriptive `User-Agent` to all server-side fetch calls in the Commons proxy (`commons.js`) and OAuth routes (`oauth.js`), per [Wikimedia's API access policy](https://meta.wikimedia.org/wiki/User-Agent_policy)
- Extracts the constant to `lib/wikimediaUserAgent.js` to avoid duplication between the two files

## Test plan

- [ ] Log in to DepictAssist and submit a batch of depicts claims — verify no `429` errors appear in CloudWatch for `Commons API returned non-JSON response`
- [ ] Verify `whoami` and OAuth callback still work correctly after login

🤖 Generated with [Claude Code](https://claude.com/claude-code)