### PR TITLE
Scroll to top of image area on Skip/Next click

### DIFF
--- a/public/static/depictassist/depictassist.js
+++ b/public/static/depictassist/depictassist.js
@@ -187,6 +187,7 @@
     $skipBtn.disabled = true;
     updateUrl(qid);
     showImageState('loading');
+    $imageArea.scrollIntoView({ block: 'start' });
 
     try {
       // Step 1: Get total hits to pick a random offset


### PR DESCRIPTION
## Summary
- Calls `$imageArea.scrollIntoView({ block: 'start' })` immediately after switching to the loading state, keeping the user anchored at the image section instead of letting the queue jump into view when the image card shrinks

## Test plan
- [ ] Load an image with tall content (large image + many tag chips). Click Next/Skip — confirm the view snaps to the top of the image area rather than showing the queue below

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR improves the user experience in the depictassist image tagging interface by automatically scrolling to the top of the image area when users click Next or Skip. This prevents the view from jumping to the batch queue below when the image card shrinks during the loading state.

## Changes

- **`public/static/depictassist/depictassist.js`**: Added one line calling `scrollIntoView({ block: 'start' })` on the image container after initiating the loading state

## Review Notes

- Low complexity change affecting only client-side static assets
- No infrastructure, environment, or API changes required
- No deployment pipeline modifications needed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->