### PR TITLE
fix: update Texas hub header citation link (TDL request)

### DIFF
--- a/public/static/local/texas/homepage.md
+++ b/public/static/local/texas/homepage.md
@@ -2,7 +2,7 @@
 
 TxHub makes digital photos, maps, books, artifacts, oral histories and more from libraries, archives, museums, and historical societies across the state freely available through a single site.
 
-TxHub is a partnership between [The Portal to Texas History](https://texashistory.unt.edu/) and [Texas Digital Library](https://www.tdl.org/). Citations for images in the header are [here](https://texasdigitallibrary.atlassian.net/l/cp/0Lk312Bc).
+TxHub is a partnership between [The Portal to Texas History](https://texashistory.unt.edu/) and [Texas Digital Library](https://www.tdl.org/). Citations for images in the header are available <a href="https://texasdigitallibrary.atlassian.net/wiki/external/YjE5ZWI1OGZmY2I0NDgxOGI1NWRkZWY2MGI4ZDhlNmE" target="_blank" rel="noopener noreferrer">at this link to the TDL wiki</a>.
 
 <br>
 


### PR DESCRIPTION
## Summary

- Updates the header image citation link on texas.dp.la to the new TDL wiki URL provided by the partner
- Changes link text from `here` to `at this link to the TDL wiki` for accessibility (descriptive link text)
- Adds `target="_blank" rel="noopener noreferrer"` so the link opens in a new browser tab as requested

## Test plan

- [ ] Visit texas.dp.la and confirm the citation sentence reads "Citations for images in the header are available at this link to the TDL wiki"
- [ ] Confirm the link opens in a new tab
- [ ] Confirm the link destination is https://texasdigitallibrary.atlassian.net/wiki/external/YjE5ZWI1OGZmY2I0NDgxOGI1NWRkZWY2MGI4ZDhlNmE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Updates the header image citation link on the Texas Digital Library hub homepage with a new TDL wiki URL, improves link accessibility with more descriptive text, and configures the link to open in a new browser tab.

## Changes
- **File**: `public/static/local/texas/homepage.md`
- Updated the partnership/citations sentence to replace a Markdown hyperlink with an HTML `<a>` tag
- Changed citation link URL to the new Texas Digital Library wiki address: `https://texasdigitallibrary.atlassian.net/wiki/external/YjE5ZWI1OGZmY2I0NDgxOGI1NWRkZWY2MGI4ZDhlNmE`
- Updated link text from "here" to "at this link to the TDL wiki" for improved accessibility
- Added `target="_blank"` and `rel="noopener noreferrer"` attributes to open link in new tab

## Impact
- Static content only; no code, infrastructure, or API changes
- No manual deployment or redeployment required
- Minimal risk change affecting only homepage text and links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->