### PR TITLE
fix(depictassist): restore queue and image state after OAuth login

### DIFF
--- a/pages/api/wikimedia/oauth.js
+++ b/pages/api/wikimedia/oauth.js
@@ -10,6 +10,8 @@ const TOKEN_ENDPOINT = `${COMMONS_BASE}/rest.php/oauth2/access_token`;
 const COMMONS_API = `${COMMONS_BASE}/api.php`;
 const TOKEN_COOKIE = 'wm_access_token';
 const STATE_COOKIE = 'wm_oauth_state';
+const RETURN_TO_COOKIE = 'wm_return_to';
+const DEPICTASSIST_PATH = '/projects/dpla-wikimedia/depictassist';
 const FETCH_TIMEOUT_MS = 5000;
 const CALLBACK_PATH = '/api/wikimedia/oauth?action=callback';
 const REDIRECT_BASE = process.env.WIKIMEDIA_OAUTH_REDIRECT_BASE?.trim().replace(/\/+$/, '');
@@ -45,12 +47,23 @@ export default async function handler(req, res) {
 
 function handleLogin(req, res) {
   const state = crypto.randomBytes(16).toString('hex');
+  const rawReturnTo = typeof req.query.returnTo === 'string' ? req.query.returnTo : '';
+  const safeReturnTo = /^\/projects\/dpla-wikimedia\/depictassist(\?|$)/.test(rawReturnTo)
+    ? rawReturnTo
+    : DEPICTASSIST_PATH;
 
-  setCookie(res, [{
-    name: STATE_COOKIE,
-    value: state,
-    options: { httpOnly: true, secure: true, sameSite: 'Lax', path: '/', maxAge: 300 }
-  }]);
+  setCookie(res, [
+    {
+      name: STATE_COOKIE,
+      value: state,
+      options: { httpOnly: true, secure: true, sameSite: 'Lax', path: '/', maxAge: 300 }
+    },
+    {
+      name: RETURN_TO_COOKIE,
+      value: safeReturnTo,
+      options: { httpOnly: true, secure: true, sameSite: 'Lax', path: '/', maxAge: 300 }
+    }
+  ]);
 
   const params = new URLSearchParams({
     response_type: 'code',
@@ -73,6 +86,8 @@ async function handleCallback(req, res) {
   if (!state || !expectedState || state !== expectedState) {
     return res.status(403).json({ error: 'Invalid OAuth state' });
   }
+
+  const returnTo = req.cookies?.[RETURN_TO_COOKIE] || DEPICTASSIST_PATH;
 
   try {
     const body = new URLSearchParams({
@@ -113,10 +128,15 @@ async function handleCallback(req, res) {
         name: STATE_COOKIE,
         value: '',
         options: { httpOnly: true, secure: true, sameSite: 'Lax', path: '/', maxAge: 0 }
+      },
+      {
+        name: RETURN_TO_COOKIE,
+        value: '',
+        options: { httpOnly: true, secure: true, sameSite: 'Lax', path: '/', maxAge: 0 }
       }
     ]);
 
-    res.redirect(302, '/projects/dpla-wikimedia/depictassist');
+    res.redirect(302, returnTo);
   } catch (err) {
     console.error('OAuth callback error:', err);
     return res.status(502).json({ error: 'Token exchange failed' });

--- a/pages/api/wikimedia/oauth.js
+++ b/pages/api/wikimedia/oauth.js
@@ -16,6 +16,12 @@ const FETCH_TIMEOUT_MS = 5000;
 const CALLBACK_PATH = '/api/wikimedia/oauth?action=callback';
 const REDIRECT_BASE = process.env.WIKIMEDIA_OAUTH_REDIRECT_BASE?.trim().replace(/\/+$/, '');
 
+function isAllowedReturnTo(path) {
+  return typeof path === 'string' &&
+    path.startsWith(DEPICTASSIST_PATH) &&
+    (path.length === DEPICTASSIST_PATH.length || path[DEPICTASSIST_PATH.length] === '?');
+}
+
 function getCallbackUrl(req) {
   if (REDIRECT_BASE) return REDIRECT_BASE + CALLBACK_PATH;
   const proto = req.headers['x-forwarded-proto'] || 'https';
@@ -48,9 +54,7 @@ export default async function handler(req, res) {
 function handleLogin(req, res) {
   const state = crypto.randomBytes(16).toString('hex');
   const rawReturnTo = typeof req.query.returnTo === 'string' ? req.query.returnTo : '';
-  const safeReturnTo = /^\/projects\/dpla-wikimedia\/depictassist(\?|$)/.test(rawReturnTo)
-    ? rawReturnTo
-    : DEPICTASSIST_PATH;
+  const safeReturnTo = isAllowedReturnTo(rawReturnTo) ? rawReturnTo : DEPICTASSIST_PATH;
 
   setCookie(res, [
     {
@@ -87,7 +91,8 @@ async function handleCallback(req, res) {
     return res.status(403).json({ error: 'Invalid OAuth state' });
   }
 
-  const returnTo = req.cookies?.[RETURN_TO_COOKIE] || DEPICTASSIST_PATH;
+  const rawReturnTo = req.cookies?.[RETURN_TO_COOKIE] || '';
+  const returnTo = isAllowedReturnTo(rawReturnTo) ? rawReturnTo : DEPICTASSIST_PATH;
 
   try {
     const body = new URLSearchParams({

--- a/public/static/depictassist/README.md
+++ b/public/static/depictassist/README.md
@@ -111,7 +111,7 @@ staging or local dev), set the explicit override.
 CloudFront's default cache behavior strips cookies before forwarding requests to
 the origin. The `/api/wikimedia/*` paths must have a custom cache behavior that:
 
-- **Whitelists these cookies for forwarding**: `wm_access_token`, `wm_oauth_state`
+- **Whitelists these cookies for forwarding**: `wm_access_token`, `wm_oauth_state`, `wm_return_to`
 - **Allows all HTTP methods** (HEAD, GET, DELETE, POST, PUT, PATCH, OPTIONS)
 - **Disables caching** (MinTTL = DefaultTTL = MaxTTL = 0)
 - **Forwards the query string** (needed by the OAuth and commons proxy routes)
@@ -156,6 +156,7 @@ User                 pro.dp.la (Next.js)          Commons (Wikimedia)
 | Cookie | httpOnly | Secure | SameSite | Max-Age | Purpose |
 |--------|----------|--------|----------|---------|---------|
 | `wm_oauth_state` | ✓ | ✓ | Lax | 300 s | CSRF protection for the OAuth callback |
+| `wm_return_to` | ✓ | ✓ | Lax | 300 s | Post-login redirect path (must be in CloudFront forwarding list) |
 | `wm_access_token` | ✓ | ✓ | Strict | 4 hours | Bearer token for authenticated API calls |
 
 `SameSite=Lax` on the state cookie is intentional: the OAuth callback is a

--- a/public/static/depictassist/depictassist.js
+++ b/public/static/depictassist/depictassist.js
@@ -121,10 +121,10 @@
     let saved;
     try {
       const raw = sessionStorage.getItem(LOGIN_STATE_KEY);
-      if (!raw) return;
+      if (!raw) return false;
       saved = JSON.parse(raw);
       sessionStorage.removeItem(LOGIN_STATE_KEY);
-    } catch { return; }
+    } catch { return false; }
 
     if (!saved || (!saved.imageData && (!Array.isArray(saved.queue) || !saved.queue.length))) return false;
 

--- a/public/static/depictassist/depictassist.js
+++ b/public/static/depictassist/depictassist.js
@@ -11,10 +11,12 @@
   const MAX_SUGGESTIONS = 6;
   // Wikidata item for "based on heuristic" — used as reference (P887) on depicts claims
   const BASED_ON_HEURISTIC_QID = 114065533;
+  const LOGIN_STATE_KEY = 'da_login_state';
 
   // ── State ────────────────────────────────────────────────
   let queue = [];           // { mid, prop, qid, label, filename, subjectTerm, dplaUrl }[]
   let currentMid = null;    // MID of the image currently displayed
+  let currentImageData = null; // full displayImage() args, saved for post-login restore
   let pendingQid = null;    // QID from URL, awaiting institution load
   let isAuthenticated = false;
   let fetchingImages = false;
@@ -46,12 +48,14 @@
     boundWrapper = wrapper;
     queue = [];
     currentMid = null;
+    currentImageData = null;
     isAuthenticated = false;
     fetchingImages = false;
     submittingBatch = false;
 
     cacheDom();
     bindEvents();
+    restoreLoginState();
     loadAuth();
     loadInstitutions();
     restoreFromUrl();
@@ -111,6 +115,37 @@
   function restoreFromUrl() {
     const qid = new URLSearchParams(window.location.search).get('id');
     if (qid) pendingQid = qid;
+  }
+
+  function restoreLoginState() {
+    let saved;
+    try {
+      const raw = sessionStorage.getItem(LOGIN_STATE_KEY);
+      if (!raw) return;
+      saved = JSON.parse(raw);
+      sessionStorage.removeItem(LOGIN_STATE_KEY);
+    } catch { return; }
+
+    if (!saved || !Array.isArray(saved.queue) || saved.queue.length === 0) return;
+
+    queue = saved.queue;
+
+    if (saved.imageData) {
+      displayImage(saved.imageData);
+      // Re-apply selected state for chips that are in the restored queue
+      for (const item of queue) {
+        const chip = $tagSuggestions.querySelector(
+          '[data-mid="' + item.mid + '"][data-qid="' + item.qid + '"]'
+        );
+        if (chip) {
+          chip.classList.add('da-tag-selected');
+          chip.disabled = true;
+          chip.setAttribute('aria-label', 'Remove depicts tag: ' + item.label);
+        }
+      }
+    }
+
+    renderQueue();
   }
 
   function selectInstitutionByQid(qid) {
@@ -374,6 +409,7 @@
 
   function displayImage({ mid, imgUrl, title, filename, description, subjectName, dplaUrl, tagSuggestions }) {
     currentMid = mid;
+    currentImageData = { mid, imgUrl, title, filename, description, subjectName, dplaUrl, tagSuggestions };
     updateSkipButton();
     showImageState('image');
 
@@ -580,7 +616,14 @@
   }
 
   function onLogin() {
-    window.location.href = OAUTH_BASE + '?action=login';
+    const returnTo = window.location.pathname + window.location.search;
+    try {
+      sessionStorage.setItem(LOGIN_STATE_KEY, JSON.stringify({
+        queue,
+        imageData: currentImageData,
+      }));
+    } catch { /* ignore — storage may be unavailable */ }
+    window.location.href = OAUTH_BASE + '?action=login&returnTo=' + encodeURIComponent(returnTo);
   }
 
   async function onLogout() {

--- a/public/static/depictassist/depictassist.js
+++ b/public/static/depictassist/depictassist.js
@@ -55,10 +55,10 @@
 
     cacheDom();
     bindEvents();
-    restoreLoginState();
+    const restoredLoginState = restoreLoginState();
     loadAuth();
     loadInstitutions();
-    restoreFromUrl();
+    if (!restoredLoginState) restoreFromUrl();
   };
 
   // If the script loads after the page component has already called onReady,
@@ -126,26 +126,25 @@
       sessionStorage.removeItem(LOGIN_STATE_KEY);
     } catch { return; }
 
-    if (!saved || !Array.isArray(saved.queue) || saved.queue.length === 0) return;
+    if (!saved || (!saved.imageData && (!Array.isArray(saved.queue) || !saved.queue.length))) return false;
 
-    queue = saved.queue;
+    queue = Array.isArray(saved.queue) ? saved.queue : [];
 
     if (saved.imageData) {
       displayImage(saved.imageData);
-      // Re-apply selected state for chips that are in the restored queue
       for (const item of queue) {
         const chip = $tagSuggestions.querySelector(
           '[data-mid="' + item.mid + '"][data-qid="' + item.qid + '"]'
         );
         if (chip) {
           chip.classList.add('da-tag-selected');
-          chip.disabled = true;
           chip.setAttribute('aria-label', 'Remove depicts tag: ' + item.label);
         }
       }
     }
 
     renderQueue();
+    return true;
   }
 
   function selectInstitutionByQid(qid) {


### PR DESCRIPTION
## Summary

- Saves the batch queue and current image to `sessionStorage` immediately before the OAuth login redirect
- Threads the return-to path through a short-lived httpOnly cookie (`wm_return_to`) so the callback redirects back to the same URL (preserving any `?id=` param)
- On page load after OAuth callback, `restoreLoginState()` reads the saved state, re-renders the image, re-applies chip selection, and restores the queue list before `loadAuth()` fires

## Infrastructure note

`wm_return_to` must be added to the CloudFront cookie forwarding whitelist for `/api/wikimedia/*` (alongside `wm_access_token` and `wm_oauth_state`). The README has been updated to document this.

## Test plan

- [ ] Load DepictAssist, select an institution, wait for an image to load, click some tags into the queue — then click Log In
- [ ] Complete the Wikimedia OAuth flow — confirm you're returned to the same page (not the bare `/depictassist` root), with the queue intact and the image still showing with chips correctly selected
- [ ] Confirm that without a saved queue (fresh login with no tags queued), login works normally and lands on the depictassist page
- [ ] Confirm the `wm_return_to` cookie is cleared after the callback redirect (check DevTools → Application → Cookies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes queue and image state loss after Wikimedia OAuth login in DepictAssist by persisting a short-lived return path in an httpOnly cookie and saving the client-side queue + current image to sessionStorage before redirecting to OAuth; after the OAuth callback and page load the client restores the saved state and re-renders the image and selected chips.

### Changes

Backend OAuth Handler (pages/api/wikimedia/oauth.js)
- Adds RETURN_TO_COOKIE = "wm_return_to" and DEPICTASSIST_PATH default.
- handleLogin:
  - Accepts optional req.query.returnTo and validates it with an allowlist regex limited to /projects/dpla-wikimedia/depictassist.
  - Sets wm_return_to httpOnly cookie (Secure, SameSite=Lax, path=/, maxAge=300) with the validated return path alongside existing wm_oauth_state cookie.
- handleCallback:
  - Reads return destination from wm_return_to cookie (falls back to DEPICTASSIST_PATH).
  - Expires wm_return_to when clearing state/token cookies.
  - Redirects to the computed returnTo after successful token exchange.
- No exported/public signatures changed.

Frontend State Restoration (public/static/depictassist/depictassist.js)
- Adds LOGIN_STATE_KEY = 'da_login_state' and module-level currentImageData to capture full displayImage(...) args.
- onLogin(): Saves { queue, imageData: currentImageData } into sessionStorage (best-effort) and appends a returnTo query parameter to the OAuth redirect URL.
- restoreLoginState(): Reads and removes da_login_state from sessionStorage, restores queue, re-renders saved.imageData via displayImage(saved.imageData), reapplies tag chip selection (including ARIA updates), calls renderQueue(), and returns a boolean to control init flow.
- displayImage(...) stores currentImageData on each render.
- initDepictAssist calls restoreLoginState() before loadAuth() and skips restoreFromUrl() when restore succeeds.

Documentation (public/static/depictassist/README.md)
- Updates CloudFront cookie-forwarding documentation and cookie table to include wm_return_to (httpOnly, Secure, SameSite=Lax, max-age=300) alongside wm_access_token and wm_oauth_state.

### Security Implications
- Mitigates open-redirect risk by validating returnTo against a strict allowlist restricted to the DepictAssist path.
- Uses httpOnly and Secure cookies; state and return-to cookies use SameSite=Lax (to permit top-level OAuth redirect), access token uses SameSite=Strict.
- Session state is stored in sessionStorage (client-side, ephemeral); no token values are exposed to JS.

### Infrastructure / Deployment Notes
- Requires a shared CloudFront configuration change: add wm_return_to to the forwarded cookie allowlist for /api/wikimedia/* alongside wm_access_token and wm_oauth_state. This change is necessary for the OAuth callback redirect to return to the saved path.
- No environment variables or AWS Secrets Manager keys were added, removed, or renamed.
- No database migrations.
- No changes to CodePipeline/CodeBuild/ECS task definitions/IAM policies in the PR itself.
- No public API response shapes or endpoints were added/removed.
- Deployment note: applying the CloudFront cookie-forwarding change (and verifying distribution behavior) is required; no application code redeploy is strictly required for the code to work once CloudFront forwards the cookie, but validate the distribution and consider cache/invalidation as needed.

### Testing / Manual QA
- Load DepictAssist, select an institution, wait for an image, queue tags, click Log In, complete Wikimedia OAuth — confirm return to the same page with queue intact and image/chips restored.
- Verify normal login behavior when no saved queue exists (fresh login).
- Confirm wm_return_to cookie is cleared after the callback redirect (DevTools → Application → Cookies).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->