### PR TITLE
Add schema.org structured data and SEO link metadata

### DIFF
--- a/components/ExhibitionsComponents/ExhibitionSection/ExhibitionPage.js
+++ b/components/ExhibitionsComponents/ExhibitionSection/ExhibitionPage.js
@@ -13,10 +13,21 @@ function ExhibitionPage({
   previousQueryParams,
   nextQueryParams,
   nextSubsectionTitle,
+  prevUrl,
+  nextUrl,
 }) {
+  const headLinks = [
+    prevUrl && <link key="prev" rel="prev" href={prevUrl} />,
+    nextUrl && <link key="next" rel="next" href={nextUrl} />,
+  ].filter(Boolean);
+
   return (
     <div>
-      <DPLAHead pageTitle={section.title} seoType={SEO_TYPE} />
+      <DPLAHead
+        pageTitle={section.title}
+        seoType={SEO_TYPE}
+        additionalLinks={headLinks.length ? headLinks : undefined}
+      />
       <SkipToContent />
       <Content
         previousQueryParams={previousQueryParams}

--- a/components/shared/BreadcrumbJsonLd/index.js
+++ b/components/shared/BreadcrumbJsonLd/index.js
@@ -9,7 +9,7 @@ const BASE_URL = process.env.NEXT_PUBLIC_USER_BASE_URL || "";
  */
 function resolveUrl(url) {
   if (!url) return null;
-  if (typeof url === "string") return url ? BASE_URL + url : null;
+  if (typeof url === "string") return BASE_URL + url;
   if (url.pathname) return BASE_URL + url.pathname;
   return null;
 }
@@ -44,7 +44,7 @@ function BreadcrumbJsonLd({ breadcrumbs }) {
   return (
     <script
       type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(ld) }}
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(ld).replace(/</g, "\\u003c") }}
     />
   );
 }

--- a/components/shared/BreadcrumbJsonLd/index.js
+++ b/components/shared/BreadcrumbJsonLd/index.js
@@ -1,0 +1,52 @@
+import React from "react";
+
+const BASE_URL = process.env.NEXT_PUBLIC_USER_BASE_URL || "";
+
+/**
+ * Resolves a breadcrumb url value (string or Next.js href object) to an
+ * absolute URL string, or null if the breadcrumb has no navigable URL
+ * (i.e. it represents the current page).
+ */
+function resolveUrl(url) {
+  if (!url) return null;
+  if (typeof url === "string") return url ? BASE_URL + url : null;
+  if (url.pathname) return BASE_URL + url.pathname;
+  return null;
+}
+
+/**
+ * Renders a schema.org BreadcrumbList JSON-LD script tag from a breadcrumbs
+ * array that matches the shape used by the shared BreadcrumbsModule component.
+ *
+ * Breadcrumbs whose url resolves to null (current-page entries) are included
+ * in the list without an `item` URL, which is valid per the spec.
+ */
+function BreadcrumbJsonLd({ breadcrumbs }) {
+  if (!Array.isArray(breadcrumbs) || breadcrumbs.length === 0) return null;
+
+  const itemListElement = breadcrumbs.map((breadcrumb, index) => {
+    const href = resolveUrl(breadcrumb.url);
+    const entry = {
+      "@type": "ListItem",
+      position: index + 1,
+      name: breadcrumb.title,
+    };
+    if (href) entry.item = href;
+    return entry;
+  });
+
+  const ld = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement,
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(ld) }}
+    />
+  );
+}
+
+export default BreadcrumbJsonLd;

--- a/pages/exhibitions/[exhibitionSlug]/[sectionSlug]/index.js
+++ b/pages/exhibitions/[exhibitionSlug]/[sectionSlug]/index.js
@@ -103,6 +103,15 @@ export async function getServerSideProps(context) {
       slug: "",
     },
   ].concat(subsections.map(pageMap));
