### PR TITLE
fix: replace inline 5xx guards with isUpstreamUnavailable + upstreamUnavailable

### DIFF
--- a/lib/safeFetch.js
+++ b/lib/safeFetch.js
@@ -130,18 +130,17 @@ export function checkResponseForSSRSafe(res, label) {
 
 /**
  * Returns true when a safeFetch result indicates a temporary upstream
- * unavailability: either a network failure (null) or an upstream 503 that
- * persisted through safeFetch's built-in retry.
+ * unavailability: either a network failure (null) or any 5xx response.
  *
- * Use this instead of a bare `!res` check so that upstream 503 responses
- * are also converted to a client-facing 503 rather than silently becoming
+ * Use this instead of a bare `!res` check so that upstream 5xx responses
+ * are converted to a client-facing 503 rather than silently becoming
  * 404s via checkResponseForSSRSafe.
  *
  * @param {Response|null} fetchRes - return value of safeFetch / cachedSafeFetch
  * @returns {boolean}
  */
 export function isUpstreamUnavailable(fetchRes) {
-  return !fetchRes || fetchRes.status === 503;
+  return !fetchRes || fetchRes.status >= 500;
 }
 
 /**

--- a/lib/safeFetch.test.mjs
+++ b/lib/safeFetch.test.mjs
@@ -8,8 +8,20 @@ test('isUpstreamUnavailable returns true for null (network failure)', () => {
   assert.equal(isUpstreamUnavailable(null), true);
 });
 
+test('isUpstreamUnavailable returns true for 500 response', () => {
+  assert.equal(isUpstreamUnavailable({ status: 500 }), true);
+});
+
 test('isUpstreamUnavailable returns true for 503 response', () => {
   assert.equal(isUpstreamUnavailable({ status: 503 }), true);
+});
+
+test('isUpstreamUnavailable returns true for 504 response', () => {
+  assert.equal(isUpstreamUnavailable({ status: 504 }), true);
+});
+
+test('isUpstreamUnavailable returns false for 499 response', () => {
+  assert.equal(isUpstreamUnavailable({ status: 499, ok: false }), false);
 });
 
 test('isUpstreamUnavailable returns false for a successful response', () => {

--- a/pages/contact/index.js
+++ b/pages/contact/index.js
@@ -17,12 +17,10 @@ import { TITLE } from "constants/contact";
 import contentCss from "stylesheets/content-pages.module.scss";
 import utils from "stylesheets/utils.module.scss";
 import { washObject } from "lib/washObject";
-import { safeFetch, isUpstreamUnavailable, upstreamUnavailable } from "lib/safeFetch";
-import ServiceUnavailable from "components/shared/ServiceUnavailable";
+import { safeFetch, isUpstreamUnavailable } from "lib/safeFetch";
 
 function Contact(props) {
-  const { sidebarItems, temporarilyUnavailable } = props;
-  if (temporarilyUnavailable) return <ServiceUnavailable />;
+  const { sidebarItems } = props;
   return (
     <MainLayout pageTitle={TITLE} seoType={SEO_TYPE}>
       <FeatureHeader title={TITLE} description={""} />
@@ -57,7 +55,12 @@ export const getServerSideProps = async (context) => {
     siteEnv === "user" ? ABOUT_MENU_ENDPOINT : PRO_MENU_ENDPOINT,
   );
 
-  if (isUpstreamUnavailable(aboutMenuRes)) return upstreamUnavailable(context.res, aboutMenuRes);
+  if (isUpstreamUnavailable(aboutMenuRes)) {
+    await Promise.allSettled([aboutMenuRes?.body?.cancel?.()]);
+    context.res.statusCode = 503;
+    context.res.setHeader("Retry-After", "10");
+    return { props: washObject({ sidebarItems: [] }) };
+  }
   if (!aboutMenuRes?.ok) return { notFound: true };
 
   const aboutMenuJson = await aboutMenuRes.json();

--- a/pages/contact/index.js
+++ b/pages/contact/index.js
@@ -17,10 +17,12 @@ import { TITLE } from "constants/contact";
 import contentCss from "stylesheets/content-pages.module.scss";
 import utils from "stylesheets/utils.module.scss";
 import { washObject } from "lib/washObject";
-import { safeFetch } from "lib/safeFetch";
+import { safeFetch, isUpstreamUnavailable, upstreamUnavailable } from "lib/safeFetch";
+import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
 function Contact(props) {
-  const { sidebarItems } = props;
+  const { sidebarItems, temporarilyUnavailable } = props;
+  if (temporarilyUnavailable) return <ServiceUnavailable />;
   return (
     <MainLayout pageTitle={TITLE} seoType={SEO_TYPE}>
       <FeatureHeader title={TITLE} description={""} />
@@ -55,22 +57,12 @@ export const getServerSideProps = async (context) => {
     siteEnv === "user" ? ABOUT_MENU_ENDPOINT : PRO_MENU_ENDPOINT,
   );
 
-  if (!aboutMenuRes?.ok) {
-    if (!aboutMenuRes || aboutMenuRes.status >= 500) {
-      // Sidebar nav is non-critical — render page without it and signal 503
-      context.res.statusCode = 503;
-      context.res.setHeader("Retry-After", "10");
-      return { props: washObject({ sidebarItems: [] }) };
-    }
-    return { notFound: true };
-  }
+  if (isUpstreamUnavailable(aboutMenuRes)) return upstreamUnavailable(context.res, aboutMenuRes);
+  if (!aboutMenuRes?.ok) return { notFound: true };
 
   const aboutMenuJson = await aboutMenuRes.json();
-  const props = washObject({ sidebarItems: aboutMenuJson.items });
 
-  return {
-    props: props,
-  };
+  return { props: washObject({ sidebarItems: aboutMenuJson.items }) };
 };
 
 export default Contact;

--- a/pages/index.js
+++ b/pages/index.js
@@ -66,11 +66,9 @@ export async function getServerSideProps(context) {
   try {
   // fetch home info
   // 1. fetch the settings from WP
-  const settingsRes = await fetch(API_SETTINGS_ENDPOINT);
-  if (!settingsRes.ok) {
-    if (settingsRes.status >= 500) return upstreamUnavailable(context.res, settingsRes);
-    return { notFound: true };
-  }
+  const settingsRes = await safeFetch(API_SETTINGS_ENDPOINT);
+  if (isUpstreamUnavailable(settingsRes)) return upstreamUnavailable(context.res, settingsRes);
+  if (!settingsRes?.ok) return { notFound: true };
   const settingsJson = await settingsRes.json();
   // 2. get the corresponding value
   const baseEndpoint = `${PAGES_ENDPOINT}/${settingsJson.acf.homepage_endpoint}`;
@@ -193,17 +191,15 @@ export async function getServerSideProps(context) {
     newsItems = await newsRes.json();
   }
 
-  const props = washObject({
-    sourceSets,
-    guides,
-    exhibitions: featuredExhibits,
-    headerDescription,
-    news: newsItems,
-    content: homepageJson,
-  });
-
   return {
-    props: props,
+    props: washObject({
+      sourceSets,
+      guides,
+      exhibitions: featuredExhibits,
+      headerDescription,
+      news: newsItems,
+      content: homepageJson,
+    }),
   };
   } catch (e) {
     console.error("[SSR] getServerSideProps failed:", e);

--- a/pages/projects/dpla-wikimedia/metrics.js
+++ b/pages/projects/dpla-wikimedia/metrics.js
@@ -11,7 +11,8 @@ import { PRO_MENU_ENDPOINT } from "constants/content-pages";
 import utils from "stylesheets/utils.module.scss";
 import contentCss from "stylesheets/content-pages.module.scss";
 import { washObject } from "lib/washObject";
-import { safeFetch } from "lib/safeFetch";
+import { safeFetch, isUpstreamUnavailable, upstreamUnavailable } from "lib/safeFetch";
+import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
 const BREADCRUMBS = [
   { title: "Projects", url: "/projects" },
@@ -19,7 +20,8 @@ const BREADCRUMBS = [
   { title: "Wikimedia Page Views" },
 ];
 
-export default function WikimetricsPage({ items, isFilterView }) {
+export default function WikimetricsPage({ items, isFilterView, temporarilyUnavailable }) {
+  if (temporarilyUnavailable) return <ServiceUnavailable />;
   const wrapperClass = `wikimedia-metrics-wrapper${isFilterView ? " filter-view" : ""}`;
 
   return (
@@ -122,15 +124,8 @@ export async function getServerSideProps(context) {
   const isFilterView = !!(show || hub);
 
   const menuResponse = await safeFetch(PRO_MENU_ENDPOINT);
-  if (!menuResponse?.ok) {
-    if (!menuResponse || menuResponse.status >= 500) {
-      // Sidebar nav is non-critical — render page without it and signal 503
-      context.res.statusCode = 503;
-      context.res.setHeader("Retry-After", "10");
-      return { props: washObject({ items: [], isFilterView }) };
-    }
-    return { notFound: true };
-  }
+  if (isUpstreamUnavailable(menuResponse)) return upstreamUnavailable(context.res, menuResponse);
+  if (!menuResponse?.ok) return { notFound: true };
   const menuJson = await menuResponse.json();
 
   return {

--- a/pages/projects/dpla-wikimedia/metrics.js
+++ b/pages/projects/dpla-wikimedia/metrics.js
@@ -11,8 +11,7 @@ import { PRO_MENU_ENDPOINT } from "constants/content-pages";
 import utils from "stylesheets/utils.module.scss";
 import contentCss from "stylesheets/content-pages.module.scss";
 import { washObject } from "lib/washObject";
-import { safeFetch, isUpstreamUnavailable, upstreamUnavailable } from "lib/safeFetch";
-import ServiceUnavailable from "components/shared/ServiceUnavailable";
+import { safeFetch, isUpstreamUnavailable } from "lib/safeFetch";
 
 const BREADCRUMBS = [
   { title: "Projects", url: "/projects" },
@@ -20,8 +19,7 @@ const BREADCRUMBS = [
   { title: "Wikimedia Page Views" },
 ];
 
-export default function WikimetricsPage({ items, isFilterView, temporarilyUnavailable }) {
-  if (temporarilyUnavailable) return <ServiceUnavailable />;
+export default function WikimetricsPage({ items, isFilterView }) {
   const wrapperClass = `wikimedia-metrics-wrapper${isFilterView ? " filter-view" : ""}`;
 
   return (
@@ -124,7 +122,12 @@ export async function getServerSideProps(context) {
   const isFilterView = !!(show || hub);
 
   const menuResponse = await safeFetch(PRO_MENU_ENDPOINT);
-  if (isUpstreamUnavailable(menuResponse)) return upstreamUnavailable(context.res, menuResponse);
+  if (isUpstreamUnavailable(menuResponse)) {
+    await Promise.allSettled([menuResponse?.body?.cancel?.()]);
+    context.res.statusCode = 503;
+    context.res.setHeader("Retry-After", "10");
+    return { props: washObject({ items: [], isFilterView }) };
+  }
   if (!menuResponse?.ok) return { notFound: true };
   const menuJson = await menuResponse.json();
 


### PR DESCRIPTION
## Summary

- **\`lib/safeFetch.js\`**: Extends \`isUpstreamUnavailable\` to treat all 5xx responses (was only 503) as upstream unavailability. Adds test coverage for 500, 504, and the 499 boundary.
- **\`pages/contact/index.js\`** and **\`pages/projects/dpla-wikimedia/metrics.js\`**: Replaces hand-rolled \`!res || res.status >= 500\` checks with \`isUpstreamUnavailable()\`. Both pages degrade gracefully — they render with an empty sidebar and set 503 + Retry-After, rather than showing \`<ServiceUnavailable />\`, since the sidebar is non-critical content.
- **\`pages/index.js\`**: Switches \`API_SETTINGS_ENDPOINT\` from raw \`fetch()\` to \`safeFetch()\`, then uses \`isUpstreamUnavailable()\` — consistent with the rest of the file and picks up the built-in 503 retry logic.

## Test plan

- [ ] \`npm test\` passes (22 unit tests including new 500/504/499 coverage)
- [ ] \`next lint\` clean (pre-existing warnings only)
- [ ] Verify contact page renders with empty sidebar (not error page) when menu endpoint is down
- [ ] Verify wikimedia metrics page renders with empty sidebar when menu endpoint is down
- [ ] Verify home page handles WP settings endpoint 5xx via 503 retry path

🤖 Generated with [Claude Code](https://claude.com/claude-code)