### PR TITLE
Revert "Retry on reconciliation API timeout instead of showing error (#1478)"

### DIFF
--- a/public/static/depictassist/depictassist.css
+++ b/public/static/depictassist/depictassist.css
@@ -171,9 +171,8 @@
 
 .depictassist-wrapper .da-tag-chip {
     display: inline-flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 2px;
+    align-items: center;
+    gap: 6px;
     padding: 8px 14px;
     margin: 0 8px 8px 0;
     font-size: 14px;
@@ -198,15 +197,11 @@
 }
 
 .depictassist-wrapper .da-tag-description {
+    display: block;
     font-size: 12px;
     color: #627d98;
+    margin-top: 2px;
     font-style: italic;
-}
-
-.depictassist-wrapper .da-tag-qid {
-    font-size: 11px;
-    color: #627d98;
-    font-weight: 400;
 }
 
 /* ── Image Display ───────────────────────────────────────── */
@@ -277,10 +272,8 @@
 /* ── Loading ─────────────────────────────────────────────── */
 
 .depictassist-wrapper .da-loading {
-    min-height: 380px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    text-align: center;
+    padding: 40px 0;
     color: #627d98;
     font-size: 15px;
 }
@@ -313,7 +306,6 @@
     background: #ecfdf5;
     padding: 14px 18px;
     border-radius: 10px;
-    margin-top: 16px;
     margin-bottom: 20px;
     font-size: 14px;
     color: #065f46;

--- a/public/static/depictassist/depictassist.js
+++ b/public/static/depictassist/depictassist.js
@@ -189,7 +189,7 @@
     showImageState('loading');
 
     try {
-      // Step 1: Get total hits to pick a random offset (once per button press)
+      // Step 1: Get total hits to pick a random offset
       const totalUrl = buildSearchUrl(qid, 0, 0);
       const totalResp = await fetch(totalUrl);
       if (!totalResp.ok) throw new Error('Commons search failed');
@@ -202,89 +202,69 @@
         return;
       }
 
+      // Step 2: Fetch a random image (with iiurlwidth=800 to avoid a separate image info call)
       const cap = Math.min(totalHits, 10000);
-      let reconTimeouts = 0;
+      const offset = Math.floor(Math.random() * cap);
+      const searchUrl = buildSearchUrl(qid, offset, 1);
+      const searchResp = await fetch(searchUrl);
+      if (!searchResp.ok) throw new Error('Commons search failed');
+      const searchData = await searchResp.json();
 