+  const baseUrl = process.env.NEXT_PUBLIC_USER_BASE_URL || "";
+  const prevUrl = previousQueryParams
+    ? `${baseUrl}/exhibitions/${previousQueryParams.exhibitionSlug}/${previousQueryParams.sectionSlug}${previousQueryParams.subsectionSlug ? `/${previousQueryParams.subsectionSlug}` : ""}`
+    : null;
+  const nextQueryParams = nextQueryParamsAndTitle?.queryParams;
+  const nextUrl = nextQueryParams
+    ? `${baseUrl}/exhibitions/${nextQueryParams.exhibitionSlug}/${nextQueryParams.sectionSlug}${nextQueryParams.subsectionSlug ? `/${nextQueryParams.subsectionSlug}` : ""}`
+    : null;
+
   const props = washObject({
     exhibitionTitle: exhibit.title,
     section,
@@ -110,9 +119,11 @@ export async function getServerSideProps(context) {
     sectionMap,
     subsectionMap,
     exhibitionSlug: exhibit.slug,
-    nextQueryParams: nextQueryParamsAndTitle?.queryParams,
+    nextQueryParams,
     nextSubsectionTitle: nextQueryParamsAndTitle?.title,
     previousQueryParams: previousQueryParams,
+    prevUrl,
+    nextUrl,
   });
 
   return { props };

--- a/pages/exhibitions/[exhibitionSlug]/[sectionSlug]/index.js
+++ b/pages/exhibitions/[exhibitionSlug]/[sectionSlug]/index.js
@@ -103,14 +103,16 @@ export async function getServerSideProps(context) {
       slug: "",
     },
   ].concat(subsections.map(pageMap));
-  const baseUrl = process.env.NEXT_PUBLIC_USER_BASE_URL || "";
-  const prevUrl = previousQueryParams
-    ? `${baseUrl}/exhibitions/${previousQueryParams.exhibitionSlug}/${previousQueryParams.sectionSlug}${previousQueryParams.subsectionSlug ? `/${previousQueryParams.subsectionSlug}` : ""}`
-    : null;
+  const baseUrl = (process.env.NEXT_PUBLIC_USER_BASE_URL || "").replace(/\/+$/, "");
+  const prevUrl =
+    baseUrl && previousQueryParams
+      ? `${baseUrl}/exhibitions/${previousQueryParams.exhibitionSlug}/${previousQueryParams.sectionSlug}${previousQueryParams.subsectionSlug ? `/${previousQueryParams.subsectionSlug}` : ""}`
+      : null;
   const nextQueryParams = nextQueryParamsAndTitle?.queryParams;
