### PR TITLE
feat: prev/next navigation for search results and topic browse subtopics

### DIFF
--- a/components/ItemComponents/SearchResultsNav/SearchResultsNav.module.scss
+++ b/components/ItemComponents/SearchResultsNav/SearchResultsNav.module.scss
@@ -1,0 +1,50 @@
+@import "stylesheets/breakpoints.module";
+
+.searchNav {
+  display: flex;
+  flex-direction: column;
+  align-items: baseline;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+
+  @media (min-width: $smallRem) {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0;
+  }
+}
+
+.backLink,
+.prevLink,
+.nextLink {
+  color: var(--linkColor);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  text-decoration: none;
+
+  &:hover,
+  &:focus-visible {
+    text-decoration: underline;
+  }
+}
+
+.prevNext {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.backArrow,
+.prevArrow {
+  height: 9px;
+  flex-shrink: 0;
+  transform: rotate(180deg);
+}
+
+.nextArrow {
+  height: 9px;
+  flex-shrink: 0;
+}

--- a/components/ItemComponents/SearchResultsNav/index.js
+++ b/components/ItemComponents/SearchResultsNav/index.js
@@ -8,7 +8,8 @@ import { BACK_URI_PARAM, NEXT_PARAM, PREV_PARAM } from "constants/searchNav";
 import css from "./SearchResultsNav.module.scss";
 import utils from "stylesheets/utils.module.scss";
 
-const ITEM_PATH_RE = new RegExp(`^/item/${DPLA_ITEM_ID_REGEX.source}$`);
+const ITEM_ID_SOURCE = DPLA_ITEM_ID_REGEX.source.replace(/^\^|\$$/g, "");
+const ITEM_PATH_RE = new RegExp(`^/item/${ITEM_ID_SOURCE}$`);
 
 function SearchResultsNav() {
   const { query } = useRouter();

--- a/components/ItemComponents/SearchResultsNav/index.js
+++ b/components/ItemComponents/SearchResultsNav/index.js
@@ -1,0 +1,73 @@
+import React from "react";
+import Link from "next/link";
+import { useRouter } from "next/router";
+
+import Chevron from "components/svg/ChevronThickOrange";
+import { DPLA_ITEM_ID_REGEX } from "constants/items";
+import { BACK_URI_PARAM, NEXT_PARAM, PREV_PARAM } from "constants/searchNav";
+import css from "./SearchResultsNav.module.scss";
+import utils from "stylesheets/utils.module.scss";
+
+const ITEM_PATH_RE = new RegExp(`^/item/${DPLA_ITEM_ID_REGEX.source}$`);
+
+function SearchResultsNav() {
+  const { query } = useRouter();
+
+  const backUri =
+    typeof query[BACK_URI_PARAM] === "string" &&
+    query[BACK_URI_PARAM].startsWith("/search")
+      ? query[BACK_URI_PARAM]
+      : null;
+  const prev =
+    typeof query[PREV_PARAM] === "string" && ITEM_PATH_RE.test(query[PREV_PARAM])
+      ? query[PREV_PARAM]
+      : null;
+  const next =
+    typeof query[NEXT_PARAM] === "string" && ITEM_PATH_RE.test(query[NEXT_PARAM])
+      ? query[NEXT_PARAM]
+      : null;
+
+  if (!backUri && !prev && !next) return null;
+
+  // Forward back_uri into neighbour links so the user can return to search
+  // results after navigating prev/next (neighbour pages won't have their own
+  // prev/next context, but the back link will still work).
+  const neighborQuery = backUri ? { [BACK_URI_PARAM]: backUri } : {};
+
+  return (
+    <div className={utils.breadcrumbsWrapper}>
+      <div className={`${utils.container} ${css.searchNav}`}>
+        {backUri && (
+          <Link href={backUri} className={css.backLink}>
+            <Chevron className={css.backArrow} aria-hidden="true" />
+            Back to results
+          </Link>
+        )}
+        {(prev || next) && (
+          <div className={css.prevNext}>
+            {prev && (
+              <Link
+                href={{ pathname: prev, query: neighborQuery }}
+                className={css.prevLink}
+              >
+                <Chevron className={css.prevArrow} aria-hidden="true" />
+                Previous item
+              </Link>
+            )}
+            {next && (
+              <Link
+                href={{ pathname: next, query: neighborQuery }}
+                className={css.nextLink}
+              >
+                Next item
+                <Chevron className={css.nextArrow} aria-hidden="true" />
+              </Link>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default SearchResultsNav;

--- a/components/SearchComponents/MainContent/index.js
+++ b/components/SearchComponents/MainContent/index.js
@@ -6,7 +6,7 @@ import Pagination from "shared/Pagination";
 import Sidebar from "./Sidebar";
 import AboutLocal from "./AboutLocal";
 
-import { addLinkInfoToResults } from "lib";
+import { useResultsWithContext } from "./useResultsWithContext";
 
 import css from "./MainContent.module.scss";
 import contentCss from "stylesheets/content-pages.module.scss";
@@ -21,6 +21,8 @@ function MainContent({
 }) {
   const siteEnv = process.env.NEXT_PUBLIC_SITE_ENV;
   const router = useRouter();
+  const itemsWithContext = useResultsWithContext(results);
+
   return (
     <div className={css.wrapper}>
       <div className={`${utils.container} ${css.mainContent}`}>
@@ -32,7 +34,7 @@ function MainContent({
         <main id="main" role="main" className={css.resultsAndPagination}>
           {results.length > 0 && (
             <ListView
-              items={addLinkInfoToResults(results)}
+              items={itemsWithContext}
               viewMode={router.query.list_view}
               behavior={"search"}
             />

--- a/components/SearchComponents/MainContent/useResultsWithContext.js
+++ b/components/SearchComponents/MainContent/useResultsWithContext.js
@@ -1,0 +1,34 @@
+import { useMemo } from "react";
+import { useRouter } from "next/router";
+
+import { addLinkInfoToResults } from "lib";
+import { BACK_URI_PARAM, NEXT_PARAM, PREV_PARAM } from "constants/searchNav";
+
+/**
+ * Returns search results augmented with back_uri / prev / next query params so
+ * the item page can render "Back to results" and neighbour navigation.
+ * Memoised on [results, router.asPath] to avoid rebuilding the array on every
+ * parent render.
+ */
+export function useResultsWithContext(results) {
+  const { asPath } = useRouter();
+  return useMemo(() => {
+    const base = addLinkInfoToResults(results);
+    return base.map((item, i) => {
+      if (!item.linkHref) return item;
+      const prev = base[i - 1]?.linkHref?.pathname;
+      const next = base[i + 1]?.linkHref?.pathname;
+      return {
+        ...item,
+        linkHref: {
+          ...item.linkHref,
+          query: {
+            [BACK_URI_PARAM]: asPath,
+            ...(prev && { [PREV_PARAM]: prev }),
+            ...(next && { [NEXT_PARAM]: next }),
+          },
+        },
+      };
+    });
+  }, [results, asPath]);
+}

--- a/components/TopicBrowseComponents/BreadcrumbsAndNav/BreadcrumbsAndNav.module.scss
+++ b/components/TopicBrowseComponents/BreadcrumbsAndNav/BreadcrumbsAndNav.module.scss
@@ -12,7 +12,7 @@
   align-items: baseline;
 
   @media (min-width: $smallRem) {
-    justify-content: flex-start;
+    justify-content: space-between;
     align-items: center;
     flex-direction: row;
   }

--- a/components/TopicBrowseComponents/BreadcrumbsAndNav/index.js
+++ b/components/TopicBrowseComponents/BreadcrumbsAndNav/index.js
@@ -1,14 +1,22 @@
 import React from "react";
 
 import Breadcrumbs from "shared/Breadcrumbs";
+import NavArrows from "./components/NavLinks";
 import css from "./BreadcrumbsAndNav.module.scss";
 import utils from "stylesheets/utils.module.scss";
 
-function BreadcrumbsAndNav({ breadcrumbs }) {
+function BreadcrumbsAndNav({ breadcrumbs, previousSubtopic, nextSubtopic, topic }) {
   return (
     <div className={utils.breadcrumbsWrapper}>
       <div className={`${css.breadcrumbsAndNav} ${utils.container}`}>
         <Breadcrumbs breadcrumbs={breadcrumbs} />
+        {topic && (previousSubtopic || nextSubtopic) && (
+          <NavArrows
+            previousSubtopic={previousSubtopic}
+            nextSubtopic={nextSubtopic}
+            topic={topic}
+          />
+        )}
       </div>
     </div>
   );

--- a/constants/searchNav.js
+++ b/constants/searchNav.js
@@ -1,0 +1,5 @@
+// Query param names written by search results and read by the item page
+// for "Back to results / Previous item / Next item" navigation.
+export const BACK_URI_PARAM = "back_uri";
+export const PREV_PARAM = "prev";
+export const NEXT_PARAM = "next";

--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -17,6 +17,8 @@ import {
   truncateString,
 } from "lib";
 
+import SearchResultsNav from "components/ItemComponents/SearchResultsNav";
+
 import css from "components/ItemComponents/itemComponent.module.scss";
 import utils from "stylesheets/utils.module.scss";
 import contentCss from "stylesheets/content-pages.module.scss";
@@ -81,6 +83,7 @@ export default function ItemDetail({ item, temporarilyUnavailable, randomItemId,
   const metadataBase = `/item/${item.id}`;
   return (
     <MainLayout pageTitle={item.title} pageImage={item.thumbnailUrl} pageDescription={pageDescription} canonicalUrl={canonicalUrl}>
+      <SearchResultsNav />
       <BreadcrumbsModule
         breadcrumbs={[
           {


### PR DESCRIPTION
## Summary

- **Closes #476** — Item pages reached via search now show a "Back to results" link plus Previous/Next item links. `useResultsWithContext` augments each search result's link href with `back_uri`, `prev`, and `next` query params (within-page neighbours only). The new `SearchResultsNav` component on the item page reads these and renders the nav strip when present; it renders nothing when the item is accessed directly.
- **Closes #519** — Topic browse subtopic pages now show Previous / Next Section links. The data was already computed in `getServerSideProps` and already passed to `BreadcrumbsAndNav` — the existing `NavArrows` component (which had been disconnected) is now wired in, and the breadcrumb bar uses `justify-content: space-between` to push the arrows to the trailing edge.

## Implementation notes

- Query param names (`back_uri`, `prev`, `next`) are in a single shared `constants/searchNav.js` — both the writer (`useResultsWithContext`) and the reader (`SearchResultsNav`) import from there.
- `ITEM_PATH_RE` in `SearchResultsNav` is built from the existing `DPLA_ITEM_ID_REGEX` constant rather than duplicating the hex-ID character class.
- The enrichment logic is extracted to a `useMemo`-backed hook (`useResultsWithContext`) rather than inline in `MainContent`, keeping the component clean and avoiding rebuilding the array on every parent render.
- `back_uri` is forwarded into neighbour links so the "Back to results" link survives a prev/next click (neighbour pages won't have their own prev/next context, but the back link still works).
- `back_uri` is validated to start with `/search` before rendering; `prev`/`next` are validated against `ITEM_PATH_RE`.

## Test plan

- [ ] Search for something, click an item in the middle of the page — verify "Back to results", "Previous item", "Next item" all appear
- [ ] Click "Previous item" or "Next item" — verify the destination item shows "Back to results" (but no prev/next, since context isn't forwarded further)
- [ ] Click "Back to results" — verify it returns to the correct search URL
- [ ] Click the first result on a page — verify only "Back to results" and "Next item" appear (no "Previous item")
- [ ] Click the last result on a page — verify only "Back to results" and "Previous item" appear
- [ ] Navigate to an item page directly (no search context) — verify nav strip is absent
- [ ] On a topic browse subtopic page, verify "Previous Section" / "Next Section" links appear and navigate correctly
- [ ] On the first subtopic in a topic, verify only "Next Section" appears; on the last, only "Previous Section"
- [ ] On the topic index page (not a subtopic), verify no section nav appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Search Results and Topic Browse Navigation

This PR implements two related navigation features to improve user navigation within search results and topic browse pages.

### Search Result Item Navigation
- New SearchResultsNav component displays "Back to results" and "Previous/Next item" links on item pages when navigated from a search results page.
- New useResultsWithContext hook augments search result links with query parameters (back_uri, prev, next) so item pages can render the navigation strip.
- Neighbors (prev/next) are limited to items within the same search-results page; back_uri is preserved through neighbor links so "Back to results" continues to work after prev/next clicks.
- Query param names centralized in constants/searchNav.js.
- Validation rules: back_uri must start with /search; prev/next must match the item URL pattern (ITEM_PATH_RE built from DPLA_ITEM_ID_REGEX).
- If an item is accessed directly (no valid params), SearchResultsNav renders nothing.
- Minor fix: adjusted item-path regular expression to align validation (commit message: "fix: item path regex").

### Topic Browse Subtopic Navigation
- Reconnected existing NavArrows inside BreadcrumbsAndNav to show Previous / Next Section links for topic browse subtopics.
- Breadcrumb bar layout adjusted (justify-content: space-between at the small breakpoint) so navigation arrows and breadcrumbs are positioned correctly.
- Section navigation data is already computed in getServerSideProps and passed into BreadcrumbsAndNav; no additional data fetching was added.

### Files Changed (high level)
- New: components/ItemComponents/SearchResultsNav (component + styles)
- New: components/SearchComponents/MainContent/useResultsWithContext.js (hook)
- Modified: components/SearchComponents/MainContent (uses hook instead of addLinkInfoToResults)
- Modified: components/TopicBrowseComponents/BreadcrumbsAndNav (props and renders NavArrows)
- New: constants/searchNav.js (BACK_URI_PARAM, PREV_PARAM, NEXT_PARAM)
- Modified: pages/item/[itemId].js (renders SearchResultsNav)

### High-level impact notes (explicit)
- No manual pipeline trigger or ECS redeployment required.
- No environment variables or AWS Secrets Manager keys added/removed/renamed.
- No database migrations.
- No changes to shared infrastructure (CodePipeline, CodeBuild, ECS task definitions, IAM policies).
- No modifications to public-facing API response shapes or endpoints.
- No security changes to authentication or credential handling; new inputs are query parameters and are validated server/client-side according to the implemented rules.

### Testing / Implementation notes
- Enrichment logic extracted to a useMemo-backed hook to avoid unnecessary rebuilds.
- The back_uri parameter is forwarded into neighbor links so the originating search results link is preserved across prev/next navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->