### PR TITLE
Fix PDF.js CSP: scope unsafe-eval to /static/pdfjs/* only

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -51,7 +51,7 @@ function redirect(source, dest, permanent = true) {
 // Failure to do this will block all JavaScript on dp.la immediately on deploy.
 // TODO: migrate to nonce-based CSP via Next.js middleware to eliminate this.
 const CLOUDFRONT_MEDIA = "https://d2jf00asb0fe6y.cloudfront.net";
-const CSP = [
+const CSP_DIRECTIVES = [
   "base-uri 'self'",
   "object-src 'none'",
   "frame-ancestors 'self'",
@@ -64,7 +64,14 @@ const CSP = [
   "font-src 'self' https://cdnjs.cloudflare.com",
   `media-src 'self' *.dp.la ${CLOUDFRONT_MEDIA}`,
   "frame-src 'self' https://www.youtube.com",
-].join("; ");
+];
+const CSP = CSP_DIRECTIVES.join("; ");
+
+// PDF.js 2.5.5 needs 'unsafe-eval' for Type3/custom font compilation. Scoped to
+// /static/pdfjs/* only so the rest of the app keeps the stricter policy.
+const CSP_PDFJS = CSP_DIRECTIVES.map((d) =>
+  d.startsWith("script-src ") ? `${d} 'unsafe-eval'` : d
+).join("; ");
 
 let config = {
   async headers() {
@@ -73,8 +80,14 @@ let config = {
     }
     return [
       {
-        source: "/:path*",
+        // Negative lookahead keeps this from also matching /static/pdfjs/*;
+        // browsers AND-combine multiple CSP headers, so both rules must not fire.
+        source: "/((?!static/pdfjs/).*)",
         headers: [{ key: "Content-Security-Policy", value: CSP }],
+      },
+      {
+        source: "/static/pdfjs/:path*",
+        headers: [{ key: "Content-Security-Policy", value: CSP_PDFJS }],
       },
     ];
   },

--- a/next.config.js
+++ b/next.config.js
@@ -251,9 +251,6 @@ let config = {
       throw new Error("Invalid site environment");
     }
   },
-  experimental: {
-    instrumentationHook: true,
-  },
   poweredByHeader: false,
   reactStrictMode: true,
   images: {

--- a/next.config.js
+++ b/next.config.js
@@ -82,7 +82,7 @@ let config = {
       {
         // Negative lookahead keeps this from also matching /static/pdfjs/*;
         // browsers AND-combine multiple CSP headers, so both rules must not fire.
-        source: "/((?!static/pdfjs).*)",
+        source: "/((?!static/pdfjs(?:/|$)).*)",
         headers: [{ key: "Content-Security-Policy", value: CSP }],
       },
       {

--- a/next.config.js
+++ b/next.config.js
@@ -82,7 +82,7 @@ let config = {
       {
         // Negative lookahead keeps this from also matching /static/pdfjs/*;
         // browsers AND-combine multiple CSP headers, so both rules must not fire.
-        source: "/((?!static/pdfjs/).*)",
+        source: "/((?!static/pdfjs(/|$)).*)",
         headers: [{ key: "Content-Security-Policy", value: CSP }],
       },
       {

--- a/next.config.js
+++ b/next.config.js
@@ -82,7 +82,7 @@ let config = {
       {
         // Negative lookahead keeps this from also matching /static/pdfjs/*;
         // browsers AND-combine multiple CSP headers, so both rules must not fire.
-        source: "/((?!static/pdfjs(/|$)).*)",
+        source: "/((?!static/pdfjs).*)",
         headers: [{ key: "Content-Security-Policy", value: CSP }],
       },
       {

--- a/next.config.js
+++ b/next.config.js
@@ -59,7 +59,7 @@ const CSP_DIRECTIVES = [
   "default-src 'self'",
   "script-src 'self' 'sha256-sYQvVdNrbb2ldJRpproLbB3h5LhCcbCA1SUM1wTfomI=' 'sha256-uZYgrdXqFswjbPEZxW2e6bv+djcz8D4kcJKjWyznRmk=' 'sha256-R7BycX6lCwOq9x3CZpytPnOyYvDNpLs38i6qKfpCcVY=' *.google-analytics.com *.googletagmanager.com *.sentry.io https://*.awswaf.com https://www.gstatic.com",
   "img-src 'self' http: https:",
-  `connect-src 'self' https://dp.la https://*.dp.la ${CLOUDFRONT_MEDIA} *.google-analytics.com *.analytics.google.com *.sentry.io https://*.awswaf.com https://gitlab.wikimedia.org https://commons.wikimedia.org https://wikimedia.org https://wikidata.reconci.link https://wikidata-reconciliation.wmcloud.org https://raw.githubusercontent.com https://meta.wikimedia.org https://www.wikidata.org`,
+  `connect-src 'self' https://dp.la https://*.dp.la ${CLOUDFRONT_MEDIA} *.google-analytics.com *.analytics.google.com *.sentry.io https://*.awswaf.com https://www.gstatic.com https://gitlab.wikimedia.org https://commons.wikimedia.org https://wikimedia.org https://wikidata.reconci.link https://wikidata-reconciliation.wmcloud.org https://raw.githubusercontent.com https://meta.wikimedia.org https://www.wikidata.org`,
   "style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://www.gstatic.com",
   "font-src 'self' https://cdnjs.cloudflare.com",
   `media-src 'self' *.dp.la ${CLOUDFRONT_MEDIA}`,

--- a/scripts/check-csp.js
+++ b/scripts/check-csp.js
@@ -35,7 +35,7 @@ function extractCsp() {
     );
   }
 
-  const block = src.match(/const CSP\s*=\s*\[([\s\S]*?)\]\.join/)?.[1];
+  const block = src.match(/const CSP_DIRECTIVES\s*=\s*\[([\s\S]*?)\];/)?.[1];
   if (!block) throw new Error("CSP array not found in next.config.js");
 
   const entries = [];


### PR DESCRIPTION
## Summary

- **Root cause**: The WAF Bot Control rule `TGT_VolumetricIpTokenAbsent` was issuing 202 Challenge responses to exhibition file requests (`/api/exhibits/files/*`) when a user's WAF token was absent or expired. OSD's `<img>` element and PDF.js's XHR cannot process a 202 HTML challenge — they see a non-image/non-200 response and fail. Confirmed via WAF sampled requests showing fullsize exhibition images being challenged.
- **WAF fix (already live)**: Added `/api/exhibits/files/` to the `Allow-Next-Static` WAF rule, bypassing Bot Control for these public static assets — same approach as `/_next/static/` and `/static/`.
- **This PR**: PDF.js 2.5.5 also needs `'unsafe-eval'` in `script-src` for Type3/custom font compilation via `new Function()`. Previously the same strict CSP applied to all routes including `/static/pdfjs/web/viewer.html`. This PR scopes a relaxed CSP to `/static/pdfjs/*` only, keeping the strict policy everywhere else. The main rule uses a negative lookahead on the path so browsers don't AND-combine both policies.

## Test plan

- [ ] Load `https://dp.la/exhibitions/erie-canal/why-new-york` and click all three thumbnails — first image, second image, and PDF — confirm all load without console errors
- [ ] Confirm `/static/pdfjs/web/viewer.html` response headers include `'unsafe-eval'` in `script-src`
- [ ] Confirm a non-pdfjs page (e.g. `/search`) response headers do NOT include `'unsafe-eval'`
- [ ] Check other exhibition pages with PDFs (e.g. `america-world-war-i`, `japanese-internment`) for the same

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

**PDF.js font rendering fix via scoped CSP relaxation**

This PR scopes the Content-Security-Policy relaxation required by PDF.js 2.5.5 to the /static/pdfjs/* subtree so only PDF.js assets receive script-src 'unsafe-eval'. The stricter site-wide CSP remains in place for all other pages. It complements a deployed WAF change that bypasses Bot Control for /api/exhibits/files/ to prevent 202 challenge HTML from breaking image/PDF loads.

## Technical Implementation

- Introduced CSP_DIRECTIVES array and rebuilt CSP from it.
- Created CSP_PDFJS by adding 'unsafe-eval' only to the script-src directive; used for PDF.js assets.
- Updated Next.js headers() to:
  - Serve the strict CSP for requests that do not match the /static/pdfjs subtree using a tightened negative lookahead: "/((?!static/pdfjs(?:/|$)).*)".
  - Serve CSP_PDFJS for "/static/pdfjs/:path*" so the relaxed header only applies to that subtree and both CSP headers do not both fire.
- Removed experimental.instrumentationHook from the Next.js config.
- Updated scripts/check-csp.js to extract CSP_DIRECTIVES (regex now matches const CSP_DIRECTIVES = [...]).

Commit message clarifies the negative lookahead was tightened to a non-capturing group (?:/|$) to avoid accidental exclusion of sibling paths like /static/pdfjs2.

## Test plan

- Load an exhibition page and open thumbnails/PDFs; confirm no console CSP or PDF.js errors.
- Verify /static/pdfjs/web/viewer.html responses include Content-Security-Policy with 'unsafe-eval'.
- Verify non-pdfjs pages (e.g., /search) do not include 'unsafe-eval'.
- Check other exhibition pages with PDFs/images to confirm they are not challenged.

## Security & Infrastructure Notes

- Security implication: CSP is relaxed only for /static/pdfjs/* to allow PDF.js font compilation; site-wide CSP remains strict elsewhere.
- WAF change already deployed: /api/exhibits/files/ added to Allow-Next-Static to bypass Bot Control for public static assets.
- No environment variable or AWS Secrets Manager changes.
- No database migrations.
- No shared infra (CodePipeline/CodeBuild/ECS task definitions/IAM) changes.
- No public API shape changes or endpoint additions/removals.
- Deployment: standard Next.js deployment; no special manual pipeline trigger or ECS redeploy beyond normal deployment.

## Lines Changed (summary)

- next.config.js: CSP refactor, CSP_PDFJS addition, tightened header negative lookahead, headers() update, removed experimental.instrumentationHook.
- scripts/check-csp.js: regex update to read CSP_DIRECTIVES.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->