### PR TITLE
Retry on reconciliation API timeout instead of showing error

### DIFF
--- a/public/static/depictassist/depictassist.css
+++ b/public/static/depictassist/depictassist.css
@@ -171,8 +171,9 @@
 
 .depictassist-wrapper .da-tag-chip {
     display: inline-flex;
-    align-items: center;
-    gap: 6px;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
     padding: 8px 14px;
     margin: 0 8px 8px 0;
     font-size: 14px;
@@ -197,11 +198,15 @@
 }
 
 .depictassist-wrapper .da-tag-description {
-    display: block;
     font-size: 12px;
     color: #627d98;
-    margin-top: 2px;
     font-style: italic;
+}
+
+.depictassist-wrapper .da-tag-qid {
+    font-size: 11px;
+    color: #627d98;
+    font-weight: 400;
 }
 
 /* ── Image Display ───────────────────────────────────────── */
@@ -272,8 +277,10 @@
 /* ── Loading ─────────────────────────────────────────────── */
 
 .depictassist-wrapper .da-loading {
-    text-align: center;
-    padding: 40px 0;
+    min-height: 380px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     color: #627d98;
     font-size: 15px;
 }
@@ -306,6 +313,7 @@
     background: #ecfdf5;
     padding: 14px 18px;
     border-radius: 10px;
+    margin-top: 16px;
     margin-bottom: 20px;
     font-size: 14px;
     color: #065f46;

--- a/public/static/depictassist/depictassist.js
+++ b/public/static/depictassist/depictassist.js
@@ -189,7 +189,7 @@
     showImageState('loading');
 
     try {
-      // Step 1: Get total hits to pick a random offset
+      // Step 1: Get total hits to pick a random offset (once per button press)
       const totalUrl = buildSearchUrl(qid, 0, 0);
       const totalResp = await fetch(totalUrl);
       if (!totalResp.ok) throw new Error('Commons search failed');
@@ -202,69 +202,89 @@
         return;
       }
 
-      // Step 2: Fetch a random image (with iiurlwidth=800 to avoid a separate image info call)
       const cap = Math.min(totalHits, 10000);
-      const offset = Math.floor(Math.random() * cap);
-      const searchUrl = buildSearchUrl(qid, offset, 1);
-      const searchResp = await fetch(searchUrl);
-      if (!searchResp.ok) throw new Error('Commons search failed');
-      const searchData = await searchResp.json();
+      let reconTimeouts = 0;
 
