### PR TITLE
docs: update DepictAssist README for recent UI changes

### DIFF
--- a/public/static/depictassist/README.md
+++ b/public/static/depictassist/README.md
@@ -8,12 +8,12 @@ Wikimedia Commons images contributed by DPLA institutions. Hosted at
 
 1. A volunteer selects a DPLA contributing institution from the dropdown
 2. The tool finds a random Commons image from that institution that has subject
-   terms (P4272) but no depicts claims (P180) yet; images that produce no tag
-   suggestions are silently skipped and a new image is tried automatically
+   terms (P4272) but no depicts claims (P180) yet
 3. Those subject terms are sent to the Wikidata Reconciliation API to generate
-   tag suggestions
-4. The volunteer clicks tags to queue P180 claims; clicking a selected tag
-   deselects it, or the volunteer can use the × button in the queue list
+   tag suggestions; images where reconciliation produces no matches show a
+   "No tag suggestions available" hint but are still displayed
+4. The volunteer clicks tags to queue P180 claims; use the × button in the
+   queue list to remove a queued claim
 5. Edits are posted to Commons under the volunteer's own Wikimedia account via
    OAuth 2.0, with each claim citing "based on heuristic" (P887 = Q114065533) as
    its reference
@@ -261,41 +261,37 @@ Every P180 claim added by DepictAssist includes a reference: P887 (basis of
 knowledge) = Q114065533 (based on heuristic). This flags the claim as
 algorithmically suggested so other editors know it warrants human review.
 
-### Suggestion chips: toggle selection via CSS class
+### Suggestion chips: selection via CSS class and disabled property
 
 Each tag chip is stamped with `data-mid` (Commons M-ID, e.g. `M12345`) and
 `data-qid` (Wikidata Q-ID, e.g. `Q67890`) when it is created. Selection state is
-tracked with the `da-tag-selected` CSS class (not the `disabled` property). Clicking
-a chip toggles it: if selected, the chip is removed from the queue, the class is
-removed, and `aria-label` is reset to "Add depicts tag: …"; if not selected, it is
-added to the queue and the class is applied. A `×` badge (`.da-tag-remove`) is
-rendered inside every chip and shown via CSS only when `da-tag-selected` is present,
-giving the volunteer a visible affordance for deselection.
+tracked with the `da-tag-selected` CSS class; `chip.disabled` is also set to `true`
+at the same time for form control state management. Clicking a chip calls
+`addToQueue()`, adds the `da-tag-selected` class, and disables the button — chips
+cannot be deselected by clicking them again. To remove a queued claim, use the
+× button in the batch list.
 
 When the volunteer clicks × on a queued item in the batch list, the remove handler
-uses `data-mid` and `data-qid` to find the corresponding chip in `$tagSuggestions`
-and removes `da-tag-selected` from it. Without those attributes the handler would
-have no way to identify the right chip after `renderQueue()` has rebuilt the list.
+uses `data-mid` and `data-qid` to find the corresponding chip in `$tagSuggestions`,
+removes `da-tag-selected`, and re-enables it (`chip.disabled = false`). Without those
+attributes the handler would have no way to identify the right chip after
+`renderQueue()` has rebuilt the list.
 
-Chip clicks are silently ignored while `submittingBatch` is `true`, preventing queue
-mutations from racing with the in-flight Commons API calls.
+### Handling images with no tag suggestions
 
-### Auto-skip of images with no tag suggestions
+Image selection runs inside a retry loop (`maxAttempts = 10`, tracked by an
+`attempts` counter). The loop retries only for invalid data — missing pages, invalid
+page IDs, or no entity data — not for empty tag suggestions.
 
-The reconciliation step (Step 3 above) runs for each randomly selected image inside
-a retry loop (`maxAttempts = 10`). If the subject terms produce no Wikidata matches,
-`tagSuggestions.length === 0` and the loop `continue`s to the next random image
-without displaying anything. A `noSuggestionSkips` counter tracks how many of the
-attempts were skipped for this reason. When the loop exhausts all attempts:
+When reconciliation returns no matches (`tagSuggestions.length === 0`), the image is
+still displayed: `displayImage()` is called and renders a "No tag suggestions
+available for this subject." hint in place of chips. The loop only retries when:
+- The Commons search returns no pages, an invalid page ID, or no entity data →
+  `showImageState('empty')` is called and the function returns immediately
+- Reconciliation times out three consecutive times → an error is thrown
 
