### PR TITLE
Retry on reconciliation API timeout instead of showing error

### DIFF
--- a/public/static/depictassist/depictassist.css
+++ b/public/static/depictassist/depictassist.css
@@ -171,8 +171,9 @@
 
 .depictassist-wrapper .da-tag-chip {
     display: inline-flex;
-    align-items: center;
-    gap: 6px;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
     padding: 8px 14px;
     margin: 0 8px 8px 0;
     font-size: 14px;
@@ -197,11 +198,15 @@
 }
 
 .depictassist-wrapper .da-tag-description {
-    display: block;
     font-size: 12px;
     color: #627d98;
-    margin-top: 2px;
     font-style: italic;
+}
+
+.depictassist-wrapper .da-tag-qid {
+    font-size: 11px;
+    color: #627d98;
+    font-weight: 400;
 }
 
 /* ── Image Display ───────────────────────────────────────── */
@@ -272,8 +277,10 @@
 /* ── Loading ─────────────────────────────────────────────── */
 
 .depictassist-wrapper .da-loading {
-    text-align: center;
-    padding: 40px 0;
+    min-height: 380px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     color: #627d98;
     font-size: 15px;
 }
@@ -306,6 +313,7 @@
     background: #ecfdf5;
     padding: 14px 18px;
     border-radius: 10px;
+    margin-top: 16px;
     margin-bottom: 20px;
     font-size: 14px;
     color: #065f46;

--- a/public/static/depictassist/depictassist.js
+++ b/public/static/depictassist/depictassist.js
@@ -189,7 +189,7 @@
     showImageState('loading');
 
     try {
-      // Step 1: Get total hits to pick a random offset
+      // Step 1: Get total hits to pick a random offset (once per button press)
       const totalUrl = buildSearchUrl(qid, 0, 0);
       const totalResp = await fetch(totalUrl);
       if (!totalResp.ok) throw new Error('Commons search failed');
@@ -202,69 +202,89 @@
         return;
       }
 
-      // Step 2: Fetch a random image (with iiurlwidth=800 to avoid a separate image info call)
       const cap = Math.min(totalHits, 10000);
-      const offset = Math.floor(Math.random() * cap);
-      const searchUrl = buildSearchUrl(qid, offset, 1);
-      const searchResp = await fetch(searchUrl);
-      if (!searchResp.ok) throw new Error('Commons search failed');
-      const searchData = await searchResp.json();
+      let reconTimeouts = 0;
 
