### PR TITLE
DepictAssist: lightbox image zoom

### DIFF
--- a/pages/projects/dpla-wikimedia/depictassist.js
+++ b/pages/projects/dpla-wikimedia/depictassist.js
@@ -148,6 +148,13 @@ export default function DepictAssistPage({ items }) {
                 <div id="da-batch-error" style={{ display: "none" }} className="da-error">
                   <p id="da-batch-error-msg" />
                 </div>
+
+                <dialog id="da-lightbox" aria-label="Image viewer">
+                  <button type="button" id="da-lightbox-close" aria-label="Close image viewer">
+                    &times;
+                  </button>
+                  <img id="da-lightbox-img" alt="" />
+                </dialog>
               </div>
             </div>
           </div>

--- a/public/static/depictassist/depictassist.css
+++ b/public/static/depictassist/depictassist.css
@@ -325,6 +325,57 @@
     font-weight: 500;
 }
 
+/* ── Lightbox ────────────────────────────────────────────── */
+
+.depictassist-wrapper #da-lightbox {
+    padding: 0;
+    border: none;
+    border-radius: 12px;
+    background: #000;
+    max-width: min(1600px, 95vw);
+    max-height: 95vh;
+    overflow: hidden;
+    position: fixed;
+}
+
+.depictassist-wrapper #da-lightbox::backdrop {
+    background: rgba(0, 0, 0, 0.82);
+}
+
+.depictassist-wrapper #da-lightbox-img {
+    display: block;
+    max-width: 100%;
+    max-height: 95vh;
+    width: auto;
+    height: auto;
+    border-radius: 0;
+    border: none;
+}
+
+.depictassist-wrapper #da-lightbox-close {
+    position: absolute;
+    top: 10px;
+    right: 12px;
+    background: rgba(0, 0, 0, 0.55);
+    border: none;
+    border-radius: 50%;
+    color: #fff;
+    font-size: 22px;
+    line-height: 1;
+    width: 34px;
+    height: 34px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    z-index: 1;
+}
+
+.depictassist-wrapper #da-lightbox-close:hover {
+    background: rgba(0, 0, 0, 0.8);
+}
+
 /* ── Error State ────────────────────────────────────────── */
 
 .depictassist-wrapper .da-error {

--- a/public/static/depictassist/depictassist.css
+++ b/public/static/depictassist/depictassist.css
@@ -376,6 +376,12 @@
     background: rgba(0, 0, 0, 0.8);
 }
 
+.depictassist-wrapper #da-lightbox-close:focus-visible {
+    outline: 2px solid #fff;
+    outline-offset: 2px;
+    background: rgba(0, 0, 0, 0.8);
+}
+
 /* ── Error State ────────────────────────────────────────── */
 
 .depictassist-wrapper .da-error {

--- a/public/static/depictassist/depictassist.js
+++ b/public/static/depictassist/depictassist.js
@@ -27,7 +27,8 @@
       $loginBtn, $userInfo,
       $username, $logoutBtn, $imageTitle, $imageDescription,
       $imageImg, $imageLink, $commonsLink, $subjectHeading,
-      $tagSuggestions, $skipBtn;
+      $tagSuggestions, $skipBtn,
+      $lightbox, $lightboxImg, $lightboxClose;
 
   // Track the wrapper element we've initialized on, so we can detect
   // SPA re-navigation (new DOM nodes) vs. duplicate calls on the same mount.
@@ -90,6 +91,9 @@
     $subjectHeading  = document.getElementById('da-subject-heading');
     $tagSuggestions  = document.getElementById('da-tag-suggestions');
     $skipBtn         = document.getElementById('da-skip-btn');
+    $lightbox        = document.getElementById('da-lightbox');
+    $lightboxImg     = document.getElementById('da-lightbox-img');
+    $lightboxClose   = document.getElementById('da-lightbox-close');
   }
 
   function bindEvents() {
@@ -98,6 +102,8 @@
     $batchBtn.addEventListener('click', onSubmitBatch);
     $loginBtn.addEventListener('click', onLogin);
     $logoutBtn.addEventListener('click', onLogout);
+    $lightboxClose.addEventListener('click', () => $lightbox.close());
+    $lightbox.addEventListener('click', (e) => { if (e.target === $lightbox) $lightbox.close(); });
   }
 
   // ── URL state ────────────────────────────────────────────
@@ -325,6 +331,22 @@
   }
 
   // ── Display ──────────────────────────────────────────────