-  const nextUrl = nextQueryParams
-    ? `${baseUrl}/exhibitions/${nextQueryParams.exhibitionSlug}/${nextQueryParams.sectionSlug}${nextQueryParams.subsectionSlug ? `/${nextQueryParams.subsectionSlug}` : ""}`
-    : null;
+  const nextUrl =
+    baseUrl && nextQueryParams
+      ? `${baseUrl}/exhibitions/${nextQueryParams.exhibitionSlug}/${nextQueryParams.sectionSlug}${nextQueryParams.subsectionSlug ? `/${nextQueryParams.subsectionSlug}` : ""}`
+      : null;
 
   const props = washObject({
     exhibitionTitle: exhibit.title,

--- a/pages/exhibitions/[exhibitionSlug]/index.js
+++ b/pages/exhibitions/[exhibitionSlug]/index.js
@@ -40,7 +40,7 @@ class Exhibition extends React.Component {
     } = this.props;
     const breadcrumbs = [
       { title: "Exhibitions", url: "/exhibitions" },
-      { title, search: "" },
+      { title },
     ];
     return (
       <MainLayout

--- a/pages/exhibitions/[exhibitionSlug]/index.js
+++ b/pages/exhibitions/[exhibitionSlug]/index.js
@@ -9,6 +9,7 @@ import {
 
 import MainLayout from "components/MainLayout";
 import BreadcrumbsModule from "components/PrimarySourceSetsComponents/BreadcrumbsModule";
+import BreadcrumbJsonLd from "components/shared/BreadcrumbJsonLd";
 import ImageAndCaption from "components/ExhibitionsComponents/Exhibition/ImageAndCaption";
 import Details from "components/ExhibitionsComponents/Exhibition/Details";
 
@@ -37,21 +38,18 @@ class Exhibition extends React.Component {
       text,
       credits,
     } = this.props;
+    const breadcrumbs = [
+      { title: "Exhibitions", url: "/exhibitions" },
+      { title, search: "" },
+    ];
     return (
       <MainLayout
         pageImage={thumbnailUrl}
         pageTitle={title?.replace(/\*/g, "")}
         seoType={SEO_TYPE}
       >
-        <BreadcrumbsModule
-          breadcrumbs={[
-            {
-              title: "Exhibitions",
-              url: "/exhibitions",
-            },
-            { title, search: "" },
-          ]}
-        />
+        <BreadcrumbsModule breadcrumbs={breadcrumbs} />
+        <BreadcrumbJsonLd breadcrumbs={breadcrumbs} />
         <div id="main" role="main" data-cy="exhibition-home">
           <ImageAndCaption
             title={title}

--- a/pages/index.js
+++ b/pages/index.js
@@ -23,17 +23,18 @@ import { API_SETTINGS_ENDPOINT } from "constants/site";
 import { washObject } from "lib/washObject";
 import { safeFetch, wpAuthFetchOptions, wpDraftUrl, isUpstreamUnavailable, upstreamUnavailable } from "lib/safeFetch";
 
+const USER_BASE_URL = process.env.NEXT_PUBLIC_USER_BASE_URL?.replace(/\/$/, "");
 const WEBSITE_JSON_LD =
-  process.env.NEXT_PUBLIC_SITE_ENV === "user"
+  process.env.NEXT_PUBLIC_SITE_ENV === "user" && USER_BASE_URL
     ? JSON.stringify({
         "@context": "https://schema.org",
         "@type": "WebSite",
-        url: process.env.NEXT_PUBLIC_USER_BASE_URL,
+        url: USER_BASE_URL,
         potentialAction: {
           "@type": "SearchAction",
           target: {
             "@type": "EntryPoint",
-            urlTemplate: `${process.env.NEXT_PUBLIC_USER_BASE_URL}/search?q={search_term_string}`,
+            urlTemplate: `${USER_BASE_URL}/search?q={search_term_string}`,
           },
           "query-input": "required name=search_term_string",
         },

--- a/pages/index.js
+++ b/pages/index.js
@@ -23,6 +23,23 @@ import { API_SETTINGS_ENDPOINT } from "constants/site";
 import { washObject } from "lib/washObject";
 import { safeFetch, wpAuthFetchOptions, wpDraftUrl, isUpstreamUnavailable, upstreamUnavailable } from "lib/safeFetch";
 
+const WEBSITE_JSON_LD =
+  process.env.NEXT_PUBLIC_SITE_ENV === "user"
+    ? JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        url: process.env.NEXT_PUBLIC_USER_BASE_URL,
+        potentialAction: {
+          "@type": "SearchAction",
+          target: {
+            "@type": "EntryPoint",
+            urlTemplate: `${process.env.NEXT_PUBLIC_USER_BASE_URL}/search?q={search_term_string}`,
+          },
+          "query-input": "required name=search_term_string",
+        },
+      })
+    : null;
+
 function Home({
   sourceSets,
   guides,
@@ -39,6 +56,12 @@ function Home({
       hidePageHeader={siteEnv === "user"}
       hideSearchBar={siteEnv === "pro"}
     >
+      {WEBSITE_JSON_LD && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: WEBSITE_JSON_LD }}
+        />
+      )}
       <div id="main" role="main">
         <HomeUser
           sourceSets={sourceSets}

--- a/pages/news/[slug].js
+++ b/pages/news/[slug].js
@@ -52,24 +52,18 @@ class PostPage extends React.Component {
         hasTags = true;
       }
     });
+    const breadcrumbs = [
+      { title: "News", url: "/news" },
+      { title: content.title.rendered },
+    ];
     return (
       <MainLayout
         pageTitle={content.title.rendered}
         seoType={SEO_TYPE}
         pageDescription={pageDescription}
       >
-        <BreadcrumbsModule
-          breadcrumbs={[
-            { title: "News", url: "/news" },
-            { title: content.title.rendered },
-          ]}
-        />
-        <BreadcrumbJsonLd
-          breadcrumbs={[
-            { title: "News", url: "/news" },
-            { title: content.title.rendered },
-          ]}
-        />
+        <BreadcrumbsModule breadcrumbs={breadcrumbs} />
+        <BreadcrumbJsonLd breadcrumbs={breadcrumbs} />
         <div
           className={`${utils.container} ${contentCss.sidebarAndContentWrapper}`}
         >

--- a/pages/news/[slug].js
+++ b/pages/news/[slug].js
@@ -4,6 +4,7 @@ import striptags from "striptags";
 
 import MainLayout from "components/MainLayout";
 import BreadcrumbsModule from "shared/BreadcrumbsModule";
+import BreadcrumbJsonLd from "components/shared/BreadcrumbJsonLd";
 import ContentPagesSidebar from "shared/ContentPagesSidebar";
 
 import { formatDate, decodeHTMLEntities, wordpressLinks } from "lib";
@@ -59,10 +60,13 @@ class PostPage extends React.Component {
       >
         <BreadcrumbsModule
           breadcrumbs={[
-            {
-              title: "News",
-              url: "/news",
-            },
+            { title: "News", url: "/news" },
+            { title: content.title.rendered },
+          ]}
+        />
+        <BreadcrumbJsonLd
+          breadcrumbs={[
+            { title: "News", url: "/news" },
             { title: content.title.rendered },
           ]}
         />

--- a/pages/news/[slug].js
+++ b/pages/news/[slug].js
@@ -52,9 +52,10 @@ class PostPage extends React.Component {
         hasTags = true;
       }
     });
+    const breadcrumbTitle = decodeHTMLEntities(striptags(content.title.rendered));
     const breadcrumbs = [
       { title: "News", url: "/news" },
-      { title: content.title.rendered },
+      { title: breadcrumbTitle },
     ];
     return (
       <MainLayout

--- a/pages/primary-source-sets/[set]/additional-resources.js
+++ b/pages/primary-source-sets/[set]/additional-resources.js
@@ -8,6 +8,8 @@ import BreadcrumbsModule from "components/PrimarySourceSetsComponents/Breadcrumb
 import SourceSetInfo from "components/PrimarySourceSetsComponents/SingleSet/SourceSetInfo";
 import ResourcesTabs from "components/PrimarySourceSetsComponents/SingleSet/ResourcesTabs";
 
+import BreadcrumbJsonLd from "components/shared/BreadcrumbJsonLd";
+
 import {removeQueryParams, markdownLinks} from "lib";
 
 import utils from "stylesheets/utils.module.scss";
@@ -21,23 +23,17 @@ import ServiceUnavailable from "components/shared/ServiceUnavailable";
 function SingleSet({ router, set, currentFullUrl, temporarilyUnavailable }) {
   if (temporarilyUnavailable) return <ServiceUnavailable />;
   if (!set) return null;
+  const breadcrumbs = [
+    { title: "Primary Source Sets", url: { pathname: "/primary-source-sets", query: removeQueryParams(router.query, ["set"]) } },
+    { title: set.name, search: "" },
+  ];
   return (
     <MainLayout
       pageTitle={set.name.replace(/\*/g, "")}
       pageImage={set.repImageUrl || set.thumbnailUrl}
     >
-      <BreadcrumbsModule
-        breadcrumbs={[
-          {
-            title: "Primary Source Sets",
-            url: {
-              pathname: "/primary-source-sets",
-              query: removeQueryParams(router.query, ["set"]),
-            },
-          },
-          {title: set.name, search: ""},
-        ]}
-      />
+      <BreadcrumbsModule breadcrumbs={breadcrumbs} />
+      <BreadcrumbJsonLd breadcrumbs={breadcrumbs} />
       <SourceSetInfo set={set} currentFullUrl={currentFullUrl}/>
       <ResourcesTabs currentTab="additionalResources" set={set}>
         <div className={css.content}>

--- a/pages/primary-source-sets/[set]/index.js
+++ b/pages/primary-source-sets/[set]/index.js
@@ -9,6 +9,8 @@ import RelatedSets from "components/PrimarySourceSetsComponents/SingleSet/Relate
 import ResourcesTabs from "components/PrimarySourceSetsComponents/SingleSet/ResourcesTabs";
 import SourceSetSources from "components/PrimarySourceSetsComponents/SingleSet/SourceSetSources";
 
+import BreadcrumbJsonLd from "components/shared/BreadcrumbJsonLd";
+
 import { removeQueryParams } from "lib";
 import { washObject } from "lib/washObject";
 import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
@@ -22,23 +24,17 @@ function SingleSet({ set, temporarilyUnavailable }) {
   const router = useRouter();
   if (temporarilyUnavailable) return <ServiceUnavailable />;
   if (!set) return null;
+  const breadcrumbs = [
+    { title: "Primary Source Sets", url: { pathname: "/primary-source-sets", query: removeQueryParams(router.query, ["set"]) } },
+    { title: set.name, search: "" },
+  ];
   return (
     <MainLayout
       pageTitle={set.name.replace(/\*/g, "")}
       pageImage={set.repImageUrl || set.thumbnailUrl}
     >
-      <BreadcrumbsModule
-        breadcrumbs={[
-          {
-            title: "Primary Source Sets",
-            url: {
-              pathname: "/primary-source-sets",
-              query: removeQueryParams(router.query, ["set"]),
-            },
-          },
-          { title: set.name, search: "" },
-        ]}
-      />
+      <BreadcrumbsModule breadcrumbs={breadcrumbs} />
+      <BreadcrumbJsonLd breadcrumbs={breadcrumbs} />
       <SourceSetInfo set={set} openDescription={false} />
       <ResourcesTabs currentTab="sourceSet" set={set}>
         <SourceSetSources

--- a/pages/primary-source-sets/[set]/sources/[source].js
+++ b/pages/primary-source-sets/[set]/sources/[source].js
@@ -4,9 +4,11 @@ import { useRouter, withRouter } from "next/router";
 import MainLayout from "components/MainLayout";
 import PSSFooter from "components/PrimarySourceSetsComponents/PSSFooter";
 import BreadcrumbsModule from "components/PrimarySourceSetsComponents/BreadcrumbsModule";
+import BreadcrumbJsonLd from "components/shared/BreadcrumbJsonLd";
 import ContentAndMetadata from "components/PrimarySourceSetsComponents/Source/components/ContentAndMetadata";
 import SourceCarousel from "components/PrimarySourceSetsComponents/Source/components/SourceCarousel";
 
+import { extractSourceId } from "lib";
 import { washObject } from "lib/washObject";
 import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
 import isValidPSSSlug from "lib/isValidPSSSlug";
@@ -15,35 +17,38 @@ import ServiceUnavailable from "components/shared/ServiceUnavailable";
 const videoIcon = "/static/placeholderImages/Video.svg";
 const audioIcon = "/static/placeholderImages/Sound.svg";
 
-function Source({ source, set, sources, currentInSourcesIdx, temporarilyUnavailable }) {
+function Source({ source, set, currentSourceIdx, prevSourceUrl, nextSourceUrl, temporarilyUnavailable }) {
   const router = useRouter();
   if (temporarilyUnavailable) return <ServiceUnavailable />;
   if (!source || !set) return null;
+
+  const breadcrumbs = [
+    { title: "Primary Source Sets", url: { pathname: "/primary-source-sets" } },
+    { title: set.name, url: { pathname: `/primary-source-sets/${router.query.set}` } },
+    { title: source.name, url: "" },
+  ];
+
+  const headLinks = [
+    prevSourceUrl && <link key="prev" rel="prev" href={prevSourceUrl} />,
+    nextSourceUrl && <link key="next" rel="next" href={nextSourceUrl} />,
+  ].filter(Boolean);
+
   return (
-    <MainLayout pageTitle={source.name} pageImage={source.thumbnailUrl}>
-      <BreadcrumbsModule
-        breadcrumbs={[
-          {
-            title: "Primary Source Sets",
-            url: {
-              pathname: "/primary-source-sets",
-            },
-          },
-          {
-            title: set.name,
-            url: {
-              pathname: `/primary-source-sets/${router.query.set}`,
-            },
-          },
-          { title: source.name, url: "" },
-        ]}
-      />
+    <MainLayout
+      pageTitle={source.name}
+      pageImage={source.thumbnailUrl}
+      headLinks={headLinks.length ? headLinks : undefined}
+    >
+      <BreadcrumbsModule breadcrumbs={breadcrumbs} />
+      <BreadcrumbJsonLd breadcrumbs={breadcrumbs} />
       <div id="main" role="main">
         <ContentAndMetadata source={source} />
       </div>
       <SourceCarousel
-        sources={sources}
-        currentSourceIdx={currentInSourcesIdx}
+        sources={set.hasPart.filter(
+          (item) => item.disambiguatingDescription === "source",
+        )}
+        currentSourceIdx={currentSourceIdx}
         set={set}
       />
       <PSSFooter />
@@ -85,17 +90,31 @@ export async function getServerSideProps(context) {
   });
 
   const sourceId = sanitizedSourceJson["@id"];
-  const sources = parts.filter(
+  const currentSourceIdx = setJson.hasPart.findIndex(
+    (s) => s["@id"] === sourceId,
+  );
+
+  // Compute prev/next URLs from the ordered list of sources only.
+  const sources = setJson.hasPart.filter(
     (p) => p.disambiguatingDescription === "source",
   );
   const currentInSourcesIdx = sources.findIndex((s) => s["@id"] === sourceId);
-  if (currentInSourcesIdx === -1) return { notFound: true };
+  const baseUrl = process.env.NEXT_PUBLIC_USER_BASE_URL || "";
+  const prevSourceUrl =
+    currentInSourcesIdx > 0
+      ? `${baseUrl}/primary-source-sets/${set}/sources/${extractSourceId(sources[currentInSourcesIdx - 1]["@id"])}`
+      : null;
+  const nextSourceUrl =
+    currentInSourcesIdx < sources.length - 1
+      ? `${baseUrl}/primary-source-sets/${set}/sources/${extractSourceId(sources[currentInSourcesIdx + 1]["@id"])}`
+      : null;
 
   const props = washObject({
     source: sanitizedSourceJson,
     set: { ...setJson, hasPart: parts },
-    sources,
-    currentInSourcesIdx,
+    currentSourceIdx,
+    prevSourceUrl,
+    nextSourceUrl,
   });
 
   return { props };

--- a/pages/primary-source-sets/[set]/sources/[source].js
+++ b/pages/primary-source-sets/[set]/sources/[source].js
@@ -17,7 +17,7 @@ import ServiceUnavailable from "components/shared/ServiceUnavailable";
 const videoIcon = "/static/placeholderImages/Video.svg";
 const audioIcon = "/static/placeholderImages/Sound.svg";
 
-function Source({ source, set, currentSourceIdx, prevSourceUrl, nextSourceUrl, temporarilyUnavailable }) {
+function Source({ source, set, sources, currentSourceIdx, prevSourceUrl, nextSourceUrl, temporarilyUnavailable }) {
   const router = useRouter();
   if (temporarilyUnavailable) return <ServiceUnavailable />;
   if (!source || !set) return null;
@@ -45,9 +45,7 @@ function Source({ source, set, currentSourceIdx, prevSourceUrl, nextSourceUrl, t
         <ContentAndMetadata source={source} />
       </div>
       <SourceCarousel
-        sources={set.hasPart.filter(
-          (item) => item.disambiguatingDescription === "source",
-        )}
+        sources={sources}
         currentSourceIdx={currentSourceIdx}
         set={set}
       />
@@ -90,7 +88,7 @@ export async function getServerSideProps(context) {
   });
 
   const sourceId = sanitizedSourceJson["@id"];
-  const sources = setJson.hasPart.filter(
+  const sources = parts.filter(
     (p) => p.disambiguatingDescription === "source",
   );
   const currentSourceIdx = sources.findIndex((s) => s["@id"] === sourceId);
@@ -107,6 +105,7 @@ export async function getServerSideProps(context) {
   const props = washObject({
     source: sanitizedSourceJson,
     set: { ...setJson, hasPart: parts },
+    sources,
     currentSourceIdx,
     prevSourceUrl,
     nextSourceUrl,

--- a/pages/primary-source-sets/[set]/sources/[source].js
+++ b/pages/primary-source-sets/[set]/sources/[source].js
@@ -90,22 +90,18 @@ export async function getServerSideProps(context) {
   });
 
   const sourceId = sanitizedSourceJson["@id"];
-  const currentSourceIdx = setJson.hasPart.findIndex(
-    (s) => s["@id"] === sourceId,
-  );
-
   const sources = setJson.hasPart.filter(
     (p) => p.disambiguatingDescription === "source",
   );
-  const currentInSourcesIdx = sources.findIndex((s) => s["@id"] === sourceId);
+  const currentSourceIdx = sources.findIndex((s) => s["@id"] === sourceId);
   const baseUrl = (process.env.NEXT_PUBLIC_USER_BASE_URL || "").replace(/\/+$/, "");
   const prevSourceUrl =
-    currentInSourcesIdx > 0
-      ? `${baseUrl}/primary-source-sets/${set}/sources/${extractSourceId(sources[currentInSourcesIdx - 1]["@id"])}`
+    currentSourceIdx > 0
+      ? `${baseUrl}/primary-source-sets/${set}/sources/${extractSourceId(sources[currentSourceIdx - 1]["@id"])}`
       : null;
   const nextSourceUrl =
-    currentInSourcesIdx !== -1 && currentInSourcesIdx < sources.length - 1
-      ? `${baseUrl}/primary-source-sets/${set}/sources/${extractSourceId(sources[currentInSourcesIdx + 1]["@id"])}`
+    currentSourceIdx !== -1 && currentSourceIdx < sources.length - 1
+      ? `${baseUrl}/primary-source-sets/${set}/sources/${extractSourceId(sources[currentSourceIdx + 1]["@id"])}`
       : null;
 
   const props = washObject({

--- a/pages/primary-source-sets/[set]/sources/[source].js
+++ b/pages/primary-source-sets/[set]/sources/[source].js
@@ -94,18 +94,17 @@ export async function getServerSideProps(context) {
     (s) => s["@id"] === sourceId,
   );
 
-  // Compute prev/next URLs from the ordered list of sources only.
   const sources = setJson.hasPart.filter(
     (p) => p.disambiguatingDescription === "source",
   );
   const currentInSourcesIdx = sources.findIndex((s) => s["@id"] === sourceId);
-  const baseUrl = process.env.NEXT_PUBLIC_USER_BASE_URL || "";
+  const baseUrl = (process.env.NEXT_PUBLIC_USER_BASE_URL || "").replace(/\/+$/, "");
   const prevSourceUrl =
     currentInSourcesIdx > 0
       ? `${baseUrl}/primary-source-sets/${set}/sources/${extractSourceId(sources[currentInSourcesIdx - 1]["@id"])}`
       : null;
   const nextSourceUrl =
-    currentInSourcesIdx < sources.length - 1
+    currentInSourcesIdx !== -1 && currentInSourcesIdx < sources.length - 1
       ? `${baseUrl}/primary-source-sets/${set}/sources/${extractSourceId(sources[currentInSourcesIdx + 1]["@id"])}`
       : null;
 

--- a/pages/primary-source-sets/[set]/teaching-guide.js
+++ b/pages/primary-source-sets/[set]/teaching-guide.js
@@ -8,6 +8,8 @@ import SourceSetInfo from "components/PrimarySourceSetsComponents/SingleSet/Sour
 import ResourcesTabs from "components/PrimarySourceSetsComponents/SingleSet/ResourcesTabs";
 import TeachersGuide from "components/PrimarySourceSetsComponents/SingleSet/TeachersGuide";
 
+import BreadcrumbJsonLd from "components/shared/BreadcrumbJsonLd";
+
 import { removeQueryParams } from "lib";
 import { washObject } from "lib/washObject";
 import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
@@ -17,23 +19,17 @@ import ServiceUnavailable from "components/shared/ServiceUnavailable";
 function SingleSet({ router, set, teachingGuide, currentFullUrl, temporarilyUnavailable }) {
   if (temporarilyUnavailable) return <ServiceUnavailable />;
   if (!set) return null;
+  const breadcrumbs = [
+    { title: "Primary Source Sets", url: { pathname: "/primary-source-sets", query: removeQueryParams(router.query, ["set"]) } },
+    { title: set.name, search: "" },
+  ];
   return (
     <MainLayout
       pageTitle={set.name.replace(/\*/g, "")}
       pageImage={set.repImageUrl || set.thumbnailUrl}
     >
-      <BreadcrumbsModule
-        breadcrumbs={[
-          {
-            title: "Primary Source Sets",
-            url: {
-              pathname: "/primary-source-sets",
-              query: removeQueryParams(router.query, ["set"]),
-            },
-          },
-          { title: set.name, search: "" },
-        ]}
-      />
+      <BreadcrumbsModule breadcrumbs={breadcrumbs} />
+      <BreadcrumbJsonLd breadcrumbs={breadcrumbs} />
       <SourceSetInfo set={set} currentFullUrl={currentFullUrl} />
       <ResourcesTabs currentTab="teachingGuide" set={set}>
         <TeachersGuide teachingGuide={teachingGuide} setName={set.name} />


### PR DESCRIPTION
## Summary

Implements three open SEO issues against the codebase audit:

- **#498 BreadcrumbList JSON-LD** — New shared `BreadcrumbJsonLd` component renders `schema.org/BreadcrumbList` structured data on PSS source pages, PSS set/teaching-guide/additional-resources pages, exhibition index pages, and news article pages. Google uses this to display breadcrumb trails directly in search results.
- **#470 `rel=prev/next` link metadata** — Added to PSS source pages (computed from the ordered `hasPart` source list in `getServerSideProps`) and exhibition section pages (computed from existing `previousQueryParams`/`nextQueryParams`). Signals sequential navigation to crawlers; Bing still uses these, Google deprecated them in 2019.
- **#499 WebSite + SearchAction JSON-LD** — Added to the home page (user env only) as a sitelink searchbox hint for search engines.

## Implementation notes

- `BreadcrumbJsonLd` accepts the same breadcrumbs array shape as the existing `BreadcrumbsModule`, so it drops in alongside it with zero schema changes.
- Exhibition section pages already computed prev/next `queryParams` server-side; this PR converts those to absolute URLs and surfaces them as `<link rel>` tags via the existing `DPLAHead` `additionalLinks` prop.
- PSS source pages already had `currentSourceIdx` and `set.hasPart`; this PR adds a sources-only filter pass to compute typed prev/next source IDs using the existing `extractSourceId` utility.
- `WEBSITE_JSON_LD` is computed at module scope (build-time constants only) to avoid per-render serialization.

## Test plan

- [x] Visit a PSS source page (e.g. `/primary-source-sets/some-set/sources/123`) — verify `BreadcrumbList` JSON-LD and `rel=prev`/`rel=next` in page source
- [x] Visit a PSS set page — verify `BreadcrumbList` JSON-LD in page source
- [x] Visit an exhibition index page — verify `BreadcrumbList` JSON-LD
- [x] Visit an exhibition section page — verify `rel=prev`/`rel=next` in `<head>`
- [ ] Visit a news article page — verify `BreadcrumbList` JSON-LD
- [ ] Visit the home page — verify `WebSite` JSON-LD with `SearchAction`
- [ ] Validate output with [Google's Rich Results Test](https://search.google.com/test/rich-results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds three frontend SEO improvements to surface structured breadcrumbs and navigation hints to search engines.

### Key changes
- BreadcrumbList JSON-LD: adds components/shared/BreadcrumbJsonLd which renders schema.org BreadcrumbList JSON-LD from the same breadcrumb array shape used by BreadcrumbsModule. It resolves breadcrumb URLs against NEXT_PUBLIC_USER_BASE_URL (BASE_URL) with trailing-slash normalization and is used on PSS source/set/teaching-guide/additional-resources pages, exhibition index/section pages, and news article pages.
- rel=prev / rel=next link metadata: emits <link rel="prev"> and <link rel="next"> for:
  - PSS source pages — computed server-side from set.hasPart filtered to sources and using extractSourceId to form absolute URLs; prev/next URLs are passed as prevSourceUrl/nextSourceUrl props and injected into MainLayout via headLinks.
  - Exhibition section pages — previous/next queryParams converted to absolute prevUrl/nextUrl strings in getServerSideProps and surfaced via DPLAHead.additionalLinks (ExhibitionPage now accepts prevUrl/nextUrl props).
- WebSite + SearchAction JSON-LD: Home page adds a WebSite JSON-LD with a SearchAction when NEXT_PUBLIC_SITE_ENV === "user" to enable sitelink searchbox hints; WEBSITE_JSON_LD is computed at module scope (build-time constants only) and injected via dangerouslySetInnerHTML.

### Notable implementation details
- BreadcrumbJsonLd maps breadcrumb entries to ListItem objects (1-based position), omitting item URLs when resolveUrl yields no absolute URL (e.g., current page). It serializes JSON-LD and escapes "<" via replace(/<\/g, "\\u003c") to reduce XSS risk.
- USER_BASE_URL / NEXT_PUBLIC_USER_BASE_URL is normalized (trailing slashes removed) before constructing absolute URLs; code guards WEBSITE_JSON_LD behind the presence of USER_BASE_URL so undefined is not emitted.
- PSS source prev/next and current index are computed server-side from a sources-only filtered array; currentSourceIdx replaces the prior currentInSourcesIdx and is guarded for -1.
- DPLAHead and MainLayout accept optional additionalLinks/headLinks and render provided <link rel="prev">/<link rel="next"> entries.
- Breadcrumb construction was consolidated across multiple pages so the same breadcrumbs array feeds both visual breadcrumbs and the JSON-LD component.
- WEBSITE_JSON_LD is created only when NEXT_PUBLIC_SITE_ENV === "user" and USER_BASE_URL is present; computed at module scope to avoid per-render serialization.

### Files changed (high level)
- Added: components/shared/BreadcrumbJsonLd/index.js
- Modified: components/ExhibitionsComponents/ExhibitionSection/ExhibitionPage.js (accepts prevUrl/nextUrl; forwards links to DPLAHead)
- Modified: components/DPLAHead/index.js and components/MainLayout/* to accept optional additionalLinks/headLinks
- Modified pages:
  - pages/index.js (WEBSITE_JSON_LD injection on user env; computed at module scope)
  - pages/exhibitions/[exhibitionSlug]/index.js
  - pages/exhibitions/[exhibitionSlug]/[sectionSlug]/index.js (computes prevUrl/nextUrl in getServerSideProps)
  - pages/exhibitions/[exhibitionSlug]/[sectionSlug]/[subsectionSlug]/index.js
  - pages/news/[slug].js
  - pages/primary-source-sets/[set]/index.js
  - pages/primary-source-sets/[set]/sources/[source].js (server-side prevSourceUrl/nextSourceUrl and headLinks; currentSourceIdx rename)
  - pages/primary-source-sets/[set]/teaching-guide.js
  - pages/primary-source-sets/[set]/additional-resources.js

### Impact on environment, infra, and security
- Environment variables: continues to use existing NEXT_PUBLIC_USER_BASE_URL and NEXT_PUBLIC_SITE_ENV only. No new or removed environment variables or Secrets Manager keys were added or renamed.
- Infrastructure & deployment: frontend-only code changes. No changes to CodePipeline/CodeBuild/ECS task definitions, IAM policies, or other shared infra. No manual pipeline trigger or ECS redeployment beyond the normal frontend deploy is required.
- Backend & APIs: no database migrations and no changes to backend API response shapes or endpoints.
- Security: JSON-LD output escapes "<" to mitigate script-injection risk. No changes to credential handling or authentication flows. The change emits additional structured data and link metadata to crawlers but does not introduce new external credential handling.

### Testing notes
- Manual verification checklist included in the PR: validate BreadcrumbList JSON-LD on PSS source/set/teaching-guide/additional-resources, exhibition index/section, and news pages; verify rel=prev/next on PSS source and exhibition section pages; verify WebSite JSON-LD with SearchAction on home page (user env); validate structured data with Google Rich Results Test and confirm rel=prev/next link elements appear with correct absolute URLs in the page head.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->