### PR TITLE
Auto-skip images with no tag suggestions

### DIFF
--- a/public/static/depictassist/depictassist.js
+++ b/public/static/depictassist/depictassist.js
@@ -205,6 +205,7 @@
 
       const cap = Math.min(totalHits, 10000);
       let reconTimeouts = 0;
+      let reconErrors = 0;
       let noSuggestionSkips = 0;
       let attempts = 0;
       const maxAttempts = 10;
@@ -267,6 +268,7 @@
               : (() => { const c = new AbortController(); setTimeout(() => c.abort(), 8000); return c.signal; })();
             const reconResp = await fetch(reconUrl, { signal: reconSignal });
             if (reconResp.ok) {
+              reconErrors = 0;
               const reconData = await reconResp.json();
               const results = reconData.q1?.result || [];
               tagSuggestions = results.slice(0, MAX_SUGGESTIONS).map(r => ({
@@ -274,6 +276,10 @@
                 label: r.name || '',
                 description: r.description || ''
               }));
+            } else {
+              reconErrors++;
+              if (reconErrors >= 3) throw new Error('Reconciliation API unavailable');
+              continue;
             }
           } catch (reconErr) {
             if (reconErr.name === 'TimeoutError' || reconErr.name === 'AbortError') {

--- a/public/static/depictassist/depictassist.js
+++ b/public/static/depictassist/depictassist.js
@@ -286,6 +286,8 @@
           continue;
         }
 
+        if (tagSuggestions.length === 0) continue;
+
         displayImage({
           mid, imgUrl, title: titleText, filename: pageTitle,
           description: descText, subjectName, dplaUrl, tagSuggestions

--- a/public/static/depictassist/depictassist.js
+++ b/public/static/depictassist/depictassist.js
@@ -205,11 +205,15 @@
 
       const cap = Math.min(totalHits, 10000);
       let reconTimeouts = 0;
+      let noSuggestionSkips = 0;
       let attempts = 0;
       const maxAttempts = 10;
 
       while (true) {
-        if (++attempts > maxAttempts) throw new Error('Unable to find a valid image after multiple attempts');
+        if (++attempts > maxAttempts) {
+          if (noSuggestionSkips >= maxAttempts) { showImageState('empty'); return; }
+          throw new Error('Unable to find a valid image after multiple attempts');
+        }
         // Step 2: Fetch a random image (with iiurlwidth=800 to avoid a separate image info call)
         const offset = Math.floor(Math.random() * cap);
         const searchUrl = buildSearchUrl(qid, offset, 1);
@@ -286,7 +290,7 @@
           continue;
         }
 
-        if (tagSuggestions.length === 0) continue;
+        if (tagSuggestions.length === 0) { noSuggestionSkips++; continue; }
 
         displayImage({
           mid, imgUrl, title: titleText, filename: pageTitle,


### PR DESCRIPTION
## Summary
- Images that return zero reconciliation suggestions are now silently skipped in the retry loop instead of being displayed as a dead end
- Covers both cases: no P4272 subject on the entity, and a subject that returns no Wikidata matches from reconci.link
- The existing `maxAttempts=10` guard prevents infinite looping if suggestions are broadly unavailable for the selected institution

## Test plan
- [ ] Confirm that images displayed always have at least one tag suggestion chip
- [ ] Confirm that "Find images" still works normally and doesn't error for institutions with good coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds an auto-skip mechanism to the DepictAssist image tagging tool so images that produce zero reconciliation/tag suggestions are silently skipped during the retry loop. If every retry results in such skips up to the retry limit, the UI now shows the existing empty-state instead of surfacing a "dead-end" or an error.

Also includes a commit that shows the empty state when all retry attempts are skipped due to no suggestions (co-authored by Claude Sonnet).

## Changes

**File: `public/static/depictassist/depictassist.js`**

- In `onFindImages`, the retry loop now:
  - Introduces counters `reconErrors` and `noSuggestionSkips`.
  - When a reconciliation response is non-ok, increments `reconErrors`; after repeated reconciliation failures (reconErrors >= 3) the flow throws a `'Reconciliation API unavailable'` error. Successful recon resets `reconErrors` to 0.
  - When reconciliation returns no `tagSuggestions` (`tagSuggestions.length === 0`), increments `noSuggestionSkips` and immediately continues to the next candidate image instead of calling `displayImage`.
  - When `attempts` exceeds `maxAttempts` (10), if `noSuggestionSkips >= maxAttempts` the UI shows the `'empty'` image state and returns; otherwise the prior error behavior is preserved.
- Preserves existing recon timeout handling and the `maxAttempts = 10` guard.

Lines changed: +13/-1

## Impact

- User-facing: Images shown in DepictAssist will always include at least one tag suggestion chip; users will no longer be shown images with no tagging options.
- No changes to public API shapes or endpoints.
- No environment variables, AWS Secrets Manager keys, database migrations, or shared infrastructure (CodePipeline/CodeBuild/ECS/IAM) changes.
- No security implications introduced (no new credential handling or auth changes).
- Deployment: standard frontend/static asset deployment is required for the change to take effect (no manual pipeline trigger or ECS redeploy beyond the normal front-end deploy process).

## Test plan

- Confirm displayed images always have at least one suggestion chip.
- Confirm "Find images" continues to work and does not error for institutions with normal coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->