-      const pages = searchData.query?.pages;
-      if (!pages) { showImageState('empty'); return; }
+      while (true) {
+        // Step 2: Fetch a random image (with iiurlwidth=800 to avoid a separate image info call)
+        const offset = Math.floor(Math.random() * cap);
+        const searchUrl = buildSearchUrl(qid, offset, 1);
+        const searchResp = await fetch(searchUrl);
+        if (!searchResp.ok) throw new Error('Commons search failed');
+        const searchData = await searchResp.json();
 
-      const pageId = Object.keys(pages)[0];
-      if (!pageId || pageId === '-1') { showImageState('empty'); return; }
+        const pages = searchData.query?.pages;
+        if (!pages) { showImageState('empty'); return; }
 
-      const page = pages[pageId];
-      const mid = 'M' + pageId;
-      const pageTitle = page.title || '';
+        const pageId = Object.keys(pages)[0];
+        if (!pageId || pageId === '-1') { showImageState('empty'); return; }
 
-      // Extract image URL from the search response (avoids a separate imageinfo call)
-      const imgUrl = page.imageinfo?.[0]?.thumburl ||
-                     page.imageinfo?.[0]?.url || '';
+        const page = pages[pageId];
+        const mid = 'M' + pageId;
+        const pageTitle = page.title || '';
 
-      // Step 3: Fetch entity data and reconciliation in parallel
-      const entityUrl = 'https://commons.wikimedia.org/wiki/Special:EntityData/' + mid + '.json';
-      const entityResp = await fetch(entityUrl);
-      if (!entityResp.ok) throw new Error('Entity data fetch failed');
-      const entityData = await entityResp.json();
-      const entity = entityData.entities?.[mid];
-      if (!entity) { showImageState('empty'); return; }
+        // Extract image URL from the search response (avoids a separate imageinfo call)
+        const imgUrl = page.imageinfo?.[0]?.thumburl ||
+                       page.imageinfo?.[0]?.url || '';
 
-      const stmts = entity.statements || {};
-      const titleText = stmts.P1476?.[0]?.mainsnak?.datavalue?.value?.text || pageTitle;
-      const descText = stmts.P10358?.[0]?.mainsnak?.datavalue?.value?.text || '';
-      const subjects = stmts.P4272 || [];
-      const dplaId = stmts.P760?.[0]?.mainsnak?.datavalue?.value;
-      const dplaUrl = dplaId ? 'https://dp.la/item/' + dplaId : null;
+        // Step 3: Fetch entity data
+        const entityUrl = 'https://commons.wikimedia.org/wiki/Special:EntityData/' + mid + '.json';
+        const entityResp = await fetch(entityUrl);
+        if (!entityResp.ok) throw new Error('Entity data fetch failed');
+        const entityData = await entityResp.json();
+        const entity = entityData.entities?.[mid];
+        if (!entity) { showImageState('empty'); return; }
 
-      // Fetch tag suggestions from reconciliation API
-      let tagSuggestions = [];
-      let subjectName = '(no subject)';
+        const stmts = entity.statements || {};
+        const titleText = stmts.P1476?.[0]?.mainsnak?.datavalue?.value?.text || pageTitle;
+        const descText = stmts.P10358?.[0]?.mainsnak?.datavalue?.value?.text || '';
+        const subjects = stmts.P4272 || [];
+        const dplaId = stmts.P760?.[0]?.mainsnak?.datavalue?.value;
+        const dplaUrl = dplaId ? 'https://dp.la/item/' + dplaId : null;
 
-      if (subjects.length > 0) {
-        subjectName = subjects[0].mainsnak?.datavalue?.value || '';
-        const narrow = subjectName.replace(/^.*--\s*/, '');
+        // Step 4: Fetch tag suggestions — 8s timeout; on timeout try a different image,
+        // but give up and show an error after 3 consecutive timeouts (API is down)
+        let tagSuggestions = [];
+        let subjectName = '(no subject)';
+        let reconTimedOut = false;
 
-        const reconUrl = RECONCILIATION_API + '?queries=' +
-          encodeURIComponent(JSON.stringify({ q1: { query: narrow } }));
-        const reconResp = await fetch(reconUrl);
-        if (reconResp.ok) {
-          const reconData = await reconResp.json();
-          const results = reconData.q1?.result || [];
-          tagSuggestions = results.slice(0, MAX_SUGGESTIONS).map(r => ({
-            qid: r.id,
-            label: r.name || '',
-            description: r.description || ''
-          }));
+        if (subjects.length > 0) {
+          subjectName = subjects[0].mainsnak?.datavalue?.value || '';
+          const narrow = subjectName.replace(/^.*--\s*/, '');
+          const reconUrl = RECONCILIATION_API + '?queries=' +
+            encodeURIComponent(JSON.stringify({ q1: { query: narrow } }));
+          try {
+            const reconResp = await fetch(reconUrl, { signal: AbortSignal.timeout(8000) });
+            if (reconResp.ok) {
+              const reconData = await reconResp.json();
+              const results = reconData.q1?.result || [];
+              tagSuggestions = results.slice(0, MAX_SUGGESTIONS).map(r => ({
+                qid: r.id,
+                label: r.name || '',
+                description: r.description || ''
+              }));
+            }
+          } catch (reconErr) {
+            if (reconErr.name === 'TimeoutError' || reconErr.name === 'AbortError') {
+              reconTimedOut = true;
+            } else {
+              throw reconErr;
+            }
+          }
         }
-      }
 
-      displayImage({
-        mid, imgUrl, title: titleText, filename: pageTitle,
-        description: descText, subjectName, dplaUrl, tagSuggestions
-      });
+        if (reconTimedOut) {
+          reconTimeouts++;
+          if (reconTimeouts >= 3) throw new Error('Reconciliation API unavailable');
+          continue;
+        }
+
+        displayImage({
+          mid, imgUrl, title: titleText, filename: pageTitle,
+          description: descText, subjectName, dplaUrl, tagSuggestions
+        });
+        break;
+      }
     } catch (err) {
       console.error('DepictAssist: error fetching image', err);
       showImageState('error');

--- a/public/static/depictassist/depictassist.js
+++ b/public/static/depictassist/depictassist.js
@@ -371,6 +371,11 @@
         chip.appendChild(descSpan);
       }
 