+  function getLargeThumbUrl(thumbUrl) {
+    return thumbUrl.replace(/\/\d+px-/, '/1600px-');
+  }
+
+  function openLightbox(imgUrl, altText) {
+    $lightboxImg.src = imgUrl;
+    $lightboxImg.alt = altText;
+    $lightbox.showModal();
+    const largeUrl = getLargeThumbUrl(imgUrl);
+    if (largeUrl !== imgUrl) {
+      const large = new Image();
+      large.onload = function () { if ($lightbox.open) $lightboxImg.src = largeUrl; };
+      large.src = largeUrl;
+    }
+  }
+
   function showImageState(state) {
     $imageArea.style.display = 'block';
     $loading.style.display = state === 'loading' ? 'block' : 'none';
@@ -342,6 +364,8 @@
     $imageTitle.textContent = title;
     $imageDescription.textContent = description || '(No description provided)';
     $imageImg.src = imgUrl;
+    $imageImg.style.cursor = 'zoom-in';
+    $imageImg.onclick = function () { openLightbox(imgUrl, title); };
     $imageLink.href = imgUrl;
 
     $commonsLink.href = 'https://commons.wikimedia.org/wiki/' + encodeURIComponent(filename);

--- a/public/static/depictassist/depictassist.js
+++ b/public/static/depictassist/depictassist.js
@@ -19,6 +19,7 @@
   let isAuthenticated = false;
   let fetchingImages = false;
   let submittingBatch = false;
+  let lightboxOpenToken = 0;
 
   // ── DOM refs (populated in init) ─────────────────────────
   let $select, $findBtn, $imageArea, $loading, $imageDisplay,
@@ -336,13 +337,16 @@
   }
 
   function openLightbox(imgUrl, altText) {
+    const token = ++lightboxOpenToken;
     $lightboxImg.src = imgUrl;
     $lightboxImg.alt = altText;
     $lightbox.showModal();
     const largeUrl = getLargeThumbUrl(imgUrl);
     if (largeUrl !== imgUrl) {
       const large = new Image();
-      large.onload = function () { if ($lightbox.open) $lightboxImg.src = largeUrl; };
+      large.onload = function () {
+        if ($lightbox.open && token === lightboxOpenToken) $lightboxImg.src = largeUrl;
+      };
       large.src = largeUrl;
     }
   }
@@ -365,8 +369,12 @@
     $imageDescription.textContent = description || '(No description provided)';
     $imageImg.src = imgUrl;
     $imageImg.style.cursor = 'zoom-in';
-    $imageImg.onclick = function () { openLightbox(imgUrl, title); };
     $imageLink.href = imgUrl;
+    $imageLink.setAttribute('aria-label', 'View larger image');
+    $imageLink.onclick = function (e) {
+      e.preventDefault();
+      openLightbox(imgUrl, title);
+    };
 
     $commonsLink.href = 'https://commons.wikimedia.org/wiki/' + encodeURIComponent(filename);
     $commonsLink.textContent = filename;


### PR DESCRIPTION
## Summary

- Click the image in DepictAssist to open a full-screen lightbox viewer
- Shows the 800px thumbnail immediately, then swaps to a 1600px version when it finishes loading (progressive enhancement)
- Wikimedia always serves thumbnails as JPEG/PNG regardless of the original format, so no TIFF/large-file risk
- The src swap is guarded: only fires if the dialog is still open when the high-res load completes
- Close by clicking the × button or clicking outside the image
- Native `<dialog>` element — handles focus trapping and Escape key automatically

## Test plan

- [ ] Load the DepictAssist page, select an institution, click "Find images"
- [ ] Click the image — lightbox should open with the thumbnail immediately visible
- [ ] After a moment, the image should sharpen/upgrade to the larger version
- [ ] Press Escape — lightbox should close
- [ ] Click outside the image (on the dark backdrop) — lightbox should close
- [ ] Click the × button — lightbox should close
- [ ] Confirm the image cursor shows a zoom-in pointer on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## DepictAssist Lightbox Image Zoom

Adds a full-screen image viewer to the DepictAssist UI using the native HTML <dialog> element for modal behavior and basic accessibility.

### Implementation

- Markup: Inserts a <dialog id="da-lightbox"> into the DepictAssist page with a close button (#da-lightbox-close) and an image element (#da-lightbox-img).
- JS: Caches dialog/image/close button refs, binds close behavior (close button, clicking backdrop), and sets image thumbnail click handler to open the lightbox. openLightbox(imgUrl, altText) immediately shows the 800px thumbnail, derives a 1600px URL via getLargeThumbUrl (replacing /<number>px- with /1600px-), preloads the larger image, and swaps the dialog image src only if the dialog is still open when the preload completes (guarded by lightboxOpenToken and checking $lightbox.open).
- CSS: Adds scoped lightbox styles under .depictassist-wrapper (max-width: min(1600px, 95vw); max-height: 95vh), a dark semi-transparent backdrop (rgba(0,0,0,0.82)), centered image sizing, and a circular floating × close button. Main image cursor set to zoom-in on hover.
- Closing UX: Lightbox can be closed via the × button, pressing Escape (native <dialog> handling), or clicking the backdrop.
- Image handling: Uses Wikimedia-served thumbnails (JPEG/PNG) and avoids handling very large/unsupported formats (e.g., TIFF).

### Tests / Behavior Checklist

- Clicking an image opens the lightbox showing the 800px thumbnail immediately.
- High-resolution (1600px) image is loaded in background and replaces the thumbnail only if the dialog remains open and the same lightbox session (token).
- Escape key, clicking outside the image (backdrop), and × button close the lightbox.
- Image shows zoom-in cursor on hover.

### Impact / Risk / Ops Notes

- Only client-side/markup/CSS changes: no server-side changes, API response shape modifications, authentication changes, environment variable or secret additions/removals, database migrations, or infrastructure (CodePipeline/CodeBuild/ECS/IAM) modifications.
- No manual pipeline trigger or ECS redeploy is required for this change (it affects frontend static assets and page markup).
- Security: client-side display logic only; images are loaded from Wikimedia and no new credential handling or external secret usage is introduced.

### Files touched (high level)

- pages/projects/dpla-wikimedia/depictassist.js — adds <dialog> markup and includes the front-end script.
- public/static/depictassist/depictassist.css — adds scoped lightbox styles.
- public/static/depictassist/depictassist.js — adds dialog/image refs, event bindings, open/close logic, getLargeThumbUrl, progressive high-res preload, and guarded src swap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->