### PR TITLE
feat(search): improve API error message with retry, status link, and navigation

### DIFF
--- a/components/SearchComponents/SearchError.js
+++ b/components/SearchComponents/SearchError.js
@@ -1,0 +1,39 @@
+import React from "react";
+import Link from "next/link";
+import Button from "components/shared/Button";
+import css from "./SearchError.module.scss";
+import utils from "stylesheets/utils.module.scss";
+
+function SearchError() {
+  return (
+    <div className={`${utils.container} ${css.searchError}`}>
+      <h1>Search is temporarily unavailable.</h1>
+      <p>
+        We&rsquo;re having trouble connecting to our search service &mdash; this
+        is on our end, not yours.
+      </p>
+      <Button type="primary" onClick={() => window.location.reload()}>
+        Try again
+      </Button>
+      <p className={css.statusLink}>
+        Check our{" "}
+        <a href="https://status.dp.la" target="_blank" rel="noreferrer">
+          status page
+        </a>{" "}
+        to see if there&rsquo;s a known issue.
+      </p>
+      <p>While search is down, you can still:</p>
+      <ul className={css.alternativeLinks}>
+        <li>
+          View our <Link href="/exhibitions">exhibitions</Link>
+        </li>
+        <li>
+          Explore our{" "}
+          <Link href="/primary-source-sets">primary source sets</Link>
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+export default SearchError;

--- a/components/SearchComponents/SearchError.module.scss
+++ b/components/SearchComponents/SearchError.module.scss
@@ -1,0 +1,25 @@
+.searchError {
+  margin-bottom: 10rem;
+  margin-top: 5rem;
+  text-align: center;
+}
+
+.searchError h1 {
+  padding-bottom: 0.8rem;
+}
+
+.statusLink {
+  margin-top: 1.5rem;
+}
+
+.alternativeLinks {
+  display: inline-block;
+  list-style: none;
+  margin-top: 0.5rem;
+  padding: 0;
+  text-align: left;
+}
+
+.alternativeLinks li::before {
+  content: "→ ";
+}

--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -24,6 +24,7 @@ import { LOCALS } from "constants/local";
 import MaxPageError from "components/SearchComponents/MaxPageError";
 import { washObject } from "lib/washObject";
 import FilterQueryError from "components/SearchComponents/FilterQueryError";
+import SearchError from "components/SearchComponents/SearchError";
 
 class Search extends React.Component {
   state = {
@@ -79,11 +80,7 @@ class Search extends React.Component {
             facets={results?.facets ?? {}}
           />
         )}
-        {fetchError && (
-          <p style={{ textAlign: "center", padding: "2rem" }}>
-            Search results couldn&apos;t be loaded. Please try again.
-          </p>
-        )}
+        {fetchError && <SearchError />}
         {!fetchError && currentPage <= MAX_PAGE_SIZE && (
           <MainContent
             hideSidebar={!this.state.showSidebar}


### PR DESCRIPTION
## Summary

- Replaces the bare single-line error paragraph with a proper `SearchError` component
- Adds a **"Try again" button** (reloads the page, re-running `getServerSideProps`)
- Adds a link to **status.dp.la** so users can self-triage known outages
- Provides **safe alternative navigation** (Exhibitions and Primary Source Sets only — links that don't depend on the search API, unlike Browse by Topic/Partner which would also be broken during an API outage)
- Matches the visual style and structure of the existing `MaxPageError` and `FilterQueryError` components

## Before / After

**Before:** `Search results couldn't be loaded. Please try again.` (plain `<p>` tag, no button, no guidance)

**After:** Heading + friendly copy + reload button + status page link + alternative nav links

## Test plan

- [x] Simulate a search API failure (e.g. set `API_URL` to an unreachable host) and verify the new error UI renders
- [x] Confirm "Try again" button reloads the page
- [x] Confirm status.dp.la link opens in a new tab
- [x] Confirm Exhibitions and Primary Source Sets links navigate correctly
- [x] Verify no regression on normal search results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Refactors the search results error UI by replacing a plain text error paragraph with a dedicated `SearchError` component that provides better user guidance during API outages.

## Changes

**New Component: SearchError**
- Displays a friendly error message indicating the search API is unavailable
- Includes a "Try again" button that reloads the page to retry the search
- Provides a link to the status page (status.dp.la) for users to check for known outages
- Offers alternative navigation to Exhibitions and Primary Source Sets (features that don't depend on the search API)
- Includes supporting CSS module for styling with centered layout, inline navigation links prefixed with right-arrow indicators

**Updated: Search Page**
- Replaces inline error paragraph with `SearchError` component
- Minimal code changes (3-line net change) while improving user experience

## Testing

Verify the error state by:
- Simulating search API failure
- Confirming the error component renders with proper styling
- Testing the "Try again" button reloads the page
- Verifying the status page link opens in a new tab
- Confirming alternative navigation links function correctly
- Confirming normal search results are not affected

## Notes

No infrastructure, environment variables, database migrations, or API changes required. This is a purely frontend UI improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->