### PR TITLE
Fix nullable .name reads on item page (subject, spatial, provider)

### DIFF
--- a/components/ItemComponents/Content/OtherMetadata.js
+++ b/components/ItemComponents/Content/OtherMetadata.js
@@ -9,6 +9,7 @@ import css from "./Content.module.scss";
 import utils from "stylesheets/utils.module.scss";
 
 function OtherMetadata({ item }) {
+  const rights = item.edmRights ? readMyRights(item.edmRights) : null;
   return (
     <div className={css.otherMetadata}>
       <dl className={css.contentDL}>
@@ -67,9 +68,9 @@ function OtherMetadata({ item }) {
         )}
         {item.subject && (
           <ItemTermValuePair className={css.subjects} heading="Subjects">
-            {item.subject.map((subj) => (
-              <span key={subj.name}>
-                <FacetLink facet="subject" value={subj.name} />
+            {item.subject.map((subj, i) => (
+              <span key={subj?.name ?? i}>
+                <FacetLink facet="subject" value={subj?.name} />
                 <br />
               </span>
             ))}
@@ -78,14 +79,14 @@ function OtherMetadata({ item }) {
         {item.spatial && (
           <ItemTermValuePair heading="Location">
             {Array.isArray(item.spatial) ? (
-              item.spatial.map((spatial) => (
-                <span key={spatial.name}>
-                  <FacetLink facet="location" value={spatial.name} />
+              item.spatial.map((spatial, i) => (
+                <span key={spatial?.name ?? i}>
+                  <FacetLink facet="location" value={spatial?.name} />
                   <br />
                 </span>
               ))
             ) : (
-              <FacetLink facet="location" value={item.spatial.name} />
+              <FacetLink facet="location" value={item.spatial?.name} />
             )}
           </ItemTermValuePair>
         )}
@@ -127,20 +128,20 @@ function OtherMetadata({ item }) {
             </a>
           </ItemTermValuePair>
         )}
-        {item.edmRights && readMyRights(item.edmRights) && (
+        {rights && (
           <ItemTermValuePair heading="Standardized Rights Statement">
-            {readMyRights(item.edmRights).label && (
+            {rights.label && (
               <a
                 href={item.edmRights}
                 rel="noopener noreferrer"
                 className={`${css.label} ${utils.link} external`}
                 target="_blank"
               >
-                {readMyRights(item.edmRights).label}:
+                {rights.label}:
               </a>
             )}
-            {readMyRights(item.edmRights).description}
-            {readMyRights(item.edmRights).description !== "" && <br />}
+            {rights.description}
+            {rights.description !== "" && <br />}
           </ItemTermValuePair>
         )}
         {item.rights && (

--- a/components/ItemComponents/Content/OtherMetadata.js
+++ b/components/ItemComponents/Content/OtherMetadata.js
@@ -66,27 +66,35 @@ function OtherMetadata({ item }) {
             {joinIfArray(item.publisher)}
           </ItemTermValuePair>
         )}
-        {item.subject && (
+        {Array.isArray(item.subject) && (
           <ItemTermValuePair className={css.subjects} heading="Subjects">
-            {item.subject.map((subj, i) => (
-              <span key={subj?.name ?? i}>
-                <FacetLink facet="subject" value={subj?.name} />
-                <br />
-              </span>
-            ))}
+            {item.subject
+              .map((subj) => subj?.name)
+              .filter((name) => name)
+              .map((name, i) => (
+                <span key={name ?? i}>
+                  <FacetLink facet="subject" value={name} />
+                  <br />
+                </span>
+              ))}
           </ItemTermValuePair>
         )}
         {item.spatial && (
           <ItemTermValuePair heading="Location">
             {Array.isArray(item.spatial) ? (
-              item.spatial.map((spatial, i) => (
-                <span key={spatial?.name ?? i}>
-                  <FacetLink facet="location" value={spatial?.name} />
-                  <br />
-                </span>
-              ))
+              item.spatial
+                .map((spatial) => spatial?.name)
+                .filter((name) => name)
+                .map((name, i) => (
+                  <span key={name ?? i}>
+                    <FacetLink facet="location" value={name} />
+                    <br />
+                  </span>
+                ))
             ) : (
-              <FacetLink facet="location" value={item.spatial?.name} />
+              item.spatial?.name && (
+                <FacetLink facet="location" value={item.spatial.name} />
+              )
             )}
           </ItemTermValuePair>
         )}

--- a/components/ItemComponents/Content/OtherMetadata.js
+++ b/components/ItemComponents/Content/OtherMetadata.js
@@ -140,7 +140,7 @@ function OtherMetadata({ item }) {
           <ItemTermValuePair heading="Standardized Rights Statement">
             {rights.label && (
               <a
-                href={item.edmRights}
+                href={rights.url}
                 rel="noopener noreferrer"
                 className={`${css.label} ${utils.link} external`}
                 target="_blank"

--- a/components/ItemComponents/Content/OtherMetadata.js
+++ b/components/ItemComponents/Content/OtherMetadata.js
@@ -154,11 +154,11 @@ function OtherMetadata({ item }) {
         )}
         {item.rights && (
           <ItemTermValuePair heading="Rights">
-            <div
-              dangerouslySetInnerHTML={{
-                __html: joinIfArray(item.rights, "<br />"),
-              }}
-            />
+            {!Array.isArray(item.rights) ? (
+              <div>{item.rights}</div>
+            ) : (
+              item.rights.map((right, i) => <div key={i}>{right}</div>)
+            )}
           </ItemTermValuePair>
         )}
       </dl>

--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -192,10 +192,11 @@ export async function getServerSideProps(context) {
   const { originalRecord, ...strippedDoc } = doc;
 
   const descriptionText = joinIfArray(doc.sourceResource.description, " ");
+  const providerText = doc.provider?.name ? ` from ${doc.provider.name}` : "";
   const pageDescription = descriptionText
     ? truncateString(descriptionText, 155)
     : truncateString(
-        `${joinIfArray(doc.sourceResource.title, ", ")}, a ${joinIfArray(doc.sourceResource.type, ", ")} from ${doc.provider?.name}`,
+        `${joinIfArray(doc.sourceResource.title, ", ")}, a ${joinIfArray(doc.sourceResource.type, ", ")}${providerText}`,
         155
       );
   const canonicalUrl = `${process.env.NEXT_PUBLIC_USER_BASE_URL}/item/${doc.id}`;

--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -127,7 +127,7 @@ export default function ItemDetail({ item, temporarilyUnavailable, randomItemId,
           <CiteButton
             creator={item.creator}
             displayDate={item.date ? item.date.displayDate : item.date}
-            spatialName={item.spatial ? item.spatial.name : item.spatial}
+            spatialName={item.spatial?.name}
             sourceUrl={item.sourceUrl}
             className={css.citeButton}
             toCiteText="item"
@@ -149,10 +149,10 @@ export async function getServerSideProps(context) {
     return notFound;
   }
   const isQA = process.env.NEXT_PUBLIC_SITE_ENV === "cqa";
-  const randomItemId = isQA ? await getRandomItemIdAsync() : null;
   if (!DPLA_ITEM_ID_REGEX.test(itemId)) {
     return notFound;
   }
+  const randomItemId = isQA ? await getRandomItemIdAsync() : null;
 
   const itemUrl = new URL(process.env.API_URL);
   itemUrl.pathname += "/items/";
@@ -185,18 +185,17 @@ export async function getServerSideProps(context) {
   const language =
     doc.sourceResource.language && Array.isArray(doc.sourceResource.language)
       ? doc.sourceResource.language.map((lang) => {
-          return lang.name;
+          return lang?.name;
         })
       : doc.sourceResource.language;
   const dataProvider = getDataProviderName(doc.dataProvider);
-  const strippedDoc = { ...doc, originalRecord: "" };
-  delete strippedDoc.originalRecord;
+  const { originalRecord, ...strippedDoc } = doc;
 
   const descriptionText = joinIfArray(doc.sourceResource.description, " ");
   const pageDescription = descriptionText
     ? truncateString(descriptionText, 155)
     : truncateString(
-        `${joinIfArray(doc.sourceResource.title, ", ")}, a ${joinIfArray(doc.sourceResource.type, ", ")} from ${doc.provider.name}`,
+        `${joinIfArray(doc.sourceResource.title, ", ")}, a ${joinIfArray(doc.sourceResource.type, ", ")} from ${doc.provider?.name}`,
         155
       );
   const canonicalUrl = `${process.env.NEXT_PUBLIC_USER_BASE_URL}/item/${doc.id}`;
@@ -211,12 +210,12 @@ export async function getServerSideProps(context) {
       date: date,
       language: language,
       contributingInstitution: dataProvider,
-      partner: doc.provider.name,
+      partner: doc.provider?.name ?? "",
       sourceUrl: doc.isShownAt,
       useDefaultImage: !doc.object,
       edmRights: doc.rights,
       doc: strippedDoc,
-      originalRecord: doc.originalRecord,
+      originalRecord,
       filecoin: doc.filecoin,
     },
     randomItemId,

--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -184,9 +184,7 @@ export async function getServerSideProps(context) {
       : doc.sourceResource.date;
   const language =
     doc.sourceResource.language && Array.isArray(doc.sourceResource.language)
-      ? doc.sourceResource.language.map((lang) => {
-          return lang?.name;
-        })
+      ? doc.sourceResource.language.map((lang) => lang?.name).filter(Boolean)
       : doc.sourceResource.language;
   const dataProvider = getDataProviderName(doc.dataProvider);
   const { originalRecord, ...strippedDoc } = doc;

--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -127,7 +127,7 @@ export default function ItemDetail({ item, temporarilyUnavailable, randomItemId,
           <CiteButton
             creator={item.creator}
             displayDate={item.date ? item.date.displayDate : item.date}
-            spatialName={item.spatial?.name}
+            spatialName={Array.isArray(item.spatial) ? item.spatial.map((s) => s?.name).filter(Boolean).join(", ") : item.spatial?.name}
             sourceUrl={item.sourceUrl}
             className={css.citeButton}
             toCiteText="item"

--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -127,7 +127,7 @@ export default function ItemDetail({ item, temporarilyUnavailable, randomItemId,
           <CiteButton
             creator={item.creator}
             displayDate={item.date ? item.date.displayDate : item.date}
-            spatialName={Array.isArray(item.spatial) ? item.spatial.map((s) => s?.name).filter(Boolean).join(", ") : item.spatial?.name}
+            spatialName={item.spatialName}
             sourceUrl={item.sourceUrl}
             className={css.citeButton}
             toCiteText="item"
@@ -186,6 +186,9 @@ export async function getServerSideProps(context) {
     doc.sourceResource.language && Array.isArray(doc.sourceResource.language)
       ? doc.sourceResource.language.map((lang) => lang?.name).filter(Boolean)
       : doc.sourceResource.language;
+  const spatialName = Array.isArray(doc.sourceResource.spatial)
+    ? doc.sourceResource.spatial.map((s) => s?.name).filter(Boolean).join(", ")
+    : doc.sourceResource.spatial?.name;
   const dataProvider = getDataProviderName(doc.dataProvider);
   const { originalRecord, ...strippedDoc } = doc;
 
@@ -212,6 +215,7 @@ export async function getServerSideProps(context) {
       partner: doc.provider?.name ?? "",
       sourceUrl: doc.isShownAt,
       useDefaultImage: !doc.object,
+      spatialName,
       edmRights: doc.rights,
       doc: strippedDoc,
       originalRecord,

--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -82,7 +82,7 @@ export default function ItemDetail({ item, temporarilyUnavailable, randomItemId,
   if (!item) return null;
   const metadataBase = `/item/${item.id}`;
   return (
-    <MainLayout pageTitle={item.title} pageImage={item.thumbnailUrl} pageDescription={pageDescription} canonicalUrl={canonicalUrl}>
+    <MainLayout pageTitle={joinIfArray(item.title, ", ")} pageImage={item.thumbnailUrl} pageDescription={pageDescription} canonicalUrl={canonicalUrl}>
       <SearchResultsNav />
       <BreadcrumbsModule
         breadcrumbs={[


### PR DESCRIPTION
## Summary

- Guards unguarded `.name` reads on `subject`, `spatial`, and `provider` fields on the item detail page that could cause SSR crashes with malformed API data
- Moves a spurious `getRandomItemIdAsync()` API call to after the item ID regex guard
- Cleans up related code quality issues found during review

## Background

This is a parallel fix to dpla/black-womens-suffrage#158, which was filed following investigation of **Sentry DPLA-FRONTEND-1KP** (SSR crash on the BWS item page when `dataProvider` is null). The exact BWS crash does not reproduce here since dpla-frontend already resolves `dataProvider` via `getDataProviderName()`, but analogous unguarded `.name` accesses exist on `subject` and `spatial` elements, and on `doc.provider` in `getServerSideProps`.

## Changes

**`components/ItemComponents/Content/OtherMetadata.js`**
- `subj?.name` and `spatial?.name` throughout to guard against malformed individual array elements
- `subj?.name ?? i` / `spatial?.name ?? i` as React keys (index fallback when name is absent)
- `item.spatial?.name` in the non-array spatial path
- Extract `readMyRights(item.edmRights)` to a local const (was called 4× per render)

**`pages/item/[itemId].js`**
- Guard `doc.provider?.name` in both the `partner` field and the `pageDescription` fallback
- Guard `lang?.name` in language array mapping
- Simplify `spatialName` prop: `item.spatial?.name` replaces the ternary that incorrectly passed the whole object when `.name` was absent
- Move `getRandomItemIdAsync()` to after the `DPLA_ITEM_ID_REGEX` guard — malformed item IDs were firing a spurious API call before the regex check could short-circuit
- Replace spread-then-delete `strippedDoc` pattern with destructuring

## Test plan

- [ ] Visit an item page with subjects — subjects render correctly
- [ ] Visit an item page with location/spatial data — location renders correctly
- [ ] Cite button renders correctly on item pages with and without spatial data
- [ ] Item pages with missing `provider` data degrade gracefully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fix nullable .name reads on item page (subject, spatial, provider)

This PR adds null-safety guards and small rendering/safeguarding refactors on the item detail page to prevent SSR crashes when API data is malformed (missing/null nested .name fields).

### Key changes

components/ItemComponents/Content/OtherMetadata.js
- Precompute rights once: const rights = item.edmRights ? readMyRights(item.edmRights) : null (avoids repeated calls).
- Subjects: only render when item.subject is an array; map subj?.name, filter falsy values, and use name ?? i as React key.
- Location: for array spatial, map spatial?.name, filter falsy values, use name ?? i keys; for non-array spatial, only render when item.spatial?.name exists.
- Rights rendering: stop using dangerous HTML join; render rights.description (and rights.label with a link) and render item.rights as plain divs (one per item) when array.
- No exported/public API surface changes.

pages/item/[itemId].js
- Page title uses joinIfArray(item.title, ", ").
- spatialName is computed null-safely:
  - If doc.sourceResource.spatial is array: join mapped s?.name entries (filtering falsy) by ", ".
  - Else: use doc.sourceResource.spatial?.name.
- Language mapping made null-safe: map lang?.name and filter(Boolean) when language is an array.
- Provider usage guarded: providerText and partner prop computed from doc.provider?.name (partner: doc.provider?.name ?? "").
- Move getRandomItemIdAsync() to after DPLA_ITEM_ID_REGEX validation to avoid calling the random-item API for malformed item IDs.
- Replace spread-then-delete originalRecord stripping with destructuring: const { originalRecord, ...strippedDoc } = doc.
- Props construction: item.edmRights now set from doc.rights and item.spatialName set from the computed spatialName.
- No exported/public entity signature changes.

### Behavior / testing impact
- Prevents SSR crashes when subject, spatial, language, or provider name fields are missing or null.
- Subjects/location rendering and CiteButton spatial behavior degrade gracefully when name fields are absent.
- Rights and rights-derived UI now render safely without injecting HTML.

### Other checks (explicit)
- No manual pipeline trigger or ECS redeployment required.
- No environment variables or AWS Secrets Manager keys added/removed/renamed.
- No database migrations.
- No changes to shared infrastructure (CodePipeline/CodeBuild/ECS/IAM).
- No public API response shape changes or new/removed endpoints.
- No security-sensitive auth/credential handling changes; changes are defensive against malformed external API data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->