### PR TITLE
fix(search): Persist prev/next buttons on items from search

### DIFF
--- a/components/ItemComponents/SearchResultsNav/index.js
+++ b/components/ItemComponents/SearchResultsNav/index.js
@@ -41,7 +41,7 @@ function SearchResultsNav() {
   const currentPath = asPath.split("?")[0];
 
   // navContext shape: { forPath, prev, next, prevQuery, nextQuery }
-  // Populated client-side from sessionStorage. Provides:
+  // Populated client-side from localStorage. Provides:
   //   - prev/next paths when not in the URL (user arrived via a neighbor link)
   //   - outgoing queries including second-level neighbors
   // Initialized to null; the effect below fills it in.

--- a/components/ItemComponents/SearchResultsNav/index.js
+++ b/components/ItemComponents/SearchResultsNav/index.js
@@ -54,7 +54,7 @@ function SearchResultsNav() {
         SEARCH_RESULTS_STORAGE_KEY_PREFIX + backUri
       );
       if (!stored) return;
-      const paths = JSON.parse(stored);
+      const { paths } = JSON.parse(stored);
       const idx = paths.indexOf(currentPath);
       if (idx === -1) return;
 

--- a/components/ItemComponents/SearchResultsNav/index.js
+++ b/components/ItemComponents/SearchResultsNav/index.js
@@ -1,39 +1,99 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 
 import Chevron from "components/svg/ChevronThickOrange";
 import { DPLA_ITEM_ID_REGEX } from "constants/items";
-import { BACK_URI_PARAM, NEXT_PARAM, PREV_PARAM } from "constants/searchNav";
+import {
+  BACK_URI_PARAM,
+  NEXT_PARAM,
+  PREV_PARAM,
+  SEARCH_RESULTS_STORAGE_KEY_PREFIX,
+} from "constants/searchNav";
 import css from "./SearchResultsNav.module.scss";
 import utils from "stylesheets/utils.module.scss";
 
 const ITEM_ID_SOURCE = DPLA_ITEM_ID_REGEX.source.replace(/^\^|\$$/g, "");
 const ITEM_PATH_RE = new RegExp(`^/item/${ITEM_ID_SOURCE}$`);
 
+function validItemPath(value) {
+  return typeof value === "string" && ITEM_PATH_RE.test(value) ? value : null;
+}
+
+function buildNeighborQuery(backUri, prevPath, nextPath) {
+  return {
+    [BACK_URI_PARAM]: backUri,
+    ...(prevPath && { [PREV_PARAM]: prevPath }),
+    ...(nextPath && { [NEXT_PARAM]: nextPath }),
+  };
+}
+
 function SearchResultsNav() {
-  const { query } = useRouter();
+  const { query, asPath } = useRouter();
 
   const backUri =
     typeof query[BACK_URI_PARAM] === "string" &&
     query[BACK_URI_PARAM].startsWith("/search")
       ? query[BACK_URI_PARAM]
       : null;
-  const prev =
-    typeof query[PREV_PARAM] === "string" && ITEM_PATH_RE.test(query[PREV_PARAM])
-      ? query[PREV_PARAM]
-      : null;
-  const next =
-    typeof query[NEXT_PARAM] === "string" && ITEM_PATH_RE.test(query[NEXT_PARAM])
-      ? query[NEXT_PARAM]
-      : null;
+  const prev = validItemPath(query[PREV_PARAM]);
+  const next = validItemPath(query[NEXT_PARAM]);
+  const currentPath = asPath.split("?")[0];
 
-  if (!backUri && !prev && !next) return null;
+  // navContext shape: { forPath, prev, next, prevQuery, nextQuery }
+  // Populated client-side from sessionStorage. Provides:
+  //   - prev/next paths when not in the URL (user arrived via a neighbor link)
+  //   - outgoing queries including second-level neighbors
+  // Initialized to null; the effect below fills it in.
+  const [navContext, setNavContext] = useState(null);
 
-  // Forward back_uri into neighbour links so the user can return to search
-  // results after navigating prev/next (neighbour pages won't have their own
-  // prev/next context, but the back link will still work).
-  const neighborQuery = backUri ? { [BACK_URI_PARAM]: backUri } : {};
+  useEffect(() => {
+    if (!backUri) return;
+    try {
+      const stored = localStorage.getItem(
+        SEARCH_RESULTS_STORAGE_KEY_PREFIX + backUri
+      );
+      if (!stored) return;
+      const paths = JSON.parse(stored);
+      const idx = paths.indexOf(currentPath);
+      if (idx === -1) return;
+
+      const prevPath = paths[idx - 1] ?? null;
+      const nextPath = paths[idx + 1] ?? null;
+
+      setNavContext({
+        forPath: currentPath,
+        prev: prevPath,
+        next: nextPath,
+        // Outgoing query for "Previous item": that item's prev is paths[idx-2],
+        // its next is the current item.
+        prevQuery: prevPath
+          ? buildNeighborQuery(backUri, paths[idx - 2] ?? null, currentPath)
+          : null,
+        // Outgoing query for "Next item": its prev is the current item,
+        // its next is paths[idx+2].
+        nextQuery: nextPath
+          ? buildNeighborQuery(backUri, currentPath, paths[idx + 2] ?? null)
+          : null,
+      });
+    } catch {
+      // localStorage unavailable
+    }
+  }, [asPath, backUri]);
+
+  // Discard navContext if stale
+  const validContext = navContext?.forPath === currentPath ? navContext : null;
+
+  const effectivePrev = validContext?.prev ?? prev;
+  const effectiveNext = validContext?.next ?? next;
+
+  if (!backUri && !effectivePrev && !effectiveNext) return null;
+
+  // Before the effect fires, outgoing links carry only back_uri. Once
+  // navContext is populated they carry the full neighborhood.
+  const fallbackQuery = backUri ? { [BACK_URI_PARAM]: backUri } : {};
+  const prevLinkQuery = validContext?.prevQuery ?? fallbackQuery;
+  const nextLinkQuery = validContext?.nextQuery ?? fallbackQuery;
 
   return (
     <div className={utils.breadcrumbsWrapper}>
@@ -44,20 +104,20 @@ function SearchResultsNav() {
             Back to results
           </Link>
         )}
-        {(prev || next) && (
+        {(effectivePrev || effectiveNext) && (
           <div className={css.prevNext}>
-            {prev && (
+            {effectivePrev && (
               <Link
-                href={{ pathname: prev, query: neighborQuery }}
+                href={{ pathname: effectivePrev, query: prevLinkQuery }}
                 className={css.prevLink}
               >
                 <Chevron className={css.prevArrow} aria-hidden="true" />
                 Previous item
               </Link>
             )}
-            {next && (
+            {effectiveNext && (
               <Link
-                href={{ pathname: next, query: neighborQuery }}
+                href={{ pathname: effectiveNext, query: nextLinkQuery }}
                 className={css.nextLink}
               >
                 Next item
@@ -72,3 +132,4 @@ function SearchResultsNav() {
 }
 
 export default SearchResultsNav;
+

--- a/components/SearchComponents/MainContent/useResultsWithContext.js
+++ b/components/SearchComponents/MainContent/useResultsWithContext.js
@@ -53,16 +53,29 @@ export function useResultsWithContext(results) {
     try {
       const now = Date.now();
       const ttl = 24 * 60 * 60 * 1000; // 24 hours
+      const maxEntries = 10;
 
-      // Evict entries older than the TTL before writing the new one.
+      // Collect all existing entries and evicting those past the TTL.
+      const surviving = [];
       for (const key of Object.keys(localStorage)) {
         if (!key.startsWith(SEARCH_RESULTS_STORAGE_KEY_PREFIX)) continue;
         try {
           const entry = JSON.parse(localStorage.getItem(key));
-          if (now - entry.ts > ttl) localStorage.removeItem(key);
+          if (now - entry.ts > ttl) {
+            localStorage.removeItem(key);
+          } else {
+            surviving.push({ key, ts: entry.ts });
+          }
         } catch {
           localStorage.removeItem(key);
         }
+      }
+
+      // If we're still at the entries limit,
+      // evict the oldest entry to make room.
+      if (surviving.length >= maxEntries) {
+        surviving.sort((a, b) => a.ts - b.ts);
+        localStorage.removeItem(surviving[0].key);
       }
 
       localStorage.setItem(

--- a/components/SearchComponents/MainContent/useResultsWithContext.js
+++ b/components/SearchComponents/MainContent/useResultsWithContext.js
@@ -44,15 +44,30 @@ export function useResultsWithContext(results) {
 
   // Persist the ordered item paths so SearchResultsNav can derive prev/next
   // even when the user arrived via a neighbour link (which only carries back_uri).
+  // A timestamp is stored alongside paths so stale entries can be evicted.
   useEffect(() => {
     const paths = itemsWithContext
       .map((item) => item.linkHref?.pathname)
       .filter(Boolean);
     if (paths.length === 0) return;
     try {
+      const now = Date.now();
+      const ttl = 24 * 60 * 60 * 1000; // 24 hours
+
+      // Evict entries older than the TTL before writing the new one.
+      for (const key of Object.keys(localStorage)) {
+        if (!key.startsWith(SEARCH_RESULTS_STORAGE_KEY_PREFIX)) continue;
+        try {
+          const entry = JSON.parse(localStorage.getItem(key));
+          if (now - entry.ts > ttl) localStorage.removeItem(key);
+        } catch {
+          localStorage.removeItem(key);
+        }
+      }
+
       localStorage.setItem(
         SEARCH_RESULTS_STORAGE_KEY_PREFIX + asPath,
-        JSON.stringify(paths)
+        JSON.stringify({ paths, ts: now })
       );
     } catch {
       // localStorage unavailable

--- a/components/SearchComponents/MainContent/useResultsWithContext.js
+++ b/components/SearchComponents/MainContent/useResultsWithContext.js
@@ -1,18 +1,28 @@
-import { useMemo } from "react";
+import { useMemo, useEffect } from "react";
 import { useRouter } from "next/router";
 
 import { addLinkInfoToResults } from "lib";
-import { BACK_URI_PARAM, NEXT_PARAM, PREV_PARAM } from "constants/searchNav";
+import {
+  BACK_URI_PARAM,
+  NEXT_PARAM,
+  PREV_PARAM,
+  SEARCH_RESULTS_STORAGE_KEY_PREFIX,
+} from "constants/searchNav";
 
 /**
  * Returns search results augmented with back_uri / prev / next query params so
  * the item page can render "Back to results" and neighbour navigation.
  * Memoised on [results, router.asPath] to avoid rebuilding the array on every
  * parent render.
+ *
+ * Also persists the ordered list of item paths to localStorage so that
+ * prev/next links continue to work after the user navigates to a neighbour
+ * item (which won't have its own prev/next URL params).
  */
 export function useResultsWithContext(results) {
   const { asPath } = useRouter();
-  return useMemo(() => {
+
+  const itemsWithContext = useMemo(() => {
     const base = addLinkInfoToResults(results);
     return base.map((item, i) => {
       if (!item.linkHref) return item;
@@ -31,4 +41,23 @@ export function useResultsWithContext(results) {
       };
     });
   }, [results, asPath]);
+
+  // Persist the ordered item paths so SearchResultsNav can derive prev/next
+  // even when the user arrived via a neighbour link (which only carries back_uri).
+  useEffect(() => {
+    const paths = itemsWithContext
+      .map((item) => item.linkHref?.pathname)
+      .filter(Boolean);
+    if (paths.length === 0) return;
+    try {
+      localStorage.setItem(
+        SEARCH_RESULTS_STORAGE_KEY_PREFIX + asPath,
+        JSON.stringify(paths)
+      );
+    } catch {
+      // localStorage unavailable
+    }
+  }, [itemsWithContext, asPath]);
+
+  return itemsWithContext;
 }

--- a/components/SearchComponents/MainContent/useResultsWithContext.js
+++ b/components/SearchComponents/MainContent/useResultsWithContext.js
@@ -71,11 +71,13 @@ export function useResultsWithContext(results) {
         }
       }
 
-      // If we're still at the entries limit,
-      // evict the oldest entry to make room.
+      // If we're at entries limit, evict oldest entries.
       if (surviving.length >= maxEntries) {
         surviving.sort((a, b) => a.ts - b.ts);
-        localStorage.removeItem(surviving[0].key);
+        const toEvict = surviving.length - maxEntries + 1;
+        for (let i = 0; i < toEvict; i++) {
+          localStorage.removeItem(surviving[i].key);
+        }
       }
 
       localStorage.setItem(

--- a/constants/searchNav.js
+++ b/constants/searchNav.js
@@ -3,3 +3,9 @@
 export const BACK_URI_PARAM = "back_uri";
 export const PREV_PARAM = "prev";
 export const NEXT_PARAM = "next";
+
+// localStorage key prefix used to persist an ordered list of item paths for
+// a given search URL so that prev/next links survive navigating between items
+// and opening items in new tabs.
+// Full key: SEARCH_RESULTS_STORAGE_KEY_PREFIX + searchAsPath
+export const SEARCH_RESULTS_STORAGE_KEY_PREFIX = "dpla:search-results:";


### PR DESCRIPTION
PR #1491 added previous+next buttons to item pages when arriving from search, by passing in `prev` and `next` query parameters to item pages. However, navigation only worked for one hop; clicking "Next item" would take you to the neighbor, but then those previous+next buttons disappear because that hop has no knowledge of its next neighbor.

This PR improves on that by storing the ordered list of item paths from a search results page in `localStorage`, keyed by the search path (query + page number). When an item page loads and has a `back_uri` query parameter, it reads its respective search results list to find its position and adds the destination's prev/next paths into each outgoing link. So the `prev` and `next` functionality via query parameters persists between items on a particular search results page.

`localStorage` is used instead of `sessionStorage` so that it works when opening an item in a new tab or window (`sessionStorage` only persists on a single tab).

Some limitations:
* This only works between the 20 search results on a single page (a user can't "next item" their way onto the following pages). But better than just one hop.
* We have to manually clean up prior search data in `localStorage`, otherwise it persists and grows. On each search, we evict any stored entries older than 24 hours, and if there are still 10 or more remaining we drop the oldest one.

I don't love this solution due to those limitations and that it's architecturally a bit weird, being a client-side solution. But it works with the current architecture without having to rework things, and is relatively light-weight. A potentially more proper way to do this could be something like, if the user is on an item page with a `back_uri`, actually perform an API call on the backend to figure out the previous and next items. But that is probably unnecessarily expensive (given each item load would make an additional API call), could increase page load times, and with us having to deal with AI scrapers, we don't want to introduce any more strain on our search endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix: Persist prev/next buttons on items from search

This PR implements client-side navigation persistence for the prev/next buttons on item detail pages when arriving from search results. When a user navigates between items within a search results page, the prev/next buttons now remain functional across multiple hops instead of breaking after a single navigation.

### Implementation approach

The solution stores the ordered list of item paths from each search results page in `localStorage`, keyed by the search path (query + page number). When an item page loads with a `back_uri` query parameter, it reads the corresponding stored list to determine the item's position and injects prev/next destinations into outgoing links. This client-side approach is compatible with the current architecture and avoids the additional API calls that a backend solution would require.

### Changes

- **`components/SearchComponents/MainContent/useResultsWithContext.js`**: Enhanced to persist ordered item paths to localStorage with a timestamp. Includes maintenance logic that evicts entries older than 24 hours and trims the store to a maximum of 10 entries to limit growth.
- **`components/ItemComponents/SearchResultsNav/index.js`**: Updated to read persisted item lists from localStorage when a `back_uri` is present, derives current/neighbor paths, and exposes prev/next with appropriate query parameters for continued navigation.
- **`constants/searchNav.js`**: Introduces `SEARCH_RESULTS_STORAGE_KEY_PREFIX` constant for shared localStorage key configuration.

### Documented limitations

- Navigation persists only across the up-to-20 results on a single search results page (does not cross paginated result pages).
- localStorage is used rather than sessionStorage, allowing the data to be available when opening items in new tabs/windows.

### No deployment impact

This change is frontend-only with no infrastructure, environment variable, database migration, or public API modifications required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->