-- If `noSuggestionSkips >= maxAttempts`, every retry was a no-suggestion skip — the
-  institution simply has no taggable images in the current sample window, so the
-  empty state is shown ("No untagged images found").
-- Otherwise, failures were due to network or API problems and the error state is
-  shown instead.
-
-Without this distinction, institutions with many tagged or suggestion-free images
-would always surface a generic error rather than the correct "nothing to tag" message.
+If `attempts` exceeds `maxAttempts`, an error is thrown and the error state is
+displayed. All other unhandled errors also fall through to `showImageState('error')`.
 
 ### Image lightbox and progressive load
 

--- a/public/static/depictassist/README.md
+++ b/public/static/depictassist/README.md
@@ -8,10 +8,12 @@ Wikimedia Commons images contributed by DPLA institutions. Hosted at
 
 1. A volunteer selects a DPLA contributing institution from the dropdown
 2. The tool finds a random Commons image from that institution that has subject
-   terms (P4272) but no depicts claims (P180) yet
+   terms (P4272) but no depicts claims (P180) yet; images that produce no tag
+   suggestions are silently skipped and a new image is tried automatically
 3. Those subject terms are sent to the Wikidata Reconciliation API to generate
    tag suggestions
-4. The volunteer clicks tags to queue P180 claims, then submits the batch
+4. The volunteer clicks tags to queue P180 claims; clicking a selected tag
+   deselects it, or the volunteer can use the × button in the queue list
 5. Edits are posted to Commons under the volunteer's own Wikimedia account via
    OAuth 2.0, with each claim citing "based on heuristic" (P887 = Q114065533) as
    its reference
@@ -259,14 +261,64 @@ Every P180 claim added by DepictAssist includes a reference: P887 (basis of
 knowledge) = Q114065533 (based on heuristic). This flags the claim as
 algorithmically suggested so other editors know it warrants human review.
 
-### Suggestion chips carry data attributes for queue management
+### Suggestion chips: toggle selection via CSS class
 
-Each tag chip element is stamped with `data-mid` (the Commons M-ID, e.g. `M12345`)
-and `data-qid` (the Wikidata Q-ID, e.g. `Q67890`) when it is created. When the user
-clicks X on a queued item, the remove handler queries `$tagSuggestions` for a chip
-matching both attributes and re-enables it — restoring the visual selected state and
-allowing the tag to be re-added. Without the attributes the handler would have no
-way to find the right chip after the DOM has been rebuilt by `renderQueue()`.
+Each tag chip is stamped with `data-mid` (Commons M-ID, e.g. `M12345`) and
+`data-qid` (Wikidata Q-ID, e.g. `Q67890`) when it is created. Selection state is
+tracked with the `da-tag-selected` CSS class (not the `disabled` property). Clicking
+a chip toggles it: if selected, the chip is removed from the queue, the class is
+removed, and `aria-label` is reset to "Add depicts tag: …"; if not selected, it is
+added to the queue and the class is applied. A `×` badge (`.da-tag-remove`) is
+rendered inside every chip and shown via CSS only when `da-tag-selected` is present,
+giving the volunteer a visible affordance for deselection.
+
+When the volunteer clicks × on a queued item in the batch list, the remove handler
+uses `data-mid` and `data-qid` to find the corresponding chip in `$tagSuggestions`
+and removes `da-tag-selected` from it. Without those attributes the handler would
+have no way to identify the right chip after `renderQueue()` has rebuilt the list.
+
+Chip clicks are silently ignored while `submittingBatch` is `true`, preventing queue
+mutations from racing with the in-flight Commons API calls.
+
+### Auto-skip of images with no tag suggestions
+
+The reconciliation step (Step 3 above) runs for each randomly selected image inside
+a retry loop (`maxAttempts = 10`). If the subject terms produce no Wikidata matches,
+`tagSuggestions.length === 0` and the loop `continue`s to the next random image
+without displaying anything. A `noSuggestionSkips` counter tracks how many of the
+attempts were skipped for this reason. When the loop exhausts all attempts:
+
+- If `noSuggestionSkips >= maxAttempts`, every retry was a no-suggestion skip — the
+  institution simply has no taggable images in the current sample window, so the
+  empty state is shown ("No untagged images found").
+- Otherwise, failures were due to network or API problems and the error state is
+  shown instead.
+
+Without this distinction, institutions with many tagged or suggestion-free images
+would always surface a generic error rather than the correct "nothing to tag" message.
+
+### Image lightbox and progressive load
+
+Clicking the thumbnail image opens a native `<dialog>` modal (`showModal()`). The
+800 px thumbnail that is already loaded for the main view is set as the lightbox
+`src` immediately so the modal appears without delay. A `new Image()` object then
+fetches the 1 600 px version in the background; when it loads, `$lightboxImg.src`
+is swapped — but only if `$lightbox.open` is still `true`, preventing an invisible
+write to a dialog the volunteer has already closed.
+
+The 1 600 px URL is derived from the existing thumb URL with a regex replace
+(`/\/\d+px-/` → `/1600px-`). Wikimedia serves thumbnails as JPEG or PNG regardless
+of the original file format, so there is no risk of fetching a raw TIFF. Requesting
+a width wider than the original is safe: Wikimedia returns the original resolution
+rather than upscaling or erroring.
+
+### Dropdown arrow CSS conflict
+
+`global.scss` applies `appearance: none` and a custom SVG `background-image` to all
+`<select>` elements site-wide, replacing the native browser arrow. The institution
+dropdown overrides both (`background-image: none; appearance: auto`) to restore the
+native arrow, because leaving the global override in place causes the browser's
+native arrow and the SVG arrow to render on top of each other.
 
 ### SPA re-navigation guard
 


