### PR TITLE
Fix double arrow on DepictAssist institution dropdown

### DIFF
--- a/public/static/depictassist/depictassist.css
+++ b/public/static/depictassist/depictassist.css
@@ -84,6 +84,7 @@
     border-radius: 10px;
     border: 1px solid #d9e2ec;
     background-color: #f9fbfd;
+    background-image: none;
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
     width: 100%;
     appearance: auto;


### PR DESCRIPTION
## Summary
- The global SCSS applies `appearance: none` + a custom chevron SVG as `background-image` to all `<select>` elements. Our scoped CSS restored the native browser arrow via `appearance: auto` but left `background-image` inherited, causing both arrows to render simultaneously.
- Fix: add `background-image: none` to the scoped select rule to suppress the inherited chevron.

## Test plan
- [ ] Confirm the institution dropdown shows only one arrow indicator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes a visual bug in the DepictAssist institution dropdown that displayed two arrow indicators. The global stylesheet applies a custom chevron SVG as a background image to all `<select>` elements. The scoped DepictAssist CSS restored the native browser arrow via `appearance: auto` but did not suppress the inherited background image, resulting in both arrows rendering simultaneously. The fix adds `background-image: none;` to the `.depictassist-wrapper select` CSS rule to eliminate the duplicate arrow.

**Changes:**
- `public/static/depictassist/depictassist.css`: Added `background-image: none;` property to the `.depictassist-wrapper select` CSS rule

This is a purely cosmetic CSS fix with no impact on functionality, APIs, infrastructure, or security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->