### PR TITLE
Add deselect-by-click to DepictAssist tag chips

### DIFF
--- a/public/static/depictassist/depictassist.css
+++ b/public/static/depictassist/depictassist.css
@@ -170,6 +170,7 @@
 /* ── Tag Chips ───────────────────────────────────────────── */
 
 .depictassist-wrapper .da-tag-chip {
+    position: relative;
     display: inline-flex;
     flex-direction: column;
     align-items: flex-start;
@@ -195,6 +196,28 @@
     background-color: #163f51;
     color: white;
     border-color: #163f51;
+}
+
+.depictassist-wrapper .da-tag-remove {
+    display: none;
+    position: absolute;
+    top: -7px;
+    right: -7px;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background-color: #627d98;
+    color: white;
+    font-size: 13px;
+    font-weight: 700;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+    pointer-events: none;
+}
+
+.depictassist-wrapper .da-tag-chip.da-tag-selected .da-tag-remove {
+    display: flex;
 }
 
 .depictassist-wrapper .da-tag-description {

--- a/public/static/depictassist/depictassist.js
+++ b/public/static/depictassist/depictassist.js
@@ -390,6 +390,7 @@
       chip.appendChild(removeSpan);
 
       chip.addEventListener('click', function () {
+        if (submittingBatch) return;
         if (chip.classList.contains('da-tag-selected')) {
           const idx = queue.findIndex(item => item.mid === mid && item.prop === 'P180' && item.qid === tag.qid);
           if (idx !== -1) queue.splice(idx, 1);

--- a/public/static/depictassist/depictassist.js
+++ b/public/static/depictassist/depictassist.js
@@ -366,6 +366,7 @@
       chip.setAttribute('aria-label', 'Add depicts tag: ' + tag.label);
       chip.dataset.mid = mid;
       chip.dataset.qid = tag.qid;
+      chip.dataset.label = tag.label;
 
       const labelSpan = document.createElement('span');
       labelSpan.textContent = tag.label;
@@ -444,6 +445,7 @@
       removeBtn.setAttribute('aria-label', 'Remove ' + item.label + ' from queue');
       removeBtn.textContent = '\u2715';
       removeBtn.addEventListener('click', function () {
+        if (submittingBatch) return;
         const idx = queue.indexOf(item);
         if (idx !== -1) queue.splice(idx, 1);
         const chip = $tagSuggestions.querySelector('[data-mid="' + item.mid + '"][data-qid="' + item.qid + '"]');
@@ -721,7 +723,7 @@
       if (succeededMids.has(currentMid)) {
         for (const chip of $tagSuggestions.querySelectorAll('.da-tag-selected')) {
           chip.classList.remove('da-tag-selected');
-          chip.setAttribute('aria-label', 'Add depicts tag: ' + (chip.querySelector('span')?.textContent || ''));
+          chip.setAttribute('aria-label', 'Add depicts tag: ' + (chip.dataset.label || ''));
         }
       }
       renderQueue();

--- a/public/static/depictassist/depictassist.js
+++ b/public/static/depictassist/depictassist.js
@@ -383,10 +383,24 @@
       qidSpan.textContent = tag.qid;
       chip.appendChild(qidSpan);
 
+      const removeSpan = document.createElement('span');
+      removeSpan.className = 'da-tag-remove';
+      removeSpan.setAttribute('aria-hidden', 'true');
+      removeSpan.textContent = '\u00d7';
+      chip.appendChild(removeSpan);
+
       chip.addEventListener('click', function () {
-        addToQueue(mid, 'P180', tag.qid, tag.label, filename, subjectName, dplaUrl);
-        chip.classList.add('da-tag-selected');
-        chip.disabled = true;
+        if (chip.classList.contains('da-tag-selected')) {
+          const idx = queue.findIndex(item => item.mid === mid && item.prop === 'P180' && item.qid === tag.qid);
+          if (idx !== -1) queue.splice(idx, 1);
+          chip.classList.remove('da-tag-selected');
+          chip.setAttribute('aria-label', 'Add depicts tag: ' + tag.label);
+          renderQueue();
+        } else {
+          addToQueue(mid, 'P180', tag.qid, tag.label, filename, subjectName, dplaUrl);
+          chip.classList.add('da-tag-selected');
+          chip.setAttribute('aria-label', 'Remove depicts tag: ' + tag.label);
+        }
       });
 
       $tagSuggestions.appendChild(chip);
@@ -434,7 +448,7 @@
         const chip = $tagSuggestions.querySelector('[data-mid="' + item.mid + '"][data-qid="' + item.qid + '"]');
         if (chip) {
           chip.classList.remove('da-tag-selected');
-          chip.disabled = false;
+          chip.setAttribute('aria-label', 'Add depicts tag: ' + item.label);
         }
         renderQueue();
       });
@@ -706,7 +720,7 @@
       if (succeededMids.has(currentMid)) {
         for (const chip of $tagSuggestions.querySelectorAll('.da-tag-selected')) {
           chip.classList.remove('da-tag-selected');
-          chip.disabled = false;
+          chip.setAttribute('aria-label', 'Add depicts tag: ' + (chip.querySelector('span')?.textContent || ''));
         }
       }
       renderQueue();


### PR DESCRIPTION
## Summary
- Clicking a selected tag chip now deselects it (removes from queue), toggling the state instead of requiring the queue's remove button
- Selected chips show a small × badge in the top-right corner as a visual affordance for deselection
- Chips are no longer disabled on selection, so the toggle works naturally
- aria-label updates on toggle to reflect the current action ("Add" vs "Remove")

## Test plan
- [ ] Click an unselected chip — confirm it turns blue and shows × badge, and appears in queue
- [ ] Click the selected chip again — confirm it deselects, × disappears, removed from queue
- [ ] Confirm queue's × remove button still works and also deselects the chip
- [ ] Submit a batch — confirm chips reset to unselected state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR improves DepictAssist tag chip UX by allowing chips to be toggled by clicking: clicking a selected chip now deselects it (removing it from the queue) rather than requiring the queue's remove button. Selected chips also show a small × badge and aria-labels update to reflect the current action ("Add" vs "Remove"). Chip toggles are blocked while a batch submission is in flight.

This change does not require pipeline or ECS redeploys, does not add/remove environment variables or Secrets Manager keys, includes no database migrations, does not modify shared infrastructure (CodePipeline/CodeBuild/ECS/IAM), does not change public API shapes or endpoints, and has no new credential handling or other security-sensitive behavior.

## Changes

**CSS (public/static/depictassist/depictassist.css)**
- Made `.da-tag-chip` position: relative to anchor an overlay control.
- Added `.da-tag-remove` element styled as a circular × badge positioned top-right.
- `.da-tag-remove` is shown only when the chip has `.da-tag-selected`.

**JavaScript (public/static/depictassist/depictassist.js)**
- Store tag.label in `chip.dataset.label` when creating chips for reliable aria-label resets.
- Switch from "disable chip after selection" to a toggleable selected-state model:
  - Clicking an unselected chip enqueues the claim, adds `.da-tag-selected`, sets aria-label to "Remove depicts tag: …", and shows the × badge.
  - Clicking a selected chip removes the queued claim, removes `.da-tag-selected`, resets aria-label to "Add depicts tag: …", and hides the × badge.
- Queue item removal now clears the chip's selected state and updates its aria-label (no enable/disable flow).
- Append a visible `da-tag-remove` span (aria-hidden) to chips as a visual deselect affordance.
- Block chip toggle and queue-remove interactions while batch submission is in progress (`submittingBatch` flag).
- After successful batch submission, reset remaining chips' aria-labels using stored `data-label`.

## Behavior / Test plan (high-level)
- Click an unselected chip: it becomes selected (blue), shows × badge, and appears in the queue.
- Click the selected chip again: it deselects, × disappears, and is removed from the queue.
- Queue item's × remove button still deselects the chip.
- Submitting a batch prevents toggles during submission and resets chips to unselected on success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->