### PR TITLE
feat(depictassist): replace server OAuth with client-side PKCE + Toolforge proxy

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -59,7 +59,7 @@ const CSP_DIRECTIVES = [
   "default-src 'self'",
   "script-src 'self' 'sha256-sYQvVdNrbb2ldJRpproLbB3h5LhCcbCA1SUM1wTfomI=' 'sha256-uZYgrdXqFswjbPEZxW2e6bv+djcz8D4kcJKjWyznRmk=' 'sha256-R7BycX6lCwOq9x3CZpytPnOyYvDNpLs38i6qKfpCcVY=' *.google-analytics.com *.googletagmanager.com *.sentry.io https://*.awswaf.com https://www.gstatic.com",
   "img-src 'self' http: https:",
-  `connect-src 'self' https://dp.la https://*.dp.la ${CLOUDFRONT_MEDIA} *.google-analytics.com *.analytics.google.com *.sentry.io https://*.awswaf.com https://www.gstatic.com https://gitlab.wikimedia.org https://commons.wikimedia.org https://wikimedia.org https://wikidata.reconci.link https://wikidata-reconciliation.wmcloud.org https://raw.githubusercontent.com https://meta.wikimedia.org https://www.wikidata.org`,
+  `connect-src 'self' https://dp.la https://*.dp.la ${CLOUDFRONT_MEDIA} *.google-analytics.com *.analytics.google.com *.sentry.io https://*.awswaf.com https://www.gstatic.com https://gitlab.wikimedia.org https://commons.wikimedia.org https://wikimedia.org https://wikidata.reconci.link https://wikidata-reconciliation.wmcloud.org https://raw.githubusercontent.com https://meta.wikimedia.org https://www.wikidata.org https://depictassist.toolforge.org`,
   "style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://www.gstatic.com",
   "font-src 'self' https://cdnjs.cloudflare.com",
   `media-src 'self' *.dp.la ${CLOUDFRONT_MEDIA}`,

--- a/public/static/depictassist/README.md
+++ b/public/static/depictassist/README.md
@@ -32,7 +32,7 @@ Wikimedia Commons images contributed by DPLA institutions. Hosted at
 The Toolforge proxy is a separate Node.js service at
 `https://depictassist.toolforge.org/api` maintained in the
 [toolforge-repos/depictassist](https://gitlab.wikimedia.org/toolforge-repos/depictassist)
-repository. See [notes/toolforge-depictassist.md] for deploy instructions.
+repository. See `~/.claude/notes/toolforge-depictassist.md` for deploy instructions.
 
 ## Architecture
 

--- a/public/static/depictassist/README.md
+++ b/public/static/depictassist/README.md
@@ -26,178 +26,176 @@ Wikimedia Commons images contributed by DPLA institutions. Hosted at
 | `depictassist.css` | Scoped styles (all selectors under `.depictassist-wrapper`) |
 | `README.md` | This file |
 | `pages/projects/dpla-wikimedia/depictassist.js` | Next.js page component — HTML shell, server-side menu fetch |
-| `pages/api/wikimedia/oauth.js` | OAuth 2.0 server route — login, callback, whoami, logout |
-| `pages/api/wikimedia/commons.js` | Server-side proxy for authenticated Commons API calls |
-| `lib/setCookie.js` | Shared cookie-serialization utility used by the OAuth route |
+| `pages/api/wikimedia/oauth.js` | Legacy server OAuth routes — superseded by client-side PKCE; pending removal |
+| `pages/api/wikimedia/commons.js` | Legacy server Commons proxy — superseded by Toolforge proxy; pending removal |
 
-## Architecture: why the proxy exists
+The Toolforge proxy is a separate Node.js service at
+`https://depictassist.toolforge.org/api` maintained in the
+[toolforge-repos/depictassist](https://gitlab.wikimedia.org/toolforge-repos/depictassist)
+repository. See [notes/toolforge-depictassist.md] for deploy instructions.
 
-Browser JavaScript cannot hold OAuth tokens safely — anything in JS is readable by
-XSS. Instead:
+## Architecture
 
-- The server exchanges the OAuth code for an access token and stores it in an
-  **httpOnly** cookie (`wm_access_token`). Browser JS never sees the token value.
-- All authenticated Commons API calls (fetching CSRF tokens, submitting edits) go
-  through `/api/wikimedia/commons`, a Next.js API route that reads the token from
-  the cookie and forwards requests to Commons with `Authorization: Bearer <token>`.
-- The client only ever talks to its own origin (`pro.dp.la`); Commons is contacted
-  only from the server.
+The DPLA pro site runs on AWS (ECS). The `98.94.0.0/16` AWS IP range is blocked by
+Wikimedia's global range block, which prevents the server from making authenticated
+Commons API calls on behalf of volunteers.
 
-This also avoids CORS problems: server-to-server calls do not need a Commons CORS
-`origin` parameter (which Commons rejects on authenticated OAuth requests anyway).
+The solution has two parts:
+
+1. **Client-side PKCE OAuth 2.0**: The browser handles the OAuth flow directly
+   using the [PKCE](https://www.rfc-editor.org/rfc/rfc7636) extension for public
+   clients. There is no `client_secret` and the access token is stored in
+   `localStorage` (never sent to the DPLA server).
+
+2. **Toolforge proxy**: Browser requests that need a Commons API call go through
+   `https://depictassist.toolforge.org/api`, a small Express app running on
+   [Toolforge](https://wikitech.wikimedia.org/wiki/Portal:Toolforge) — Wikimedia's
+   own hosting platform, whose IPs are explicitly exempt from range blocks. The
+   browser sends its Bearer token in an `Authorization` header; the proxy forwards
+   it to `commons.wikimedia.org/w/api.php`.
+
+Unauthenticated read calls (image search, entity data, reconciliation) continue to
+be made directly from the browser as before — they do not need the token.
 
 ## External APIs
 
 | API | Called from | Auth | Purpose |
 |-----|-------------|------|---------|
-| Wikimedia Commons Action API (`commons.wikimedia.org/w/api.php`) | **Server** (via proxy) | Bearer token | CSRF tokens, `wbeditentity` edits |
-| Wikimedia Commons Action API | **Client** (unauthenticated) | None | CirrusSearch for images, image info |
+| Toolforge proxy (`depictassist.toolforge.org/api`) | **Client** | Bearer token | CSRF tokens, `wbeditentity` edits |
+| Wikimedia Commons Action API (`commons.wikimedia.org/w/api.php`) | **Client** (unauthenticated) | None | CirrusSearch for images, image info |
 | Wikidata Reconciliation API (`wikidata.reconci.link/en/api`) | **Client** | None | Tag suggestions from subject text |
 | GitHub Raw (`raw.githubusercontent.com`) | **Client** | None | Institution list (`institutions_v2.json`) |
-| Wikimedia OAuth 2.0 authorize (`/w/rest.php/oauth2/authorize`) | **Client** (browser redirect) | None | User login + consent UI |
-| Wikimedia OAuth 2.0 token (`/w/rest.php/oauth2/access_token`) | **Server** | Client secret | Authorization code → access token exchange |
-
-Note: the unauthenticated Commons calls (image search, image info) are made
-directly from the browser, not through the proxy, because they don't need the token
-and are read-only.
+| Wikimedia OAuth 2.0 authorize (`/w/rest.php/oauth2/authorize`) | **Client** (browser redirect) | — | User login + consent UI |
+| Wikimedia OAuth 2.0 token (`/w/rest.php/oauth2/access_token`) | **Client** (PKCE exchange) | PKCE verifier | Authorization code → access token |
 
 ## OAuth setup
 
-### 1. Register a Wikimedia OAuth consumer
+### 1. Register a Wikimedia OAuth 2.0 consumer
 
 Go to
 [meta.wikimedia.org/wiki/Special:OAuthConsumerRegistration](https://meta.wikimedia.org/wiki/Special:OAuthConsumerRegistration)
-and register a new consumer with these settings:
+and register a **public** consumer with these settings:
 
 | Setting | Value |
 |---------|-------|
 | Version | OAuth 2.0 |
 | Project | `commons.wikimedia.org` |
-| Grants | Whatever grants the consumer was registered with (e.g. `editpage`) |
-| Callback URL | `https://pro.dp.la/api/wikimedia/oauth?action=callback` |
-| Consumer type | Confidential (server-side) |
+| Consumer type | **Public** (PKCE — no client secret) |
+| Grants | "Edit existing pages" |
+| Callback URL | `https://pro.dp.la/projects/dpla-wikimedia/depictassist` |
 
-The callback URL must match exactly including the `?action=callback` query string.
-Wikimedia will provide a **Client ID** and a **Client Secret**.
+The callback URL must match exactly. Wikimedia will provide a **Client ID** only
+(public consumers have no secret). Update the `WIKIMEDIA_CLIENT_ID` constant in
+`depictassist.js` with the registered ID. The consumer requires steward approval
+before it becomes usable.
 
-The authorization request does **not** send a `scope` parameter — the token
-inherits whatever grants the consumer was registered with on Wikimedia. Do not
-add a `scope` parameter to the authorization URL unless you have confirmed it
-exactly matches the consumer's registered grants; a mismatch causes Wikimedia to
-reject the authorization code exchange.
+### 2. No server environment variables required
 
-### 2. Set environment variables
+Because the token exchange happens in the browser (PKCE) and authenticated API
+calls go through the Toolforge proxy, no Wikimedia credentials need to be stored
+on the DPLA server. The `WIKIMEDIA_OAUTH_CLIENT_ID` and `WIKIMEDIA_OAUTH_CLIENT_SECRET`
+environment variables used by the legacy `oauth.js` route are no longer needed.
 
-Add to the server environment (not committed to git):
+### 3. CloudFront cookie forwarding no longer needed for DepictAssist
 
-```bash
-WIKIMEDIA_OAUTH_CLIENT_ID=<from Wikimedia registration>
-WIKIMEDIA_OAUTH_CLIENT_SECRET=<from Wikimedia registration>
-```
-
-Optional override if the server cannot detect its own public hostname:
-
-```bash
-WIKIMEDIA_OAUTH_REDIRECT_BASE=https://pro.dp.la
-```
-
-If `WIKIMEDIA_OAUTH_REDIRECT_BASE` is not set, the callback URL is inferred from
-the incoming request's `x-forwarded-proto` and `x-forwarded-host` headers. This
-works correctly behind the CloudFront + ALB setup, but if it ever breaks (e.g.
-staging or local dev), set the explicit override.
-
-### 3. CloudFront cookie forwarding
-
-CloudFront's default cache behavior strips cookies before forwarding requests to
-the origin. The `/api/wikimedia/*` paths must have a custom cache behavior that:
-
-- **Whitelists these cookies for forwarding**: `wm_access_token`, `wm_oauth_state`, `wm_return_to`
-- **Allows all HTTP methods** (HEAD, GET, DELETE, POST, PUT, PATCH, OPTIONS)
-- **Disables caching** (MinTTL = DefaultTTL = MaxTTL = 0)
-- **Forwards the query string** (needed by the OAuth and commons proxy routes)
-
-Without this, the Next.js API routes receive empty `req.cookies` and every
-authenticated request returns 401.
+The previous architecture required the `/api/wikimedia/*` paths to have a custom
+CloudFront cache behavior that forwarded `wm_access_token`, `wm_oauth_state`, and
+`wm_return_to` cookies. That is no longer needed — the token lives in `localStorage`
+and never touches the DPLA server.
 
 ## The OAuth flow, step by step
 
 ```text
-User                 pro.dp.la (Next.js)          Commons (Wikimedia)
- |                         |                              |
- |-- click "Log in" ------>|                              |
- |                         |-- generate state, set -----> |
- |                         |   wm_oauth_state cookie      |
- |<-- 302 redirect --------|                              |
- |                         |                              |
- |-- GET /w/rest.php/oauth2/authorize ----------------->  |
- |<-- Wikimedia login + approve dialog ----------------   |
- |-- approve ------------------------------------------>  |
- |<-- 302 redirect to /api/wikimedia/oauth?action=callback&code=X&state=Y
- |                         |                              |
- |-- GET callback -------->|                              |
- |                         |-- validate state vs cookie   |
- |                         |-- POST /oauth2/access_token->|
- |                         |<-- { access_token: "..." } --|
- |                         |-- set wm_access_token cookie |
- |                         |-- clear wm_oauth_state cookie|
- |<-- 302 to /depictassist-|                              |
- |                         |                              |
- |-- submit batch -------->|                              |
- |   POST /api/wikimedia/commons                          |
- |   (cookie sent automatically)                          |
- |                         |-- read wm_access_token cookie|
- |                         |-- POST wbeditentity -------> |
- |                         |<-- edit result --------------|
- |<-- edit result (JSON) --|                              |
+User (browser)              Wikimedia                  Toolforge proxy
+      |                         |                              |
+      |-- click "Log in"        |                              |
+      |   generatePkce()        |                              |
+      |   store verifier in     |                              |
+      |   sessionStorage        |                              |
+      |                         |                              |
+      |-- GET /oauth2/authorize?code_challenge=… -->           |
+      |<-- Wikimedia login + approve dialog ------             |
+      |-- approve ------------------------------------>        |
+      |<-- 302 to /depictassist?code=X&state=Y ----            |
+      |                         |                              |
+      |   handleOAuthCallback() |                              |
+      |   validate state        |                              |
+      |-- POST /oauth2/access_token?code_verifier=… -------->  |  (direct to Wikimedia)
+      |<-- { access_token: "..." } ----------------------      |
+      |   store token in localStorage                          |
+      |                         |                              |
+      |-- submit batch          |                              |
+      |-- GET /api?action=query&meta=tokens                --> |
+      |   Authorization: Bearer <token>                        |
+      |                         |         -- GET api.php -->   |
+      |                         |         <-- CSRF token --    |
+      |<-- CSRF token ---------------------------------------- |
+      |                         |                              |
+      |-- POST /api (wbeditentity)                         --> |
+      |   Authorization: Bearer <token>                        |
+      |                         |         -- POST api.php --> |
+      |                         |         <-- edit result --  |
+      |<-- edit result (JSON) ----------------------------     |
 ```
 
-### Cookies
+## Token storage
 
-| Cookie | httpOnly | Secure | SameSite | Max-Age | Purpose |
-|--------|----------|--------|----------|---------|---------|
-| `wm_oauth_state` | ✓ | ✓ | Lax | 300 s | CSRF protection for the OAuth callback |
-| `wm_return_to` | ✓ | ✓ | Lax | 300 s | Post-login redirect path (must be in CloudFront forwarding list) |
-| `wm_access_token` | ✓ | ✓ | Strict | 4 hours | Bearer token for authenticated API calls |
+The access token is stored in `localStorage` under the key `da_access_token` as a
+JSON object:
 
-`SameSite=Lax` on the state cookie is intentional: the OAuth callback is a
-top-level navigation arriving from `commons.wikimedia.org`, and `SameSite=Strict`
-would suppress the cookie on that cross-site redirect, breaking state validation.
+```json
+{ "token": "...", "expiry": 1714000000000 }
+```
 
-`SameSite=Strict` on the token cookie ensures it is never sent in any cross-site
-context — only same-site requests from `pro.dp.la` can use it.
+The expiry is computed from the `expires_in` field in the Wikimedia token response
+(default 4 hours if not provided). `getStoredToken()` returns `null` and removes
+the entry if the token has expired.
+
+PKCE state (verifier + random `state` value) is stored temporarily in
+`sessionStorage` under `da_pkce_state` and removed immediately upon callback.
+
+## The Toolforge proxy in detail
+
+`https://depictassist.toolforge.org/api` is a narrow allowlist proxy:
+
+| Method | Allowed `action` values | What it's used for |
+|--------|------------------------|---------------------|
+| GET | `query` | Fetch CSRF token (`meta=tokens`), check userinfo (`meta=userinfo`) |
+| POST | `wbeditentity` | Add P180 depicts claims to a Commons media file |
+
+Any other `action` value returns HTTP 400. Any request without an
+`Authorization: Bearer <token>` header returns HTTP 401.
+
+CORS is restricted to `https://pro.dp.la`. The proxy adds
+`Access-Control-Allow-Origin: https://pro.dp.la` to every response, including
+OPTIONS preflight responses.
+
+Source lives at `~/github/toolforge-depictassist/`. To deploy updates, see
+`~/.claude/notes/toolforge-depictassist.md`.
 
 ### CSRF tokens and the OAuth pseudotoken
 
 Wikimedia's MediaWiki Action API requires a CSRF token for writes. To get one, the
-client calls `/api/wikimedia/commons?action=query&meta=tokens` through the proxy.
+client calls the Toolforge proxy with `action=query&meta=tokens&type=csrf`.
 
 For OAuth 2.0 Bearer-authenticated requests, MediaWiki always returns `+\` as the
 CSRF token. This is the **valid pseudotoken for OAuth flows** — it should be
 passed as-is in the `token` field of subsequent write requests. Do not reject it.
-(Earlier code had a check `csrfToken === '+\\'` that wrongly treated this as an
-error; it has been removed.)
 
-## The commons proxy in detail
+## CSP requirements
 
-`pages/api/wikimedia/commons.js` is a narrow allowlist proxy:
+Configured in `next.config.js`. DepictAssist requires these origins in `connect-src`:
 
-| Method | Allowed `action` values | What it's used for |
-|--------|------------------------|---------------------|
-| GET | `query` | Fetch CSRF token (`meta=tokens`), check userinfo |
-| POST | `wbeditentity` | Add P180 depicts claims to a Commons media file |
+- `https://commons.wikimedia.org` — unauthenticated image search and info calls; OAuth authorize redirect
+- `https://wikidata.reconci.link` — tag reconciliation
+- `https://raw.githubusercontent.com` — institution list
+- `https://meta.wikimedia.org` — required by some Wikimedia analytics
+- `https://www.wikidata.org` — entity page links shown in the UI
+- `https://wikimedia.org` — Wikimedia analytics
+- `https://depictassist.toolforge.org` — Toolforge proxy for authenticated Commons API calls
 
-Any other `action` value returns HTTP 400. Any request without a valid
-`wm_access_token` cookie returns HTTP 401.
-
-The proxy strips the internal `_proxy` query parameter (added by client code to
-avoid caching) before forwarding. It does not forward the `origin` parameter,
-which Commons rejects on OAuth Bearer requests.
-
-MediaWiki API-level errors (bad token, permission denied, invalid entity) are
-returned as HTTP 200 with an `error` field in the JSON body; the proxy logs
-these via `console.warn`. HTTP-level errors (rate limiting, server faults) are
-forwarded with their original status code and logged via `console.error`. Both
-appear in CloudWatch via ECS stdout.
+After adding any new external URL to the code, run `node scripts/check-csp.js` to
+verify coverage.
 
 ## Institution data
 
@@ -216,23 +214,6 @@ that institution is auto-selected once the dropdown finishes loading.
 | Parameter | Example | Description |
 |-----------|---------|-------------|
 | `id` | `?id=Q105281139` | Pre-selects an institution by Wikidata QID and starts a search |
-
-## CSP requirements
-
-Configured in `next.config.js`. DepictAssist requires these origins in `connect-src`:
-
-- `https://commons.wikimedia.org` — unauthenticated image search and info calls
-- `https://wikidata.reconci.link` — tag reconciliation
-- `https://raw.githubusercontent.com` — institution list
-- `https://meta.wikimedia.org` — required by some Wikimedia analytics
-- `https://www.wikidata.org` — entity page links shown in the UI
-- `https://wikimedia.org` — Wikimedia analytics
-
-The `form-action` directive must include `https://meta.wikimedia.org` for the OAuth
-authorization redirect (the browser navigates to Wikimedia to show the approval UI).
-
-After adding any new external URL to the code, run `node scripts/check-csp.js` to
-verify coverage.
 
 ## Non-obvious implementation details
 

--- a/public/static/depictassist/README.md
+++ b/public/static/depictassist/README.md
@@ -32,7 +32,7 @@ Wikimedia Commons images contributed by DPLA institutions. Hosted at
 The Toolforge proxy is a separate Node.js service at
 `https://depictassist.toolforge.org/api` maintained in the
 [toolforge-repos/depictassist](https://gitlab.wikimedia.org/toolforge-repos/depictassist)
-repository. See `~/.claude/notes/toolforge-depictassist.md` for deploy instructions.
+repository for source and deploy instructions.
 
 ## Architecture
 
@@ -170,8 +170,9 @@ CORS is restricted to `https://pro.dp.la`. The proxy adds
 `Access-Control-Allow-Origin: https://pro.dp.la` to every response, including
 OPTIONS preflight responses.
 
-Source lives at `~/github/toolforge-depictassist/`. To deploy updates, see
-`~/.claude/notes/toolforge-depictassist.md`.
+Source and deploy instructions are in the
+[toolforge-repos/depictassist](https://gitlab.wikimedia.org/toolforge-repos/depictassist)
+GitLab repository.
 
 ### CSRF tokens and the OAuth pseudotoken
 

--- a/public/static/depictassist/depictassist.js
+++ b/public/static/depictassist/depictassist.js
@@ -5,10 +5,8 @@
   const INSTITUTIONS_URL =
     'https://raw.githubusercontent.com/dpla/ingestion3/main/src/main/resources/wiki/institutions_v2.json';
   const COMMONS_API = 'https://commons.wikimedia.org/w/api.php';
-  // Toolforge proxy — runs on Wikimedia-trusted IPs, forwards requests to Commons api.php
   const TOOLFORGE_PROXY = 'https://depictassist.toolforge.org/api';
   const RECONCILIATION_API = 'https://wikidata.reconci.link/en/api';
-  // Wikimedia OAuth 2.0 PKCE — public consumer, token lives in browser only
   const WIKIMEDIA_CLIENT_ID = 'a46cd7bde5376cce96e454d80fb7d809';
   const WIKIMEDIA_AUTH_ENDPOINT = 'https://commons.wikimedia.org/w/rest.php/oauth2/authorize';
   const WIKIMEDIA_TOKEN_ENDPOINT = 'https://commons.wikimedia.org/w/rest.php/oauth2/access_token';
@@ -63,8 +61,6 @@
     cacheDom();
     bindEvents();
 
-    // When returning from Wikimedia OAuth the URL contains ?code=...&state=...
-    // handleOAuthCallback takes over the full init sequence in that case.
     const urlParams = new URLSearchParams(window.location.search);
     const oauthCode = urlParams.get('code');
     if (oauthCode) {
@@ -145,6 +141,8 @@
     if (!saved || (!saved.imageData && (!Array.isArray(saved.queue) || !saved.queue.length))) return false;
 
     queue = Array.isArray(saved.queue) ? saved.queue : [];
+
+    if (saved.institutionQid) pendingQid = saved.institutionQid;
 
     if (saved.imageData) {
       displayImage(saved.imageData);
@@ -584,6 +582,11 @@
 
   // ── Auth — PKCE OAuth 2.0 (token lives in browser only) ──
 
+  function clearSession() {
+    localStorage.removeItem(ACCESS_TOKEN_KEY);
+    showLoggedOut();
+  }
+
   function toUrlSafeBase64(bytes) {
     return btoa(String.fromCharCode.apply(null, bytes))
       .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
@@ -593,7 +596,6 @@
     return window.location.origin + window.location.pathname.replace(/\/$/, '');
   }
 
-  // Generates a PKCE code_verifier / code_challenge pair using SHA-256.
   async function generatePkce() {
     const array = new Uint8Array(32);
     crypto.getRandomValues(array);
@@ -632,8 +634,6 @@
     if (!restored) restoreFromUrl();
   }
 
-  // Called on page load when ?code=...&state=... are present in the URL
-  // (the browser has just returned from Wikimedia's authorization page).
   async function handleOAuthCallback(code, urlState) {
     let pkceData;
     try {
@@ -711,8 +711,8 @@
       });
 
       if (!resp.ok) {
-        if (resp.status === 401) localStorage.removeItem(ACCESS_TOKEN_KEY);
-        showLoggedOut();
+        if (resp.status === 401) clearSession();
+        else showLoggedOut();
         return;
       }
 
@@ -722,8 +722,7 @@
         isAuthenticated = true;
         showLoggedIn(userinfo.name);
       } else {
-        localStorage.removeItem(ACCESS_TOKEN_KEY);
-        showLoggedOut();
+        clearSession();
       }
     } catch {
       showLoggedOut();
@@ -749,6 +748,7 @@
       sessionStorage.setItem(LOGIN_STATE_KEY, JSON.stringify({
         queue,
         imageData: currentImageData,
+        institutionQid: $select.value || null,
       }));
     } catch { /* ignore — storage may be unavailable */ }
 
@@ -778,8 +778,7 @@
   }
 
   function onLogout() {
-    localStorage.removeItem(ACCESS_TOKEN_KEY);
-    showLoggedOut();
+    clearSession();
   }
 
   function isIpBlocked(apiError) {
@@ -790,10 +789,8 @@
   async function onSubmitBatch() {
     if (!isAuthenticated || queue.length === 0 || submittingBatch) return;
 
-    // Guard against token expiry between page load and submit
     const accessToken = getStoredToken();
     if (!accessToken) {
-      isAuthenticated = false;
       showLoggedOut();
       return;
     }
@@ -811,9 +808,7 @@
         headers: { 'Authorization': 'Bearer ' + accessToken }
       });
       if (tokenResp.status === 401) {
-        localStorage.removeItem(ACCESS_TOKEN_KEY);
-        isAuthenticated = false;
-        showLoggedOut();
+        clearSession();
         $batchErrorMsg.textContent = 'Your session expired. Please log in again.';
         $batchError.style.display = 'block';
         return;
@@ -845,6 +840,7 @@
       const diffs = [];
       const failures = [];
       const succeededMids = new Set();
+      let sessionExpired = false;
       for (const [mid, items] of byMid) {
         const claims = items.map(item => {
           const snaks = {
@@ -935,12 +931,9 @@
           body: body
         });
         if (editResp.status === 401) {
-          localStorage.removeItem(ACCESS_TOKEN_KEY);
-          isAuthenticated = false;
-          showLoggedOut();
-          $batchErrorMsg.textContent = 'Your session expired. Please log in again.';
-          $batchError.style.display = 'block';
-          return;
+          clearSession();
+          sessionExpired = true;
+          break;
         }
         if (!editResp.ok) {
           failures.push(mid);
@@ -981,7 +974,10 @@
         $results.style.display = 'block';
       }
 
-      if (failures.length > 0) {
+      if (sessionExpired) {
+        $batchErrorMsg.textContent = 'Your session expired. Please log in again.';
+        $batchError.style.display = 'block';
+      } else if (failures.length > 0) {
         const count = failures.length;
         if (ipBlockDetected) {
           $batchErrorMsg.textContent = IP_BLOCK_MSG;

--- a/public/static/depictassist/depictassist.js
+++ b/public/static/depictassist/depictassist.js
@@ -5,14 +5,20 @@
   const INSTITUTIONS_URL =
     'https://raw.githubusercontent.com/dpla/ingestion3/main/src/main/resources/wiki/institutions_v2.json';
   const COMMONS_API = 'https://commons.wikimedia.org/w/api.php';
-  const COMMONS_PROXY = '/api/wikimedia/commons';
+  // Toolforge proxy — runs on Wikimedia-trusted IPs, forwards requests to Commons api.php
+  const TOOLFORGE_PROXY = 'https://depictassist.toolforge.org/api';
   const RECONCILIATION_API = 'https://wikidata.reconci.link/en/api';
-  const OAUTH_BASE = '/api/wikimedia/oauth';
+  // Wikimedia OAuth 2.0 PKCE — public consumer, token lives in browser only
+  const WIKIMEDIA_CLIENT_ID = 'a46cd7bde5376cce96e454d80fb7d809';
+  const WIKIMEDIA_AUTH_ENDPOINT = 'https://commons.wikimedia.org/w/rest.php/oauth2/authorize';
+  const WIKIMEDIA_TOKEN_ENDPOINT = 'https://commons.wikimedia.org/w/rest.php/oauth2/access_token';
   const MAX_SUGGESTIONS = 6;
   // Wikidata item for "based on heuristic" — used as reference (P887) on depicts claims
   const BASED_ON_HEURISTIC_QID = 114065533;
   const LOGIN_STATE_KEY = 'da_login_state';
-  const IP_BLOCK_MSG = 'Wikimedia has blocked our server\u2019s IP address and cannot accept edits right now. Your queue has been preserved \u2014 please try again later or contact DPLA at info@dp.la.';
+  const PKCE_STATE_KEY = 'da_pkce_state';
+  const ACCESS_TOKEN_KEY = 'da_access_token';
+  const IP_BLOCK_MSG = 'A server error prevented your edits from being submitted. Your queue has been preserved \u2014 please try again or contact DPLA at info@dp.la.';
 
   // ── State ────────────────────────────────────────────────
   let queue = [];           // { mid, prop, qid, label, filename, subjectTerm, dplaUrl }[]
@@ -56,10 +62,19 @@
 
     cacheDom();
     bindEvents();
-    const restoredLoginState = restoreLoginState();
-    loadAuth();
-    loadInstitutions();
-    if (!restoredLoginState) restoreFromUrl();
+
+    // When returning from Wikimedia OAuth the URL contains ?code=...&state=...
+    // handleOAuthCallback takes over the full init sequence in that case.
+    const urlParams = new URLSearchParams(window.location.search);
+    const oauthCode = urlParams.get('code');
+    if (oauthCode) {
+      handleOAuthCallback(oauthCode, urlParams.get('state'));
+    } else {
+      const restoredLoginState = restoreLoginState();
+      loadAuth();
+      loadInstitutions();
+      if (!restoredLoginState) restoreFromUrl();
+    }
   };
 
   // If the script loads after the page component has already called onReady,
@@ -567,38 +582,149 @@
     }
   }
 
-  // ── Auth ─────────────────────────────────────────────────
-  async function loadAuth() {
-    try {
-      const resp = await fetch(OAUTH_BASE + '?action=whoami');
+  // ── Auth — PKCE OAuth 2.0 (token lives in browser only) ──
 
-      // 500 means OAuth is not configured on the server — hide login entirely
-      if (resp.status === 500) {
-        showOAuthUnavailable();
+  function toUrlSafeBase64(bytes) {
+    return btoa(String.fromCharCode.apply(null, bytes))
+      .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+  }
+
+  function getRedirectUri() {
+    return getRedirectUri();
+  }
+
+  // Generates a PKCE code_verifier / code_challenge pair using SHA-256.
+  async function generatePkce() {
+    const array = new Uint8Array(32);
+    crypto.getRandomValues(array);
+    const verifier = toUrlSafeBase64(array);
+    const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+    const challenge = toUrlSafeBase64(new Uint8Array(digest));
+    return { verifier, challenge };
+  }
+
+  function storeToken(accessToken, expiresIn) {
+    try {
+      localStorage.setItem(ACCESS_TOKEN_KEY, JSON.stringify({
+        token: accessToken,
+        expiry: Date.now() + (expiresIn || 14400) * 1000
+      }));
+    } catch { /* storage unavailable */ }
+  }
+
+  function getStoredToken() {
+    try {
+      const raw = localStorage.getItem(ACCESS_TOKEN_KEY);
+      if (!raw) return null;
+      const { token, expiry } = JSON.parse(raw);
+      if (Date.now() >= expiry) {
+        localStorage.removeItem(ACCESS_TOKEN_KEY);
+        return null;
+      }
+      return token;
+    } catch { return null; }
+  }
+
+  // Called on page load when ?code=...&state=... are present in the URL
+  // (the browser has just returned from Wikimedia's authorization page).
+  async function handleOAuthCallback(code, urlState) {
+    let pkceData;
+    try {
+      pkceData = JSON.parse(sessionStorage.getItem(PKCE_STATE_KEY));
+      sessionStorage.removeItem(PKCE_STATE_KEY);
+    } catch { pkceData = null; }
+
+    // Validate CSRF state before exchanging the code
+    if (!pkceData || !urlState || urlState !== pkceData.state) {
+      console.error('DepictAssist: OAuth state mismatch — possible CSRF');
+      cleanOAuthParams();
+      showLoggedOut();
+      loadInstitutions();
+      return;
+    }
+
+    cleanOAuthParams();
+
+    try {
+      const redirectUri = getRedirectUri();
+      const resp = await fetch(WIKIMEDIA_TOKEN_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          grant_type: 'authorization_code',
+          code,
+          client_id: WIKIMEDIA_CLIENT_ID,
+          redirect_uri: redirectUri,
+          code_verifier: pkceData.verifier
+        })
+      });
+
+      if (!resp.ok) {
+        console.error('DepictAssist: token exchange failed', resp.status);
+        showLoggedOut();
+        loadInstitutions();
         return;
       }
 
-      if (!resp.ok) throw new Error('Auth check failed');
-      const data = await resp.json();
+      const tokenData = await resp.json();
+      if (!tokenData.access_token) {
+        showLoggedOut();
+        loadInstitutions();
+        return;
+      }
 
-      if (data.username) {
+      storeToken(tokenData.access_token, tokenData.expires_in);
+    } catch (err) {
+      console.error('DepictAssist: OAuth callback error', err);
+      showLoggedOut();
+      loadInstitutions();
+      return;
+    }
+
+    const restoredLoginState = restoreLoginState();
+    loadInstitutions();
+    loadAuth();
+    if (!restoredLoginState) restoreFromUrl();
+  }
+
+  // Remove OAuth params from the URL without triggering a navigation
+  function cleanOAuthParams() {
+    const url = new URL(window.location.href);
+    url.searchParams.delete('code');
+    url.searchParams.delete('state');
+    window.history.replaceState({}, '', url.toString());
+  }
+
+  async function loadAuth() {
+    const token = getStoredToken();
+    if (!token) {
+      showLoggedOut();
+      return;
+    }
+
+    try {
+      const resp = await fetch(TOOLFORGE_PROXY + '?action=query&meta=userinfo', {
+        headers: { 'Authorization': 'Bearer ' + token }
+      });
+
+      if (!resp.ok) {
+        if (resp.status === 401) localStorage.removeItem(ACCESS_TOKEN_KEY);
+        showLoggedOut();
+        return;
+      }
+
+      const data = await resp.json();
+      const userinfo = data.query?.userinfo;
+      if (userinfo?.name && userinfo.id !== 0) {
         isAuthenticated = true;
-        showLoggedIn(data.username);
+        showLoggedIn(userinfo.name);
       } else {
+        localStorage.removeItem(ACCESS_TOKEN_KEY);
         showLoggedOut();
       }
     } catch {
       showLoggedOut();
     }
-  }
-
-  function showOAuthUnavailable() {
-    isAuthenticated = false;
-    $loginBtn.style.display = 'none';
-    $userInfo.style.display = 'none';
-    $batchBtn.disabled = true;
-    $batchLoginMsg.textContent = 'Wikimedia login is not available at this time.';
-    $batchLoginMsg.style.display = 'block';
   }
 
   function showLoggedIn(username) {
@@ -615,21 +741,41 @@
     updateBatchButton();
   }
 
-  function onLogin() {
-    const returnTo = window.location.pathname + window.location.search;
+  async function onLogin() {
     try {
       sessionStorage.setItem(LOGIN_STATE_KEY, JSON.stringify({
         queue,
         imageData: currentImageData,
       }));
     } catch { /* ignore — storage may be unavailable */ }
-    window.location.href = OAUTH_BASE + '?action=login&returnTo=' + encodeURIComponent(returnTo);
+
+    const { verifier, challenge } = await generatePkce();
+    const state = typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : Array.from(crypto.getRandomValues(new Uint8Array(16)))
+          .map(b => b.toString(16).padStart(2, '0')).join('');
+
+    try {
+      sessionStorage.setItem(PKCE_STATE_KEY, JSON.stringify({ verifier, state }));
+    } catch {
+      console.error('DepictAssist: sessionStorage unavailable — cannot start login');
+      return;
+    }
+
+    const redirectUri = getRedirectUri();
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: WIKIMEDIA_CLIENT_ID,
+      redirect_uri: redirectUri,
+      state,
+      code_challenge: challenge,
+      code_challenge_method: 'S256'
+    });
+    window.location.href = WIKIMEDIA_AUTH_ENDPOINT + '?' + params.toString();
   }
 
-  async function onLogout() {
-    try {
-      await fetch(OAUTH_BASE + '?action=logout');
-    } catch { /* ignore */ }
+  function onLogout() {
+    localStorage.removeItem(ACCESS_TOKEN_KEY);
     showLoggedOut();
   }
 
@@ -641,6 +787,14 @@
   async function onSubmitBatch() {
     if (!isAuthenticated || queue.length === 0 || submittingBatch) return;
 
+    // Guard against token expiry between page load and submit
+    const accessToken = getStoredToken();
+    if (!accessToken) {
+      isAuthenticated = false;
+      showLoggedOut();
+      return;
+    }
+
     submittingBatch = true;
     $batchBtn.disabled = true;
     $batchBtn.textContent = 'Submitting...';
@@ -650,9 +804,15 @@
 
     let ipBlockDetected = false;
     try {
-      // _proxy=<timestamp> makes each URL unique so CloudFront never serves a
-      // stale cached response; the proxy strips the parameter before forwarding.
-      const tokenResp = await fetch(COMMONS_PROXY + '?action=query&meta=tokens&_proxy=' + Date.now());
+      const tokenResp = await fetch(TOOLFORGE_PROXY + '?action=query&meta=tokens&type=csrf', {
+        headers: { 'Authorization': 'Bearer ' + accessToken }
+      });
+      if (tokenResp.status === 401) {
+        localStorage.removeItem(ACCESS_TOKEN_KEY);
+        isAuthenticated = false;
+        showLoggedOut();
+        return;
+      }
       if (!tokenResp.ok) throw new Error('Failed to get CSRF token (HTTP ' + tokenResp.status + ')');
       const tokenText = await tokenResp.text();
       let tokenData;
@@ -761,9 +921,12 @@
           summary: 'Added depicts (P180) claim via DepictAssist (DPLA) \u2014 https://pro.dp.la/projects/dpla-wikimedia/depictassist'
         });
 
-        const editResp = await fetch(COMMONS_PROXY, {
+        const editResp = await fetch(TOOLFORGE_PROXY, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Authorization': 'Bearer ' + accessToken
+          },
           body: body
         });
         if (!editResp.ok) {

--- a/public/static/depictassist/depictassist.js
+++ b/public/static/depictassist/depictassist.js
@@ -929,6 +929,14 @@
           },
           body: body
         });
+        if (editResp.status === 401) {
+          localStorage.removeItem(ACCESS_TOKEN_KEY);
+          isAuthenticated = false;
+          showLoggedOut();
+          $batchErrorMsg.textContent = 'Your session expired. Please log in again.';
+          $batchError.style.display = 'block';
+          return;
+        }
         if (!editResp.ok) {
           failures.push(mid);
           continue;

--- a/public/static/depictassist/depictassist.js
+++ b/public/static/depictassist/depictassist.js
@@ -590,7 +590,7 @@
   }
 
   function getRedirectUri() {
-    return getRedirectUri();
+    return window.location.origin + window.location.pathname.replace(/\/$/, '');
   }
 
   // Generates a PKCE code_verifier / code_challenge pair using SHA-256.

--- a/public/static/depictassist/depictassist.js
+++ b/public/static/depictassist/depictassist.js
@@ -597,6 +597,9 @@
   }
 
   async function generatePkce() {
+    if (!crypto.subtle) {
+      throw new Error('DepictAssist: PKCE requires a secure context (HTTPS or localhost)');
+    }
     const array = new Uint8Array(32);
     crypto.getRandomValues(array);
     const verifier = toUrlSafeBase64(array);
@@ -685,8 +688,8 @@
     }
 
     const restoredLoginState = restoreLoginState();
+    await loadAuth();
     loadInstitutions();
-    loadAuth();
     if (!restoredLoginState) restoreFromUrl();
   }
 

--- a/public/static/depictassist/depictassist.js
+++ b/public/static/depictassist/depictassist.js
@@ -625,6 +625,13 @@
     } catch { return null; }
   }
 
+  function handleOAuthCallbackError() {
+    showLoggedOut();
+    const restored = restoreLoginState();
+    loadInstitutions();
+    if (!restored) restoreFromUrl();
+  }
+
   // Called on page load when ?code=...&state=... are present in the URL
   // (the browser has just returned from Wikimedia's authorization page).
   async function handleOAuthCallback(code, urlState) {
@@ -638,8 +645,7 @@
     if (!pkceData || !urlState || urlState !== pkceData.state) {
       console.error('DepictAssist: OAuth state mismatch — possible CSRF');
       cleanOAuthParams();
-      showLoggedOut();
-      loadInstitutions();
+      handleOAuthCallbackError();
       return;
     }
 
@@ -661,23 +667,20 @@
 
       if (!resp.ok) {
         console.error('DepictAssist: token exchange failed', resp.status);
-        showLoggedOut();
-        loadInstitutions();
+        handleOAuthCallbackError();
         return;
       }
 
       const tokenData = await resp.json();
       if (!tokenData.access_token) {
-        showLoggedOut();
-        loadInstitutions();
+        handleOAuthCallbackError();
         return;
       }
 
       storeToken(tokenData.access_token, tokenData.expires_in);
     } catch (err) {
       console.error('DepictAssist: OAuth callback error', err);
-      showLoggedOut();
-      loadInstitutions();
+      handleOAuthCallbackError();
       return;
     }
 
@@ -811,6 +814,8 @@
         localStorage.removeItem(ACCESS_TOKEN_KEY);
         isAuthenticated = false;
         showLoggedOut();
+        $batchErrorMsg.textContent = 'Your session expired. Please log in again.';
+        $batchError.style.display = 'block';
         return;
       }
       if (!tokenResp.ok) throw new Error('Failed to get CSRF token (HTTP ' + tokenResp.status + ')');


### PR DESCRIPTION
## Summary

- **Root cause**: AWS ECS IP range `98.94.0.0/16` is blocked by Wikimedia's global range block until 2028, preventing any server-side authenticated Commons API calls.
- **OAuth**: Replaced server-side confidential OAuth with client-side PKCE flow. Browser exchanges the authorization code directly with Wikimedia using a `code_verifier`; access token stored in `localStorage` with 4-hour expiry; never touches the DPLA server.
- **Proxy**: All authenticated Commons API calls (CSRF token, `wbeditentity`) now go through `https://depictassist.toolforge.org/api` — a small Express app on Toolforge (Wikimedia's own hosting, IPs exempt from range blocks). The browser passes its Bearer token in an `Authorization` header.
- **CSP**: Added `https://depictassist.toolforge.org` to `connect-src`.
- **README**: Updated to document the new architecture, flow diagram, token storage, and Toolforge proxy details.

The legacy server routes (`pages/api/wikimedia/oauth.js`, `commons.js`, `lib/setCookie.js`) are still present but no longer called. They will be removed in a follow-up PR once the new flow is confirmed working in production.

⚠️ **Deployment note**: This PR requires the new Wikimedia OAuth consumer (`a46cd7bde5376cce96e454d80fb7d809`) to be approved by a Wikimedia steward before the login flow is usable. The code can be merged and deployed now, but login will not work until approval is granted.

## Test plan

- [ ] Visit https://pro.dp.la/projects/dpla-wikimedia/depictassist — page loads, institution dropdown populates
- [ ] Click "Log in" — redirected to `commons.wikimedia.org/w/rest.php/oauth2/authorize` (once consumer is approved)
- [ ] Approve — redirected back to depictassist page with `?code=…&state=…` in URL; URL is cleaned up immediately; username appears in header
- [ ] Select institution, find image, click tags, click "Submit batch" — edits post successfully; diff links appear
- [ ] Reload page — still logged in (token persists in localStorage)
- [ ] Click "Log out" — username disappears, Submit batch grays out
- [ ] Prior to consumer approval: page loads normally, "Log in" button is present, no JS errors in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR replaces server-side Wikimedia OAuth with a browser-based OAuth2 PKCE flow and routes authenticated Commons Action API calls through a Toolforge-hosted proxy (https://depictassist.toolforge.org/api) to work around AWS ECS IP blocking (98.94.0.0/16). It changes DepictAssist authentication, token storage, and how authenticated Commons edits are submitted.

## Security & Architecture Implications

- OAuth flow moved from Next.js server-side confidential consumer to client-side public PKCE (hardcoded public client id a46cd7bde5376cce96e454d80fb7d809).
- Access tokens are stored in browser localStorage with a 4-hour expiry; PKCE state/verifier are stored in sessionStorage. Tokens are never sent to the DPLA server; the browser sends Bearer tokens directly to the Toolforge proxy.
- Authenticated Commons calls (CSRF token fetch, action=wbeditentity) go to the external Toolforge proxy which enforces an allowlist of actions and requires Authorization: Bearer <token>.
- CSP updated: added https://depictassist.toolforge.org to connect-src.
- Root cause: Wikimedia blocks AWS ECS IP range 98.94.0.0/16 until 2028, preventing server-side Commons edits.

## Environment & Infra Changes

- Environment variables no longer required (legacy server-side OAuth):
  - WIKIMEDIA_OAUTH_CLIENT_ID
  - WIKIMEDIA_OAUTH_CLIENT_SECRET
  - WIKIMEDIA_OAUTH_REDIRECT_BASE
  These are still referenced by legacy API routes left in repo but are not used by the new client-side flow.

- No database migrations.
- No changes to shared infrastructure (CodePipeline, CodeBuild, ECS task definitions, IAM) and no required pipeline trigger or ECS redeployment to merge/deploy these code changes.

## API / Endpoints

- Legacy Next.js endpoints remain in repo but are superseded (not invoked):
  - pages/api/wikimedia/oauth.js (server-side code→token exchange)
  - pages/api/wikimedia/commons.js (server-side Commons proxy)
- New external service used at runtime: https://depictassist.toolforge.org/api — a Toolforge-hosted Express proxy that:
  - Accepts Bearer tokens from the browser
  - Restricts allowed actions (400 for unsupported action)
  - Returns 401 when no/invalid Bearer token
  - Includes explicit Access-Control-Allow-Origin handling per README
- No public-facing API shapes on DPLA’s server are changed.

## Deployment Notes

- No pipeline/ECS redeploy required for code merge.
- Wikimedia steward approval required before the new consumer (a46cd7bde5376cce96e454d80fb7d809) can be used for login; code can be deployed now but login will not function until approval is granted.
- Legacy server routes are retained temporarily for rollback/testing and will be removed in a follow-up PR after production verification.

## Files/Touched Areas (high level)

- next.config.js: add https://depictassist.toolforge.org to CSP connect-src.
- public/static/depictassist/README.md: updated architecture docs, PKCE flow, token storage, Toolforge proxy behavior, CORS expectations, and notes on legacy routes pending removal.
- public/static/depictassist/depictassist.js: implements PKCE flow (verifier/challenge generation, auth redirect, in-browser token exchange, localStorage/sessionStorage handling), session management, Toolforge proxy calls (CSRF fetch and edits), 401/session-expiry handling, and updated user-facing error messaging.

## Tests / Test plan (summarized)

- Page loads and institution dropdown populates.
- Login redirects to Wikimedia OAuth endpoint (works only post-steward approval), returns code/state, URL cleaned, username displayed.
- Select institution → find image → submit batch → edits submitted via proxy and diffs appear.
- Token persists across reloads; logout clears session.
- Prior to consumer approval: page loads with Login button and no JS errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->