### PR TITLE
Fix SourceCarousel using hasPart index instead of sources-only index

### DIFF
--- a/pages/primary-source-sets/[set]/sources/[source].js
+++ b/pages/primary-source-sets/[set]/sources/[source].js
@@ -89,6 +89,7 @@ export async function getServerSideProps(context) {
     (p) => p.disambiguatingDescription === "source",
   );
   const currentInSourcesIdx = sources.findIndex((s) => s["@id"] === sourceId);
+  if (currentInSourcesIdx === -1) return { notFound: true };
 
   const props = washObject({
     source: sanitizedSourceJson,

--- a/pages/primary-source-sets/[set]/sources/[source].js
+++ b/pages/primary-source-sets/[set]/sources/[source].js
@@ -15,7 +15,7 @@ import ServiceUnavailable from "components/shared/ServiceUnavailable";
 const videoIcon = "/static/placeholderImages/Video.svg";
 const audioIcon = "/static/placeholderImages/Sound.svg";
 
-function Source({ source, set, currentSourceIdx, temporarilyUnavailable }) {
+function Source({ source, set, sources, currentInSourcesIdx, temporarilyUnavailable }) {
   const router = useRouter();
   if (temporarilyUnavailable) return <ServiceUnavailable />;
   if (!source || !set) return null;
@@ -42,10 +42,8 @@ function Source({ source, set, currentSourceIdx, temporarilyUnavailable }) {
         <ContentAndMetadata source={source} />
       </div>
       <SourceCarousel
-        sources={set.hasPart.filter(
-          (item) => item.disambiguatingDescription === "source",
-        )}
-        currentSourceIdx={currentSourceIdx}
+        sources={sources}
+        currentSourceIdx={currentInSourcesIdx}
         set={set}
       />
       <PSSFooter />
@@ -87,14 +85,16 @@ export async function getServerSideProps(context) {
   });
 
   const sourceId = sanitizedSourceJson["@id"];
-  const currentSourceIdx = setJson.hasPart.findIndex(
-    (source) => source["@id"] === sourceId,
+  const sources = parts.filter(
+    (p) => p.disambiguatingDescription === "source",
   );
+  const currentInSourcesIdx = sources.findIndex((s) => s["@id"] === sourceId);
 
   const props = washObject({
     source: sanitizedSourceJson,
     set: { ...setJson, hasPart: parts },
-    currentSourceIdx,
+    sources,
+    currentInSourcesIdx,
   });
 
   return { props };


### PR DESCRIPTION
## Summary

- `getServerSideProps` was computing `currentSourceIdx` via `findIndex` on the full `setJson.hasPart` array (which includes non-source items like guides), then passing it to `SourceCarousel`
- `SourceCarousel` and `CarouselSlider` both treat the index as a position within a **sources-only** filtered array — using it to display "Item N of M", enable/disable Prev/Next buttons, navigate to adjacent sources by array index, and highlight the active thumbnail
- If any non-source item appeared before source items in `hasPart`, the index would be wrong, producing incorrect navigation and highlighting

**Fix:** Replace `currentSourceIdx` (hasPart index) with `currentInSourcesIdx` (sources-only index). Also:
- Filter `sources` from the thumbnail-enriched `parts` array (not the raw `setJson.hasPart`) so the index is computed against the same data the carousel renders
- Pass `sources` as a prop from `getServerSideProps` instead of re-filtering `set.hasPart` on every client render

This was flagged as a latent bug during review of #1473 but was out of scope for that PR.

## Test plan

- [ ] Navigate to a primary source set source page — "Item N of M" shows correct position
- [ ] Prev/Next buttons navigate to the correct adjacent sources
- [ ] Active source thumbnail is highlighted in the carousel
- [ ] First source: Previous button is disabled; last source: Next button is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fix SourceCarousel using hasPart index instead of sources-only index

Fixes incorrect carousel navigation when non-source items appear before sources in a primary source set.

Problem:
- SourceCarousel expects an index into a sources-only array for "Item N of M", Prev/Next enablement, adjacent-source navigation, and active thumbnail highlighting.
- getServerSideProps previously computed currentSourceIdx as an index into set.hasPart (which can include non-source items like guides). If non-source items appear before sources, navigation and highlighting broke.

Solution:
- Compute and pass a pre-filtered sources array and an index into that array from the server:
  - getServerSideProps now builds thumbnail-enriched parts, filters sources via disambiguatingDescription === "source" into a new sources prop, and computes currentInSourcesIdx as the index of the current source's @id within that sources array.
  - If the current source is not found in the filtered sources (currentInSourcesIdx === -1), return notFound to avoid rendering a broken UI.
- Source component now accepts sources and currentInSourcesIdx and passes them to SourceCarousel (currentSourceIdx now refers to the index into the sources prop).
- Removed client-side re-filtering of set.hasPart for carousel use.

Files changed:
- pages/primary-source-sets/[set]/sources/[source].js — updated props, getServerSideProps, and SourceCarousel invocation.

Deployment / infra / API impact:
- No manual pipeline/ECS redeploy required.
- No environment variable, secret, database migration, infrastructure, or public API shape changes.
- No security implications beyond the existing behavior.

Tests / expected behavior:
- "Item N of M" shows the correct position for a primary source set source.
- Prev/Next navigate to adjacent sources correctly.
- Active source thumbnail is highlighted.
- Prev disabled on first source; Next disabled on last source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->