### PR TITLE
feat: Log broken thumbnail URLs

### DIFF
--- a/components/ItemComponents/Content/ItemImage/index.js
+++ b/components/ItemComponents/Content/ItemImage/index.js
@@ -27,11 +27,16 @@ class ItemImage extends React.Component {
 
   updateImage() {
     const probedUrl = this.props.url;
-    this._cancelProbe = probeImage(probedUrl, () => {
-      if (this.props.url === probedUrl) {
-        this.setState({ updateToDefaultImage: true });
-      }
-    });
+    const { provider } = this.props;
+    this._cancelProbe = probeImage(
+      probedUrl,
+      () => {
+        if (this.props.url === probedUrl) {
+          this.setState({ updateToDefaultImage: true });
+        }
+      },
+      provider,
+    );
   }
 
   render() {

--- a/components/ItemComponents/Content/ItemImage/index.js
+++ b/components/ItemComponents/Content/ItemImage/index.js
@@ -27,7 +27,7 @@ class ItemImage extends React.Component {
 
   updateImage() {
     const probedUrl = this.props.url;
-    const { provider } = this.props;
+    const { provider, thumbnailSourceUrl } = this.props;
     this._cancelProbe = probeImage(
       probedUrl,
       () => {
@@ -36,6 +36,7 @@ class ItemImage extends React.Component {
         }
       },
       provider,
+      thumbnailSourceUrl,
     );
   }
 

--- a/components/ItemComponents/Content/MainMetadata.js
+++ b/components/ItemComponents/Content/MainMetadata.js
@@ -85,6 +85,7 @@ class MainMetadata extends React.Component {
                 title=""
                 type={item.type}
                 url={item.thumbnailUrl}
+                provider={item.partner}
                 defaultImageClass={css.defaultItemImage}
                 useDefaultImage={item.useDefaultImage}
               />

--- a/components/ItemComponents/Content/MainMetadata.js
+++ b/components/ItemComponents/Content/MainMetadata.js
@@ -86,6 +86,7 @@ class MainMetadata extends React.Component {
                 type={item.type}
                 url={item.thumbnailUrl}
                 provider={item.partner}
+                thumbnailSourceUrl={item.thumbnailSourceUrl}
                 defaultImageClass={css.defaultItemImage}
                 useDefaultImage={item.useDefaultImage}
               />

--- a/components/shared/ListView/ListImage.js
+++ b/components/shared/ListView/ListImage.js
@@ -30,7 +30,7 @@ class ListImage extends React.Component {
 
   updateImage() {
     const probedUrl = this.props.url;
-    const { provider } = this.props;
+    const { provider, thumbnailSourceUrl } = this.props;
     this._cancelProbe = probeImage(
       probedUrl,
       () => {
@@ -39,6 +39,7 @@ class ListImage extends React.Component {
         }
       },
       provider,
+      thumbnailSourceUrl,
     );
   }
 

--- a/components/shared/ListView/ListImage.js
+++ b/components/shared/ListView/ListImage.js
@@ -30,11 +30,16 @@ class ListImage extends React.Component {
 
   updateImage() {
     const probedUrl = this.props.url;
-    this._cancelProbe = probeImage(probedUrl, () => {
-      if (this.props.url === probedUrl) {
-        this.setState({ updateToDefaultImage: true });
-      }
-    });
+    const { provider } = this.props;
+    this._cancelProbe = probeImage(
+      probedUrl,
+      () => {
+        if (this.props.url === probedUrl) {
+          this.setState({ updateToDefaultImage: true });
+        }
+      },
+      provider,
+    );
   }
 
   render() {

--- a/components/shared/ListView/index.js
+++ b/components/shared/ListView/index.js
@@ -400,6 +400,7 @@ export default function ListView({
                 title={item.title}
                 type={item.type}
                 url={item.thumbnailUrl}
+                provider={item.provider}
                 useDefaultImage={item.useDefaultImage}
               />
               <div className={css.itemInfo}>

--- a/components/shared/ListView/index.js
+++ b/components/shared/ListView/index.js
@@ -401,6 +401,7 @@ export default function ListView({
                 type={item.type}
                 url={item.thumbnailUrl}
                 provider={item.provider}
+                thumbnailSourceUrl={item.thumbnailSourceUrl}
                 useDefaultImage={item.useDefaultImage}
               />
               <div className={css.itemInfo}>

--- a/lib/probeImage.js
+++ b/lib/probeImage.js
@@ -17,19 +17,19 @@ const BLANK_IMAGE =
 // each unique broken URL is reported at most once per browser session
 const reportedUrls = new Set();
 
-function reportThumbnailError(url, provider) {
+function reportThumbnailError(url, provider, sourceUrl) {
   if (typeof window === "undefined") return;
   if (!url || reportedUrls.has(url)) return;
   reportedUrls.add(url);
   fetch("/api/thumbnail-error", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ url, provider }),
+    body: JSON.stringify({ url, provider, sourceUrl }),
     keepalive: true,
   }).catch(() => {});
 }
 
-const probeImage = (url, onError, provider) => {
+const probeImage = (url, onError, provider, sourceUrl) => {
   if (typeof url !== "string" || url.trim() === "") {
     onError();
     return () => {};
@@ -45,14 +45,14 @@ const probeImage = (url, onError, provider) => {
 
   img.onload = () => {
     if (!cancelled && img.naturalWidth === 0) {
-      reportThumbnailError(url, provider);
+      reportThumbnailError(url, provider, sourceUrl);
       onError();
     }
     cleanup();
   };
   img.onerror = () => {
     if (!cancelled) {
-      reportThumbnailError(url, provider);
+      reportThumbnailError(url, provider, sourceUrl);
       onError();
     }
     cleanup();

--- a/lib/probeImage.js
+++ b/lib/probeImage.js
@@ -13,7 +13,23 @@
 const BLANK_IMAGE =
   "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
 
-const probeImage = (url, onError) => {
+// Session-level deduplication:
+// each unique broken URL is reported at most once per browser session
+const reportedUrls = new Set();
+
+function reportThumbnailError(url, provider) {
+  if (typeof window === "undefined") return;
+  if (!url || reportedUrls.has(url)) return;
+  reportedUrls.add(url);
+  fetch("/api/thumbnail-error", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ url, provider }),
+    keepalive: true,
+  }).catch(() => {});
+}
+
+const probeImage = (url, onError, provider) => {
   if (typeof url !== "string" || url.trim() === "") {
     onError();
     return () => {};
@@ -28,11 +44,17 @@ const probeImage = (url, onError) => {
   };
 
   img.onload = () => {
-    if (!cancelled && img.naturalWidth === 0) onError();
+    if (!cancelled && img.naturalWidth === 0) {
+      reportThumbnailError(url, provider);
+      onError();
+    }
     cleanup();
   };
   img.onerror = () => {
-    if (!cancelled) onError();
+    if (!cancelled) {
+      reportThumbnailError(url, provider);
+      onError();
+    }
     cleanup();
   };
   img.src = url;

--- a/lib/probeImage.js
+++ b/lib/probeImage.js
@@ -13,14 +13,44 @@
 const BLANK_IMAGE =
   "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
 
-// Session-level deduplication:
-// each unique broken URL is reported at most once per browser session
+// Each broken URL is reported at most once per browser session.
+// Persist in sessionStorage to check across navigation.
+const STORAGE_KEY = "dpla_reported_thumbnail_urls";
+
+// Checked once at module load; false in SSR or when storage is unavailable.
+const storageAvailable = (() => {
+  if (typeof window === "undefined") return false;
+  try {
+    sessionStorage.setItem("__dpla_test__", "1");
+    sessionStorage.removeItem("__dpla_test__");
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+// Seed from sessionStorage so prior-session reports are not repeated.
 const reportedUrls = new Set();
+if (storageAvailable) {
+  try {
+    const stored = sessionStorage.getItem(STORAGE_KEY);
+    if (stored) JSON.parse(stored).forEach((u) => reportedUrls.add(u));
+  } catch {
+    // Malformed storage value
+  }
+}
 
 function reportThumbnailError(url, provider, sourceUrl) {
   if (typeof window === "undefined") return;
   if (!url || reportedUrls.has(url)) return;
   reportedUrls.add(url);
+  if (storageAvailable) {
+    try {
+      sessionStorage.setItem(STORAGE_KEY, JSON.stringify([...reportedUrls]));
+    } catch {
+      // Quota exceeded or other storage error
+    }
+  }
   fetch("/api/thumbnail-error", {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/pages/api/thumbnail-error.js
+++ b/pages/api/thumbnail-error.js
@@ -55,6 +55,10 @@ export default function handler(req, res) {
     return res.status(400).end();
   }
 
-  console.log(JSON.stringify({ event: "thumbnail_error", url, provider, sourceUrl }));
+  // Strip query strings and hashes before logging
+  const redactedUrl = url.split(/[?#]/)[0];
+  const redactedSourceUrl = sourceUrl ? sourceUrl.split(/[?#]/)[0] : "";
+
+  console.log(JSON.stringify({ event: "thumbnail_error", url: redactedUrl, provider, sourceUrl: redactedSourceUrl }));
   return res.status(204).end();
 }

--- a/pages/api/thumbnail-error.js
+++ b/pages/api/thumbnail-error.js
@@ -1,0 +1,55 @@
+const MAX_URL_LENGTH = 2048;
+const MAX_PROVIDER_LENGTH = 256;
+const WINDOW_MS = 60_000; // 1 minute window for rate limiting
+const LIMIT = 60; // Rate limit: Max requests per window
+const ipWindows = new Map(); // ip -> { count, windowStart }
+
+// Rate limiting to prevent excessive logging
+function isRateLimited(ip) {
+  const now = Date.now();
+  const entry = ipWindows.get(ip);
+  if (!entry || now - entry.windowStart >= WINDOW_MS) {
+    // Evict expired entries when opening a new window,
+    // keeping the Map from growing unboundedly
+    for (const [key, val] of ipWindows) {
+      if (now - val.windowStart >= WINDOW_MS) ipWindows.delete(key);
+    }
+    ipWindows.set(ip, { count: 1, windowStart: now });
+    return false;
+  }
+  if (entry.count >= LIMIT) return true;
+  entry.count++;
+  return false;
+}
+
+export default function handler(req, res) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).end();
+  }
+
+  // Use the rightmost X-Forwarded-For value for remote address
+  const ip =
+    (req.headers["x-forwarded-for"] || "").split(",").at(-1)?.trim() ||
+    req.socket?.remoteAddress ||
+    "unknown";
+  if (isRateLimited(ip)) {
+    return res.status(429).end();
+  }
+
+  const url =
+    typeof req.body?.url === "string"
+      ? req.body.url.slice(0, MAX_URL_LENGTH)
+      : "";
+  const provider =
+    typeof req.body?.provider === "string"
+      ? req.body.provider.slice(0, MAX_PROVIDER_LENGTH)
+      : "";
+
+  if (!url) {
+    return res.status(400).end();
+  }
+
+  console.log(JSON.stringify({ event: "thumbnail_error", url, provider }));
+  return res.status(204).end();
+}

--- a/pages/api/thumbnail-error.js
+++ b/pages/api/thumbnail-error.js
@@ -1,5 +1,6 @@
 const MAX_URL_LENGTH = 2048;
 const MAX_PROVIDER_LENGTH = 256;
+const MAX_SOURCE_URL_LENGTH = 2048;
 const WINDOW_MS = 60_000; // 1 minute window for rate limiting
 const LIMIT = 60; // Rate limit: Max requests per window
 const ipWindows = new Map(); // ip -> { count, windowStart }
@@ -45,11 +46,15 @@ export default function handler(req, res) {
     typeof req.body?.provider === "string"
       ? req.body.provider.slice(0, MAX_PROVIDER_LENGTH)
       : "";
+  const sourceUrl =
+    typeof req.body?.sourceUrl === "string"
+      ? req.body.sourceUrl.slice(0, MAX_SOURCE_URL_LENGTH)
+      : "";
 
   if (!url) {
     return res.status(400).end();
   }
 
-  console.log(JSON.stringify({ event: "thumbnail_error", url, provider }));
+  console.log(JSON.stringify({ event: "thumbnail_error", url, provider, sourceUrl }));
   return res.status(204).end();
 }

--- a/pages/api/thumbnail-error.js
+++ b/pages/api/thumbnail-error.js
@@ -29,9 +29,8 @@ export default function handler(req, res) {
     return res.status(405).end();
   }
 
-  // Use the rightmost X-Forwarded-For value for remote address
   const ip =
-    (req.headers["x-forwarded-for"] || "").split(",").at(-1)?.trim() ||
+    (req.headers["x-forwarded-for"] || "").split(",")[0]?.trim() ||
     req.socket?.remoteAddress ||
     "unknown";
   if (isRateLimited(ip)) {

--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -206,6 +206,7 @@ export async function getServerSideProps(context) {
       ...doc.sourceResource,
       id: doc.id,
       thumbnailUrl,
+      thumbnailSourceUrl: doc.object,
       contributor: dataProvider,
       intermediateProvider: doc.intermediateProvider,
       date: date,

--- a/pages/lists/[listId].js
+++ b/pages/lists/[listId].js
@@ -95,6 +95,7 @@ const List = () => {
             return {
               ...result.sourceResource,
               thumbnailUrl,
+              thumbnailSourceUrl: result.object,
               id: result.id ? result.id : result.sourceResource["@id"],
               sourceUrl: result.isShownAt,
               provider: result.provider && result.provider.name,

--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -278,6 +278,7 @@ export async function getServerSideProps(context) {
         return {
           ...result.sourceResource,
           thumbnailUrl,
+          thumbnailSourceUrl: result.object,
           id: result.id ? result.id : result.sourceResource["@id"],
           sourceUrl: result.isShownAt,
           provider: result.provider && result.provider.name,
@@ -344,6 +345,7 @@ export async function getServerSideProps(context) {
       return {
         ...result.sourceResource,
         thumbnailUrl,
+        thumbnailSourceUrl: result.object,
         id: result.id ? result.id : result.sourceResource["@id"],
         sourceUrl: result.isShownAt,
         provider: result.provider && result.provider.name,


### PR DESCRIPTION
This PR resolves https://github.com/dpla/dpla-frontend/issues/1500 (Log thumbnail load failures for partner reporting and ingest validation).

We have a new `thumbnail-error` API endpoint that can be called to report when a thumbnail fails to load. To prevent abuse or over-logging, we have the following limits:
* Input lengths capped before logging (URL: 2048 chars, provider: 256, sourceUrl: 2048)
* Per-IP rate limit: 60 requests per minute; excess returns 429
* IP read from rightmost X-Forwarded-For used to identify client for rate limiting
* Expired rate-limit entries evicted on each new window

Our `probeImage.js` script is updated so that, when a thumbnail is expected (`object` field is defined) but fails to load, we log an error.

We do update some elements with `provider` and `thumbnailSourceUrl` so that we can surface that data in our errors.

# Example

Example of an item with a broken thumbnail:
https://dp.la/item/2513b033864b0c5eded356a7721bd97a

Enriched JSON+LD:
https://dp.la/item/2513b033864b0c5eded356a7721bd97a.json

The Enriched JSON+LD has an `object` field with value https://webconfig.digitalmaryland.org/utils/getthumbnail/collection/wclc/id/64. This is meant to be a working thumbnail URL, but it does not return anything. With this PR, since there is a defined `object` field but the thumbnail does not load, we capture the error and log it with fields `event`, `url`, `provider`, and `sourceUrl`.

```json
{
  "event": "thumbnail_error",
  "url": "https://dp.la/thumb/2513b033864b0c5eded356a7721bd97a",
  "provider": "Digital Maryland",
  "sourceUrl": "http://webconfig.digitalmaryland.org/utils/getthumbnail/collection/wclc/id/64"
}
```

# Notes

There are cases where an item purposefully does not have a thumbnail attached, in which case we do _not_ log an error. The obvious case is when an item genuinely does not have an image. Another example are items that came from the now-retired Artstor; these originally had Artstor thumbnails attached (which can be seen in the "original record" data), but have since been removed from the enriched JSON+LD. While the images are now available on JSTOR, we need to reingest them. These items won't report thumbnails errors, which is fine because we already know the entire dataset needs to be reingested and errors would just be noise.

# CodeRabbit Summary
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## High-Level Summary

This PR implements client-side thumbnail error reporting with a backend logging endpoint to capture broken thumbnail URLs for partner reporting and ingest validation. When images fail to load (network errors or zero-width), the client reports the failure with provider and source metadata; a new lightweight API endpoint logs these reports as structured JSON lines to stdout for CloudWatch ingestion with per-IP rate limiting.

### Key Implementation Details

**New API Endpoint** (pages/api/thumbnail-error.js)
- POST-only Next.js API route that accepts `url`, `provider`, and `sourceUrl`.
- Per-IP rate limiting: 60 requests per 60-second window; excessive requests return HTTP 429.
- Client IP is read from the rightmost `X-Forwarded-For` header, falling back to `req.socket.remoteAddress` or `"unknown"`.
- Input truncation: url (2048 chars), provider (256 chars), sourceUrl (2048 chars).
- Strips query strings and URL fragments from `url` and `sourceUrl` before logging.
- Emits structured JSON log lines to stdout: `{ "event": "thumbnail_error", url, provider, sourceUrl }`.
- Returns HTTP 204 on success, 400 if `url` missing/empty, 405 for non-POST methods.
- Keeps an in-memory Map for rate-limit state and evicts expired entries on each new window to prevent unbounded growth.

**Client-Side Reporting** (lib/probeImage.js and components)
- probeImage signature updated to accept `provider` and `sourceUrl` (from component props) and still invokes the same onError/cancellation logic.
- Reports broken thumbnails on both `img.onerror` and `img.onload` when `naturalWidth === 0`.
- Session-level deduplication via `sessionStorage` (each distinct broken URL reported at most once per browser session).
- Uses `fetch` with `keepalive: true` to send reports (works on page unload); reporting is a no-op during SSR or when `window` is unavailable.
- Components (ItemImage, ListImage, ListView, MainMetadata, pages) thread `provider` and `thumbnailSourceUrl` from server-side item data (`doc.object`) down into probeImage so reports include metadata.

### Security & Operational Considerations

- New public POST endpoint accepts unauthenticated external inputs (URLs and provider/source strings); rate limiting (60 req/IP/min) and input length caps mitigate abuse and DoS risks.
- Reports redact query strings and fragments before logging to reduce sensitive data leakage.
- Session deduplication reduces client-side noise but relies on client-side storage and can be bypassed by clearing storage or different browsers.
- In-memory rate-limit state is not persistent across process restarts or redeploys (per-process); expired entries are evicted proactively.
- Logs to stdout for CloudWatch ingestion; structured JSON lines enable metric filters, Logs Insights queries, alarms, and partner-facing rank reports.

### Infrastructure & Deployment Impact

- No database migrations.
- No new or changed environment variables or AWS Secrets Manager keys.
- No changes to shared infra (CodePipeline, CodeBuild, ECS task definitions, IAM policies).
- No manual pipeline trigger or ECS redeployment is required for code to take effect beyond the normal deployment process (standard deployment needed to roll this code to production).
- The new endpoint is a public API route (adds an endpoint but does not change existing API response shapes).

### Files / Functional Changes (high level)
- Added pages/api/thumbnail-error.js (new API handler).
- Updated lib/probeImage.js to accept and report provider/sourceUrl with session dedupe.
- Threaded thumbnailSourceUrl and provider metadata through pages and components: pages/search/index.js, pages/item/[itemId].js, pages/lists/[listId].js, components/ItemComponents/Content/ItemImage/index.js, components/shared/ListView/ListImage.js, components/shared/ListView/index.js, components/ItemComponents/Content/MainMetadata.js.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->