### PR TITLE
fix(exhibitions): restore partner pageview tracking on exhibition home pages

### DIFF
--- a/pages/exhibitions/[exhibitionSlug]/index.js
+++ b/pages/exhibitions/[exhibitionSlug]/index.js
@@ -101,7 +101,7 @@ export async function getStaticProps(context) {
   const homeFile = homePage.page_blocks[0].attachments[0].files[0];
   const thumbnailUrl = homeFile.file_urls.fullsize;
   const dplaItemId = getDplaItemIdFromExhibit(item);
-  const dplaItemJson = loadDplaItem(dplaItemId);
+  const dplaItemJson = await loadDplaItem(dplaItemId);
 
   const props = washObject({
     thumbnailUrl,


### PR DESCRIPTION
## Summary

- `loadDplaItem` in `getStaticProps` for exhibition home pages was called without `await`, so `dplaItemJson` was always a `Promise` — serialized to `{}` by `washObject` before being passed as a prop
- As a result, `parseDplaItemRecord({})` returned empty fields for every exhibition home page, and the `gtag.event` call in `Details.componentDidMount` always fired with `"Broken ID"` as the action (the contributor/partner field) instead of the contributing institution name
- Partner and contributor pageview tracking has been silently broken for all exhibition home pages since this code was introduced; the fix is a single `await`

This was surfaced while investigating Sentry issue DPLA-FRONTEND-1A0 (`TypeError: e is not iterable` on `/exhibitions/[exhibitionSlug]`), which is an unrelated stale-chunk noise issue.

## Test plan

- [ ] Visit any exhibition home page (e.g. `/exhibitions/new-deal`) and verify no JS errors in console
- [ ] Confirm GA `View Exhibition Item` event fires with a real partner/contributor value instead of `"Broken ID"` (check Network tab → GA collect request → event action parameter)
- [ ] Verify the exhibition home page still renders correctly (thumbnail, title, sections list, text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)