### PR TITLE
fix(csp): add data: to img-src for probeImage blank-gif cancellation

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -58,7 +58,7 @@ const CSP_DIRECTIVES = [
   "form-action 'self' https://meta.wikimedia.org",
   "default-src 'self'",
   "script-src 'self' 'sha256-sYQvVdNrbb2ldJRpproLbB3h5LhCcbCA1SUM1wTfomI=' 'sha256-uZYgrdXqFswjbPEZxW2e6bv+djcz8D4kcJKjWyznRmk=' 'sha256-R7BycX6lCwOq9x3CZpytPnOyYvDNpLs38i6qKfpCcVY=' *.google-analytics.com *.googletagmanager.com *.sentry.io https://*.awswaf.com https://www.gstatic.com",
-  "img-src 'self' http: https:",
+  "img-src 'self' http: https: data:",
   `connect-src 'self' https://dp.la https://*.dp.la ${CLOUDFRONT_MEDIA} *.google-analytics.com *.analytics.google.com *.sentry.io https://*.awswaf.com https://www.gstatic.com https://gitlab.wikimedia.org https://commons.wikimedia.org https://wikimedia.org https://wikidata.reconci.link https://wikidata-reconciliation.wmcloud.org https://raw.githubusercontent.com https://meta.wikimedia.org https://www.wikidata.org https://depictassist.toolforge.org`,
   "style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://www.gstatic.com",
   "font-src 'self' https://cdnjs.cloudflare.com",


### PR DESCRIPTION
## Summary

- `img-src` CSP directive was missing the `data:` scheme
- `probeImage.js` uses a 1×1 transparent GIF data URI (`BLANK_IMAGE`) to abort in-flight image loads in its cleanup disposer
- Every probe cancellation (component unmount, URL change) was generating a CSP violation in the console
- Introduced when PR #1444 added `probeImage.js` but did not update the CSP

## Notes

This is console noise only — the CSP violation does **not** cause visible thumbnail failures. The displayed `<img>` element and the probe's off-DOM element are separate; `cleanup()` nulls the probe's handlers before `img.src = BLANK_IMAGE` is set, so no `onError()` callback fires from the CSP block. The missing thumbnails reported on ppc.dp.la are a separate WAF issue being investigated.

## Test plan

- [ ] Deploy to any production site and confirm no `data:` CSP violations appear in the browser console on search results pages
- [ ] Confirm thumbnail fallback behaviour (placeholder on 504) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes Content Security Policy (CSP) violations that occur when probeImage.js cancels in-flight image loads during component unmount or URL changes. The `probeImage` cleanup handler uses a 1×1 transparent GIF data URI (`BLANK_IMAGE`) to abort image requests, but the CSP `img-src` directive was missing the `data:` scheme, causing browser console violations.

## Changes

**next.config.js**: Updated the `img-src` CSP directive from `"img-src 'self' http: https:"` to `"img-src 'self' http: https: data:"` to permit data URIs.

## Security Implications

This change **broadens the CSP `img-src` directive** to allow data-scheme images. While necessary for the probeImage cleanup behavior, it slightly relaxes CSP restrictions. The impact is minimal since data URIs are self-contained and cannot reference external resources.

## Deployment Notes

**Requires redeployment**: This Next.js configuration change requires a full rebuild and redeployment to take effect. The updated CSP headers will be served after the application is redeployed.

## Additional Context

- The CSP violations were console noise only—they did not cause visible thumbnail failures since the cleanup handlers were nulled before the data URI assignment, preventing the CSP-blocked onError callback from firing.
- Missing thumbnails reported at ppc.dp.la are attributed to a separate WAF issue, not this CSP limitation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->