-      const pages = searchData.query?.pages;
-      if (!pages) { showImageState('empty'); return; }
+      while (true) {
+        // Step 2: Fetch a random image (with iiurlwidth=800 to avoid a separate image info call)
+        const offset = Math.floor(Math.random() * cap);
+        const searchUrl = buildSearchUrl(qid, offset, 1);
+        const searchResp = await fetch(searchUrl);
+        if (!searchResp.ok) throw new Error('Commons search failed');
+        const searchData = await searchResp.json();
 
-      const pageId = Object.keys(pages)[0];
-      if (!pageId || pageId === '-1') { showImageState('empty'); return; }
+        const pages = searchData.query?.pages;
+        if (!pages) { showImageState('empty'); return; }
 
-      const page = pages[pageId];
-      const mid = 'M' + pageId;
-      const pageTitle = page.title || '';
+        const pageId = Object.keys(pages)[0];
+        if (!pageId || pageId === '-1') { showImageState('empty'); return; }
 
-      // Extract image URL from the search response (avoids a separate imageinfo call)
-      const imgUrl = page.imageinfo?.[0]?.thumburl ||
-                     page.imageinfo?.[0]?.url || '';
+        const page = pages[pageId];
+        const mid = 'M' + pageId;
+        const pageTitle = page.title || '';
 
-      // Step 3: Fetch entity data and reconciliation in parallel
-      const entityUrl = 'https://commons.wikimedia.org/wiki/Special:EntityData/' + mid + '.json';
-      const entityResp = await fetch(entityUrl);
-      if (!entityResp.ok) throw new Error('Entity data fetch failed');
-      const entityData = await entityResp.json();
-      const entity = entityData.entities?.[mid];
-      if (!entity) { showImageState('empty'); return; }
+        // Extract image URL from the search response (avoids a separate imageinfo call)
+        const imgUrl = page.imageinfo?.[0]?.thumburl ||
+                       page.imageinfo?.[0]?.url || '';
 
-      const stmts = entity.statements || {};
-      const titleText = stmts.P1476?.[0]?.mainsnak?.datavalue?.value?.text || pageTitle;
-      const descText = stmts.P10358?.[0]?.mainsnak?.datavalue?.value?.text || '';
-      const subjects = stmts.P4272 || [];
-      const dplaId = stmts.P760?.[0]?.mainsnak?.datavalue?.value;
-      const dplaUrl = dplaId ? 'https://dp.la/item/' + dplaId : null;
+        // Step 3: Fetch entity data
+        const entityUrl = 'https://commons.wikimedia.org/wiki/Special:EntityData/' + mid + '.json';
+        const entityResp = await fetch(entityUrl);
+        if (!entityResp.ok) throw new Error('Entity data fetch failed');
+        const entityData = await entityResp.json();
+        const entity = entityData.entities?.[mid];
+        if (!entity) { showImageState('empty'); return; }
 
-      // Fetch tag suggestions from reconciliation API
-      let tagSuggestions = [];
-      let subjectName = '(no subject)';
+        const stmts = entity.statements || {};
+        const titleText = stmts.P1476?.[0]?.mainsnak?.datavalue?.value?.text || pageTitle;
+        const descText = stmts.P10358?.[0]?.mainsnak?.datavalue?.value?.text || '';
+        const subjects = stmts.P4272 || [];
+        const dplaId = stmts.P760?.[0]?.mainsnak?.datavalue?.value;
+        const dplaUrl = dplaId ? 'https://dp.la/item/' + dplaId : null;
 
-      if (subjects.length > 0) {
-        subjectName = subjects[0].mainsnak?.datavalue?.value || '';
-        const narrow = subjectName.replace(/^.*--\s*/, '');
+        // Step 4: Fetch tag suggestions — 8s timeout; on timeout try a different image,
+        // but give up and show an error after 3 consecutive timeouts (API is down)
+        let tagSuggestions = [];
+        let subjectName = '(no subject)';
+        let reconTimedOut = false;
 
-        const reconUrl = RECONCILIATION_API + '?queries=' +
-          encodeURIComponent(JSON.stringify({ q1: { query: narrow } }));
-        const reconResp = await fetch(reconUrl);
-        if (reconResp.ok) {
-          const reconData = await reconResp.json();
-          const results = reconData.q1?.result || [];
-          tagSuggestions = results.slice(0, MAX_SUGGESTIONS).map(r => ({
-            qid: r.id,
-            label: r.name || '',
-            description: r.description || ''
-          }));
+        if (subjects.length > 0) {
+          subjectName = subjects[0].mainsnak?.datavalue?.value || '';
+          const narrow = subjectName.replace(/^.*--\s*/, '');
+          const reconUrl = RECONCILIATION_API + '?queries=' +
+            encodeURIComponent(JSON.stringify({ q1: { query: narrow } }));
+          try {
+            const reconResp = await fetch(reconUrl, { signal: AbortSignal.timeout(8000) });
+            if (reconResp.ok) {
+              const reconData = await reconResp.json();
+              const results = reconData.q1?.result || [];
+              tagSuggestions = results.slice(0, MAX_SUGGESTIONS).map(r => ({
+                qid: r.id,
+                label: r.name || '',
+                description: r.description || ''
+              }));
+            }
+          } catch (reconErr) {
+            if (reconErr.name === 'TimeoutError' || reconErr.name === 'AbortError') {
+              reconTimedOut = true;
+            } else {
+              throw reconErr;
+            }
+          }
         }
-      }
 
-      displayImage({
-        mid, imgUrl, title: titleText, filename: pageTitle,
-        description: descText, subjectName, dplaUrl, tagSuggestions
-      });
+        if (reconTimedOut) {
+          reconTimeouts++;
+          if (reconTimeouts >= 3) throw new Error('Reconciliation API unavailable');
+          continue;
+        }
+
+        displayImage({
+          mid, imgUrl, title: titleText, filename: pageTitle,
+          description: descText, subjectName, dplaUrl, tagSuggestions
+        });
+        break;
+      }
     } catch (err) {
       console.error('DepictAssist: error fetching image', err);
       showImageState('error');

--- a/public/static/depictassist/depictassist.js
+++ b/public/static/depictassist/depictassist.js
@@ -371,6 +371,11 @@
         chip.appendChild(descSpan);
       }
 