### PR DESCRIPTION
## Summary

- Updates "What it does" steps to mention auto-skip of no-suggestion images and chip deselection
- Replaces stale "Suggestion chips carry data attributes" section (described old `disabled`-property approach) with accurate description of CSS-class toggle, × badge, and `submittingBatch` guard
- Adds new sections covering:
  - **Auto-skip of no-suggestion images** — `noSuggestionSkips` counter and how it distinguishes empty vs. error state
  - **Image lightbox and progressive load** — `<dialog>`, 800px→1600px swap, `$lightbox.open` guard, Wikimedia thumb URL behavior
  - **Dropdown arrow CSS conflict** — why `background-image: none; appearance: auto` is needed to override `global.scss`

Covers changes from PRs #1481, #1482, #1483, #1484, #1485.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This pull request updates the DepictAssist README to document recent UI and UX behavior changes introduced across PRs #1481–#1485.

Changes
- What it does / workflow
  - Clarifies auto-skip behavior: the client will retry a randomly selected Commons image when reconciliation returns no suggestions; an explicit empty-state message ("No tag suggestions available") is shown only after the retry loop exhausts attempts. The retry loop distinguishes empty-suggestion results from error/invalid-data cases (which trigger retries up to maxAttempts and otherwise surface an error state).
- Tag selection / queue behavior
  - Corrects prior inaccuracies about chip interactions:
    - Selection state is represented by a `da-tag-selected` CSS class and `chip.disabled`.
    - Chips are not deselected by repeated chip clicks; deselection is done via the × badge in the queue list. The README now documents that queue removals re-enable the corresponding chip by matching `data-mid`/`data-qid` after `renderQueue()` rebuilds the DOM.
    - A `submittingBatch` guard exists to prevent duplicate concurrent submissions / queue mutations.
- Image lightbox and progressive loading
  - Documents use of a `<dialog>` lightbox, initial use of the already-loaded thumbnail (800px), background fetch of a higher-resolution image (1600px) and progressive swap only if the dialog remains open, and behavior for Wikimedia thumbnail URLs.
- CSS override for dropdown arrow
  - Notes a global CSS conflict (global.scss) and documents the needed override (`background-image: none; appearance: auto`) to restore native select-arrow styling.
- Retry-loop and error handling
  - Adds a dedicated section describing which conditions trigger retries (missing/invalid pages, no entity data) versus when an image is treated as an empty result, and how attempts/maxAttempts are applied.

Other
- README-only change; no code, exported/public API, infrastructure, environment variables, database migrations, or IAM changes.
- No deployment, pipeline trigger, or ECS redeploy required — documentation takes effect immediately.
- Lines changed in README: +58 / -10
- Commit messages fix previous README inaccuracies (chip deselection, disabled/class behavior, remove references to non-existent in-chip remove badge and chip-click checks of `submittingBatch`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->