-      while (true) {
-        // Step 2: Fetch a random image (with iiurlwidth=800 to avoid a separate image info call)
-        const offset = Math.floor(Math.random() * cap);
-        const searchUrl = buildSearchUrl(qid, offset, 1);
-        const searchResp = await fetch(searchUrl);
-        if (!searchResp.ok) throw new Error('Commons search failed');
-        const searchData = await searchResp.json();
+      const pages = searchData.query?.pages;
+      if (!pages) { showImageState('empty'); return; }
 
-        const pages = searchData.query?.pages;
-        if (!pages) { showImageState('empty'); return; }
+      const pageId = Object.keys(pages)[0];
+      if (!pageId || pageId === '-1') { showImageState('empty'); return; }
 
-        const pageId = Object.keys(pages)[0];
-        if (!pageId || pageId === '-1') { showImageState('empty'); return; }
+      const page = pages[pageId];
+      const mid = 'M' + pageId;
+      const pageTitle = page.title || '';
 
-        const page = pages[pageId];
-        const mid = 'M' + pageId;
-        const pageTitle = page.title || '';
+      // Extract image URL from the search response (avoids a separate imageinfo call)
+      const imgUrl = page.imageinfo?.[0]?.thumburl ||
+                     page.imageinfo?.[0]?.url || '';
 
-        // Extract image URL from the search response (avoids a separate imageinfo call)
-        const imgUrl = page.imageinfo?.[0]?.thumburl ||
-                       page.imageinfo?.[0]?.url || '';
+      // Step 3: Fetch entity data and reconciliation in parallel
+      const entityUrl = 'https://commons.wikimedia.org/wiki/Special:EntityData/' + mid + '.json';
+      const entityResp = await fetch(entityUrl);
+      if (!entityResp.ok) throw new Error('Entity data fetch failed');
+      const entityData = await entityResp.json();
+      const entity = entityData.entities?.[mid];
+      if (!entity) { showImageState('empty'); return; }
 
-        // Step 3: Fetch entity data
-        const entityUrl = 'https://commons.wikimedia.org/wiki/Special:EntityData/' + mid + '.json';
-        const entityResp = await fetch(entityUrl);
-        if (!entityResp.ok) throw new Error('Entity data fetch failed');
-        const entityData = await entityResp.json();
-        const entity = entityData.entities?.[mid];
-        if (!entity) { showImageState('empty'); return; }
+      const stmts = entity.statements || {};
+      const titleText = stmts.P1476?.[0]?.mainsnak?.datavalue?.value?.text || pageTitle;
+      const descText = stmts.P10358?.[0]?.mainsnak?.datavalue?.value?.text || '';
+      const subjects = stmts.P4272 || [];
+      const dplaId = stmts.P760?.[0]?.mainsnak?.datavalue?.value;
+      const dplaUrl = dplaId ? 'https://dp.la/item/' + dplaId : null;
 
-        const stmts = entity.statements || {};
-        const titleText = stmts.P1476?.[0]?.mainsnak?.datavalue?.value?.text || pageTitle;
-        const descText = stmts.P10358?.[0]?.mainsnak?.datavalue?.value?.text || '';
-        const subjects = stmts.P4272 || [];
-        const dplaId = stmts.P760?.[0]?.mainsnak?.datavalue?.value;
-        const dplaUrl = dplaId ? 'https://dp.la/item/' + dplaId : null;
+      // Fetch tag suggestions from reconciliation API
+      let tagSuggestions = [];
+      let subjectName = '(no subject)';
 
-        // Step 4: Fetch tag suggestions — 8s timeout; on timeout try a different image,
-        // but give up and show an error after 3 consecutive timeouts (API is down)
-        let tagSuggestions = [];
-        let subjectName = '(no subject)';
-        let reconTimedOut = false;
+      if (subjects.length > 0) {
+        subjectName = subjects[0].mainsnak?.datavalue?.value || '';
+        const narrow = subjectName.replace(/^.*--\s*/, '');
 
-        if (subjects.length > 0) {
-          subjectName = subjects[0].mainsnak?.datavalue?.value || '';
-          const narrow = subjectName.replace(/^.*--\s*/, '');
-          const reconUrl = RECONCILIATION_API + '?queries=' +
-            encodeURIComponent(JSON.stringify({ q1: { query: narrow } }));
-          try {
-            const reconResp = await fetch(reconUrl, { signal: AbortSignal.timeout(8000) });
-            if (reconResp.ok) {
-              const reconData = await reconResp.json();
-              const results = reconData.q1?.result || [];
-              tagSuggestions = results.slice(0, MAX_SUGGESTIONS).map(r => ({
-                qid: r.id,
-                label: r.name || '',
-                description: r.description || ''
-              }));
-            }
-          } catch (reconErr) {
-            if (reconErr.name === 'TimeoutError' || reconErr.name === 'AbortError') {
-              reconTimedOut = true;
-            } else {
-              throw reconErr;
-            }
-          }
+        const reconUrl = RECONCILIATION_API + '?queries=' +
+          encodeURIComponent(JSON.stringify({ q1: { query: narrow } }));
+        const reconResp = await fetch(reconUrl);
+        if (reconResp.ok) {
+          const reconData = await reconResp.json();
+          const results = reconData.q1?.result || [];
+          tagSuggestions = results.slice(0, MAX_SUGGESTIONS).map(r => ({
+            qid: r.id,
+            label: r.name || '',
+            description: r.description || ''
+          }));
         }
-
-        if (reconTimedOut) {
-          reconTimeouts++;
-          if (reconTimeouts >= 3) throw new Error('Reconciliation API unavailable');
-          continue;
-        }
-
-        displayImage({
-          mid, imgUrl, title: titleText, filename: pageTitle,
-          description: descText, subjectName, dplaUrl, tagSuggestions
-        });
-        break;
       }
+
+      displayImage({
+        mid, imgUrl, title: titleText, filename: pageTitle,
+        description: descText, subjectName, dplaUrl, tagSuggestions
+      });
     } catch (err) {
       console.error('DepictAssist: error fetching image', err);
       showImageState('error');
@@ -370,11 +350,6 @@
         descSpan.textContent = tag.description;
         chip.appendChild(descSpan);
       }
-
-      const qidSpan = document.createElement('span');
-      qidSpan.className = 'da-tag-qid';
-      qidSpan.textContent = tag.qid;
-      chip.appendChild(qidSpan);
 
       chip.addEventListener('click', function () {
         addToQueue(mid, 'P180', tag.qid, tag.label, filename, subjectName, dplaUrl);
@@ -696,12 +671,6 @@
       }
 
       queue = queue.filter(item => !succeededMids.has(item.mid));
-      if (succeededMids.has(currentMid)) {
-        for (const chip of $tagSuggestions.querySelectorAll('.da-tag-selected')) {
-          chip.classList.remove('da-tag-selected');
-          chip.disabled = false;
-        }
-      }
       renderQueue();
     } catch (err) {
       console.error('DepictAssist: batch submit error', err);


### PR DESCRIPTION
Reverting the premature merge of #1478 — CodeRabbit review was not complete at time of merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Reverts PR #1478 ("Retry on reconciliation API timeout instead of showing error") due to incomplete CodeRabbit review at the time of the original merge.

## Changes

### DepictAssist Feature Changes (public/static/depictassist/)

**JavaScript** (`depictassist.js`):
- Removes retry `while (true)` loop and reconciliation timeout handling
- Simplifies `onFindImages()` to select a single random Commons offset, fetch the first page, and perform reconciliation once without timeout retries
- Removes `AbortSignal.timeout`, `reconTimedOut` state, and "try another image" consecutive-timeout failure logic
- Removes fallback tag population path on timeout; now only populates `tagSuggestions` when reconciliation response is successful
- Removes QID text chip element rendering in `displayImage()`
- Removes logic in `onSubmitBatch()` that unselected/re-enabled tag chips after successful submissions

**CSS** (`depictassist.css`):
- Updates `.da-tag-chip` from flex column to single-row alignment (`align-items: center`, `gap: 6px`)
- Modifies `.da-tag-description` with `display: block` and `margin-top: 2px`
- Removes `.da-tag-qid` CSS rule entirely
- Simplifies `.da-loading` styling, replacing flex centering with `text-align: center` and `padding: 40px 0`
- Removes `margin-top: 16px` from `.da-results-bar`

## Deployment Impact

No deployment, pipeline trigger, or infrastructure changes required. This is a pure frontend revert of feature logic and styling changes. No environment variables, secrets, API shapes, or backend systems are affected.

## Files Modified

Core changes: 2 files (depictassist.js, depictassist.css)  
Additional files: Configuration examples and build artifacts restored to baseline state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->