+      const qidSpan = document.createElement('span');
+      qidSpan.className = 'da-tag-qid';
+      qidSpan.textContent = tag.qid;
+      chip.appendChild(qidSpan);
+
       chip.addEventListener('click', function () {
         addToQueue(mid, 'P180', tag.qid, tag.label, filename, subjectName, dplaUrl);
         chip.classList.add('da-tag-selected');
@@ -691,6 +696,12 @@
       }
 
       queue = queue.filter(item => !succeededMids.has(item.mid));
+      if (succeededMids.has(currentMid)) {
+        for (const chip of $tagSuggestions.querySelectorAll('.da-tag-selected')) {
+          chip.classList.remove('da-tag-selected');
+          chip.disabled = false;
+        }
+      }
       renderQueue();
     } catch (err) {
       console.error('DepictAssist: batch submit error', err);

--- a/public/static/depictassist/depictassist.js
+++ b/public/static/depictassist/depictassist.js
@@ -204,8 +204,11 @@
 
       const cap = Math.min(totalHits, 10000);
       let reconTimeouts = 0;
+      let attempts = 0;
+      const maxAttempts = 10;
 
       while (true) {
+        if (++attempts > maxAttempts) throw new Error('Unable to find a valid image after multiple attempts');
         // Step 2: Fetch a random image (with iiurlwidth=800 to avoid a separate image info call)
         const offset = Math.floor(Math.random() * cap);
         const searchUrl = buildSearchUrl(qid, offset, 1);
@@ -254,7 +257,10 @@
           const reconUrl = RECONCILIATION_API + '?queries=' +
             encodeURIComponent(JSON.stringify({ q1: { query: narrow } }));
           try {
-            const reconResp = await fetch(reconUrl, { signal: AbortSignal.timeout(8000) });
+            const reconSignal = typeof AbortSignal.timeout === 'function'
+              ? AbortSignal.timeout(8000)
+              : (() => { const c = new AbortController(); setTimeout(() => c.abort(), 8000); return c.signal; })();
+            const reconResp = await fetch(reconUrl, { signal: reconSignal });
             if (reconResp.ok) {
               const reconData = await reconResp.json();
               const results = reconData.q1?.result || [];


### PR DESCRIPTION
## Summary
- Silently retries a different random image when reconci.link times out (8s AbortSignal), instead of immediately showing an error
- After 3 consecutive timeouts, assumes the endpoint is down and shows an error
- Four DepictAssist UI fixes: padding above results bar, loading area min-height to prevent page bounce, Skip→Next chip state reset after submit, Q-ID shown under tag label in suggestion chips

## Test plan
- [ ] Find images → select tags → submit → confirm blue chips deselect and Skip button reverts to gray "Skip" for the same image
- [ ] Confirm Q-IDs appear as small gray text below label in each tag chip
- [ ] Confirm page doesn't bounce/jump when loading the next image
- [ ] Confirm padding between "Edits saved." banner and Skip/Next button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Reconciliation Timeout Retry and DepictAssist UI Refinements

**Changes Overview**

This PR implements resilience improvements to the reconciliation API integration and refines the DepictAssist UI for better user experience. All changes are frontend-only and affect only the DepictAssist image suggestion/tagging tool.

**Reconciliation API Timeout Handling**

- Wraps reconciliation requests with an 8-second `AbortSignal` timeout instead of failing immediately on timeout
- When a timeout occurs, silently retries by selecting a different random Commons image rather than showing an error
- After 3 consecutive timeouts, treats the reconciliation endpoint as unavailable and surfaces an error (`Reconciliation API unavailable`)
- Includes a legacy browser fallback for `AbortSignal.timeout()` using `AbortController` + `setTimeout` for browsers without native support

**Image Fetch Loop Guard**

- Adds `maxAttempts=10` guard on the image selection `while(true)` loop to prevent infinite loops if the Commons API repeatedly returns pages with invalid data

**DepictAssist UI Refinements**

CSS changes:
- Converted tag chips from horizontal inline-flex to vertical flex layout (`flex-direction: column; align-items: flex-start`)
- Added new `.da-tag-qid` styling for Q-ID display (small gray text below each tag label)
- Changed loading area from text-center padding to centered flex layout with `min-height: 380px` to prevent page bounce during image load
- Added `margin-top: 16px` to results bar for better separation from controls

JavaScript changes:
- Updated tag chip DOM generation to include Q-ID as a separate span element below the label
- Added logic in `onSubmitBatch()` to reset tag chip selection state (remove `da-tag-selected` class and re-enable buttons) after successful submission, causing the Skip button to revert to gray "Skip" for the same image

**Deployment Notes**

No manual pipeline trigger, environment variables, database migrations, API changes, or infrastructure configuration updates are required. This is a client-side feature enhancement with no external dependencies or breaking changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->