+      const qidSpan = document.createElement('span');
+      qidSpan.className = 'da-tag-qid';
+      qidSpan.textContent = tag.qid;
+      chip.appendChild(qidSpan);
+
       chip.addEventListener('click', function () {
         addToQueue(mid, 'P180', tag.qid, tag.label, filename, subjectName, dplaUrl);
         chip.classList.add('da-tag-selected');
@@ -691,6 +696,12 @@
       }
 
       queue = queue.filter(item => !succeededMids.has(item.mid));
+      if (succeededMids.has(currentMid)) {
+        for (const chip of $tagSuggestions.querySelectorAll('.da-tag-selected')) {
+          chip.classList.remove('da-tag-selected');
+          chip.disabled = false;
+        }
+      }
       renderQueue();
     } catch (err) {
       console.error('DepictAssist: batch submit error', err);


### PR DESCRIPTION
## Summary

- Wraps the `reconci.link` fetch in `AbortSignal.timeout(8000)` so it fails fast (8s) instead of hanging until the browser's TCP timeout
- On a timeout, silently picks a new random image and retries rather than showing the user an error
- After 3 consecutive timeouts, assumes the API itself is down and shows the error state

## Test plan

- [ ] Load DepictAssist and click Find Images — confirm images load normally when reconci.link is healthy
- [ ] If reconci.link is slow/down, confirm the tool silently cycles through images rather than showing an error on the first timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds resilient retry logic to the DepictAssist image tagging tool to handle timeouts from the Wikimedia reconciliation API (https://wikidata.reconci.link). It also includes several UI/CSS tweaks to improve layout and loading behavior.

## Changes

- Files modified:
  - public/static/depictassist/depictassist.js (+92 / -61)
  - public/static/depictassist/depictassist.css (+14 / -6)

- Key behavior changes in depictassist.js:
  - Implements a retry loop when selecting an image/entity so the UI will pick another random image if reconciliation/tag-suggestion fetches fail.
  - Adds an 8-second timeout to reconciliation/tag-suggestion fetches via AbortSignal.timeout(8000).
  - Silently retries with a new random image on timeout; tracks consecutive timeouts with reconTimeouts and shows the error UI only after 3 consecutive timeouts (assumes reconciliation API is down).
  - Moves reconciliation to a per-iteration step so failed reconciliation triggers another attempt instead of immediately showing an error.
  - Adds minor comment clarification and preserves existing image/entity extraction/display logic.
  - Resets selected tag-chip visual states after a successful batch submit so Skip/Next remains consistent with the queue.

- Key UI/CSS changes in depictassist.css:
  - Stacks tag chips vertically and adds a visible QID sub-element (.da-tag-qid) beneath tag descriptions.
  - Adds min-height: 380px and flex centering to the loading state to prevent page bounce when images load.
  - Adds margin-top: 16px to the results bar to avoid crowding Skip/Next.

## Deployment / Infra / Config Impact

- Client-only changes to static frontend assets. No backend changes.
- No database migrations.
- No changes to environment variables or AWS Secrets Manager.
- No changes to shared infrastructure (CodePipeline/CodeBuild/ECS/IAM).
- No special deployment steps beyond the standard frontend deployment (CloudFront will serve updated JS/CSS). No manual pipeline trigger or ECS redeploy required.

## Security / Privacy Notes

- The code continues to call the external reconciliation service (https://wikidata.reconci.link). Calls are now abortable after 8s; there are no changes to credential handling or new secrets.
- No new external data inputs beyond existing reconciliation requests; no authentication or authorization changes.

## Testing Notes

- Verify DepictAssist behavior when reconci.link is healthy: clicking Find Images loads images normally.
- Simulate reconci.link slowness/unavailability: the tool should silently cycle through images on timeouts and only show the error UI after three consecutive timeouts.
- Confirm visual/UI tweaks: loading area min-height prevents layout jumps, results bar spacing updated, tag chips stacked and show QID, and tag-chip states reset after batch submit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->