### PR TITLE
fix: treat all 5xx as upstream unavailable, not just 503

### DIFF
--- a/lib/safeFetch.js
+++ b/lib/safeFetch.js
@@ -130,18 +130,17 @@ export function checkResponseForSSRSafe(res, label) {
 
 /**
  * Returns true when a safeFetch result indicates a temporary upstream
- * unavailability: either a network failure (null) or an upstream 503 that
- * persisted through safeFetch's built-in retry.
+ * unavailability: either a network failure (null) or any 5xx response.
  *
- * Use this instead of a bare `!res` check so that upstream 503 responses
- * are also converted to a client-facing 503 rather than silently becoming
+ * Use this instead of a bare `!res` check so that upstream 5xx responses
+ * are converted to a client-facing 503 rather than silently becoming
  * 404s via checkResponseForSSRSafe.
  *
  * @param {Response|null} fetchRes - return value of safeFetch / cachedSafeFetch
  * @returns {boolean}
  */
 export function isUpstreamUnavailable(fetchRes) {
-  return !fetchRes || fetchRes.status === 503;
+  return !fetchRes || fetchRes.status >= 500;
 }
 
 /**

--- a/lib/safeFetch.test.mjs
+++ b/lib/safeFetch.test.mjs
@@ -8,9 +8,11 @@ test('isUpstreamUnavailable returns true for null (network failure)', () => {
   assert.equal(isUpstreamUnavailable(null), true);
 });
 
-test('isUpstreamUnavailable returns true for 503 response', () => {
-  assert.equal(isUpstreamUnavailable({ status: 503 }), true);
-});
+for (const status of [500, 502, 503, 504]) {
+  test(`isUpstreamUnavailable returns true for ${status} response`, () => {
+    assert.equal(isUpstreamUnavailable({ status }), true);
+  });
+}
 
 test('isUpstreamUnavailable returns false for a successful response', () => {
   assert.equal(isUpstreamUnavailable({ status: 200, ok: true }), false);


### PR DESCRIPTION
## Summary

- Pages like `/browse-by-partner` and `/primary-source-sets` were rendering a 404 when the API returned 500/502/504 during traffic-related downtime
- `isUpstreamUnavailable` only checked for `null` (network failure) and `503`; other 5xx responses fell through to `checkResponseForSSRSafe`, which converted them to `{ notFound: true }`
- Expanded the check to `status >= 500` so any server error routes to the "temporarily unavailable" 503 UI with `Retry-After: 10` — applies to all 22 pages that use this pattern

## Test plan

- [ ] Verify existing test suite passes (`npm test`)
- [ ] Confirm `/browse-by-partner` and `/primary-source-sets` show the "temporarily unavailable" page (not 404) when the API is down

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR expands the `isUpstreamUnavailable()` function in `lib/safeFetch.js` to treat all HTTP 5xx responses (status >= 500) as temporary upstream unavailability, rather than only treating 503 responses and network failures as unavailable.

### Problem Addressed
Pages like `/browse-by-partner` and `/primary-source-sets` were incorrectly displaying 404 errors when the API returned 5xx errors (500, 502, 504) during traffic-related downtime. Previously, only 503 responses and network failures were recognized as upstream unavailability, while other 5xx responses were passed to `checkResponseForSSRSafe`, which incorrectly converted them to `{ notFound: true }`.

### Changes
- **lib/safeFetch.js**: Updated `isUpstreamUnavailable()` to return `true` for `status >= 500` instead of only `status === 503`, and updated JSDoc comments to reflect the new 5xx-inclusive behavior
- **lib/safeFetch.test.mjs**: Replaced the single 503-only test with parameterized tests covering multiple 5xx status codes (500, 502, 503, 504)

### Impact
These changes apply to all 22 pages that use the `isUpstreamUnavailable` pattern, ensuring they will now show the "temporarily unavailable" page (503 with Retry-After: 10 header) for any server error, preventing misinterpretation of 5xx responses as 404s.

### Deployment Notes
- No manual pipeline trigger or ECS redeployment required
- No environment variables, AWS Secrets Manager keys, or infrastructure changes
- No database migrations
- No public API changes or security implications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->