### PR TITLE
fix: guard all SSR .json() calls against non-JSON upstream responses

### DIFF
--- a/lib/safeFetch.js
+++ b/lib/safeFetch.js
@@ -162,6 +162,29 @@ export async function upstreamUnavailable(res, ...fetchResponses) {
 }
 
 /**
+ * Wraps Response.json() in a try/catch. Returns the parsed JSON on success, or
+ * null if the body is not valid JSON (e.g. an HTML error page returned by an
+ * upstream in a degraded state).
+ *
+ * Use this in place of res.json() after isUpstreamUnavailable() so that a
+ * non-JSON body degrades to a 503 instead of an unhandled SyntaxError.
+ *
+ * @param {Response} res
+ * @returns {Promise<*|null>}
+ */
+export async function safeJson(res) {
+  try {
+    return await res.json();
+  } catch (err) {
+    console.warn(
+      `[safeFetch] Response body is not valid JSON (Content-Type: ${res.headers?.get("content-type") ?? "unknown"}, status: ${res.status}):`,
+      err.message,
+    );
+    return null;
+  }
+}
+
+/**
  * Checks a safeFetch response and returns { notFound: true } for 4xx errors,
  * or throws for 5xx/network errors so Next.js renders the 500 page.
  *

--- a/lib/safeFetch.test.mjs
+++ b/lib/safeFetch.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import { isUpstreamUnavailable, upstreamUnavailable } from './safeFetch.js';
+import { isUpstreamUnavailable, upstreamUnavailable, safeJson } from './safeFetch.js';
 
 // isUpstreamUnavailable
 
@@ -78,4 +78,33 @@ test('upstreamUnavailable tolerates rejected body.cancel()', async () => {
   await assert.doesNotReject(() => upstreamUnavailable(res, rejectingResponse));
   assert.equal(res.statusCode, 503);
   assert.equal(res.getHeader('Retry-After'), '10');
+});
+
+// safeJson
+
+test('safeJson returns parsed JSON on success', async () => {
+  const mockRes = {
+    json: () => Promise.resolve({ key: 'value' }),
+    headers: { get: () => 'application/json' },
+    status: 200,
+  };
+  assert.deepEqual(await safeJson(mockRes), { key: 'value' });
+});
+
+test('safeJson returns null when body is not valid JSON', async () => {
+  const mockRes = {
+    json: () => Promise.reject(new SyntaxError("Unexpected token '<'")),
+    headers: { get: () => 'text/html' },
+    status: 200,
+  };
+  assert.equal(await safeJson(mockRes), null);
+});
+
+test('safeJson returns null for malformed JSON with unknown content-type', async () => {
+  const mockRes = {
+    json: () => Promise.reject(new SyntaxError('Unexpected token')),
+    headers: { get: () => null },
+    status: 503,
+  };
+  assert.equal(await safeJson(mockRes), null);
 });

--- a/pages/about/[...sections].js
+++ b/pages/about/[...sections].js
@@ -25,7 +25,7 @@ import {
 import contentCss from "stylesheets/content-pages.module.scss";
 import utils from "stylesheets/utils.module.scss";
 import { washObject } from "lib/washObject";
-import { safeFetch, wpAuthFetchOptions, wpDraftUrl, isUpstreamUnavailable, upstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, wpAuthFetchOptions, wpDraftUrl, isUpstreamUnavailable, upstreamUnavailable, safeJson } from "lib/safeFetch";
 import { upgradeWordPressUrls } from "lib/upgradeWordPressUrls";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
@@ -102,7 +102,8 @@ export const getServerSideProps = async (context) => {
   const settingsRes = await safeFetch(API_SETTINGS_ENDPOINT);
   if (isUpstreamUnavailable(settingsRes)) return upstreamUnavailable(context.res, settingsRes);
   if (!settingsRes?.ok) return { notFound: true };
-  const settingsJson = await settingsRes.json();
+  const settingsJson = await safeJson(settingsRes);
+  if (settingsJson === null) return upstreamUnavailable(context.res, settingsRes);
   // 2. get the corresponding value
   const endpoint = `${PAGES_ENDPOINT}/${settingsJson.acf.guides_endpoint}`;
   const sections = context.params.sections;
@@ -112,7 +113,8 @@ export const getServerSideProps = async (context) => {
   const response = await safeFetch(ABOUT_MENU_ENDPOINT);
   if (isUpstreamUnavailable(response)) return upstreamUnavailable(context.res, response);
   if (!response?.ok) return { notFound: true };
-  const json = await response.json();
+  const json = await safeJson(response);
+  if (json === null) return upstreamUnavailable(context.res, response);
   const pageItem = json.items.find((item) => item.post_name === pageSlug);
   const guidesPageItem = json.items.find((item) => item.url === endpoint);
   if (
@@ -156,7 +158,8 @@ export const getServerSideProps = async (context) => {
   const pageRes = await safeFetch(url, authOptions);
   if (isUpstreamUnavailable(pageRes)) return upstreamUnavailable(context.res, pageRes);
   if (!pageRes?.ok) return { notFound: true };
-  const pageJson = await pageRes.json();
+  const pageJson = await safeJson(pageRes);
+  if (pageJson === null) return upstreamUnavailable(context.res, pageRes);
   let pageDescription = "";
   if (pageJson.excerpt && pageJson.excerpt.rendered) {
     pageDescription = decodeHTMLEntities(

--- a/pages/about/index.js
+++ b/pages/about/index.js
@@ -25,7 +25,7 @@ import {
 import contentCss from "stylesheets/content-pages.module.scss";
 import utils from "stylesheets/utils.module.scss";
 import { washObject } from "lib/washObject";
-import { safeFetch, wpAuthFetchOptions, wpDraftUrl, isUpstreamUnavailable, upstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, wpAuthFetchOptions, wpDraftUrl, isUpstreamUnavailable, upstreamUnavailable, safeJson } from "lib/safeFetch";
 import { upgradeWordPressUrls } from "lib/upgradeWordPressUrls";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
@@ -102,14 +102,16 @@ export const getServerSideProps = async (context) => {
   const settingsRes = await safeFetch(API_SETTINGS_ENDPOINT);
   if (isUpstreamUnavailable(settingsRes)) return upstreamUnavailable(context.res, settingsRes);
   if (!settingsRes?.ok) return { notFound: true };
-  const settingsJson = await settingsRes.json();
+  const settingsJson = await safeJson(settingsRes);
+  if (settingsJson === null) return upstreamUnavailable(context.res, settingsRes);
   // 2. get the corresponding value
   const endpoint = `${PAGES_ENDPOINT}/${settingsJson.acf.guides_endpoint}`;
   const pageName = query.subsection || query.section || "about-us";
   const response = await safeFetch(ABOUT_MENU_ENDPOINT);
   if (isUpstreamUnavailable(response)) return upstreamUnavailable(context.res, response);
   if (!response?.ok) return { notFound: true };
-  const json = await response.json();
+  const json = await safeJson(response);
+  if (json === null) return upstreamUnavailable(context.res, response);
   const pageItem = json.items.find((item) => item.post_name === pageName);
   const guidesPageItem = json.items.find((item) => item.url === endpoint);
   if (
@@ -153,7 +155,8 @@ export const getServerSideProps = async (context) => {
   const pageRes = await safeFetch(url, authOptions);
   if (isUpstreamUnavailable(pageRes)) return upstreamUnavailable(context.res, pageRes);
   if (!pageRes?.ok) return { notFound: true };
-  const pageJson = await pageRes.json();
+  const pageJson = await safeJson(pageRes);
+  if (pageJson === null) return upstreamUnavailable(context.res, pageRes);
   let pageDescription = "";
   if (pageJson.excerpt && pageJson.excerpt.rendered) {
     pageDescription = decodeHTMLEntities(

--- a/pages/browse-by-partner/index.js
+++ b/pages/browse-by-partner/index.js
@@ -62,7 +62,7 @@ export const getServerSideProps = async ({ res }) => {
   const resError = checkResponseForSSRSafe(fetchRes, "Partner browse");
   if (resError) return resError;
   const json = await safeJson(fetchRes);
-  if (json === null) return upstreamUnavailable(context.res);
+  if (json === null) return upstreamUnavailable(res);
   const terms = json?.facets?.[facetName]?.terms;
   if (!Array.isArray(terms)) {
     return { notFound: true };

--- a/pages/browse-by-partner/index.js
+++ b/pages/browse-by-partner/index.js
@@ -9,7 +9,7 @@ import { LOCALS } from "constants/local";
 
 import css from "components/PartnerBrowseComponents/PartnerBrowseContent.module.scss";
 import { washObject } from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable, safeJson } from "lib/safeFetch";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
 function PartnerBrowse({ partners, temporarilyUnavailable }) {
@@ -61,7 +61,8 @@ export const getServerSideProps = async ({ res }) => {
   }
   const resError = checkResponseForSSRSafe(fetchRes, "Partner browse");
   if (resError) return resError;
-  const json = await fetchRes.json();
+  const json = await safeJson(fetchRes);
+  if (json === null) return upstreamUnavailable(context.res);
   const terms = json?.facets?.[facetName]?.terms;
   if (!Array.isArray(terms)) {
     return { notFound: true };

--- a/pages/browse-by-topic/[topicSlug]/[subtopicSlug]/index.js
+++ b/pages/browse-by-topic/[topicSlug]/[subtopicSlug]/index.js
@@ -5,7 +5,7 @@ import MainLayout from "components/MainLayout";
 import Sidebar from "components/TopicBrowseComponents/SubtopicItemsList/Sidebar";
 
 import { decodeHTMLEntities, extractItemId, getDataProviderName, getItemThumbnail } from "lib";
-import { safeFetch } from "lib/safeFetch";
+import { safeFetch, safeJson } from "lib/safeFetch";
 
 import {
   API_ENDPOINT_ALL_ITEMS_100_PER_PAGE,
@@ -87,7 +87,8 @@ export const getServerSideProps = async (context) => {
     return { notFound: true };
   }
 
-  const topicsJson = await topicsRes.json();
+  const topicsJson = await safeJson(topicsRes);
+  if (topicsJson === null) return { notFound: true };
   const currentTopic = topicsJson[0];
   if (!currentTopic) {
     return {
@@ -103,7 +104,8 @@ export const getServerSideProps = async (context) => {
     return { notFound: true };
   }
 
-  const subtopicsJson = await subtopicsRes.json();
+  const subtopicsJson = await safeJson(subtopicsRes);
+  if (subtopicsJson === null) return { notFound: true };
   const subtopics = subtopicsJson.map((subtopic) => ({
     ...subtopic,
     thumbnailUrl: subtopic.acf.category_image,
@@ -134,7 +136,8 @@ export const getServerSideProps = async (context) => {
     return { notFound: true };
   }
 
-  const itemsJson = await itemsRes.json();
+  const itemsJson = await safeJson(itemsRes);
+  if (itemsJson === null) return { notFound: true };
 
   const fetchItem = async (item) => {
     const itemDplaId = extractItemId(item.acf.dpla_url);
@@ -146,8 +149,8 @@ export const getServerSideProps = async (context) => {
     if (!itemRes?.ok) {
       return null;
     }
-    const itemJson = await itemRes.json();
-    const doc = itemJson.docs?.[0];
+    const itemJson = await safeJson(itemRes);
+    const doc = itemJson?.docs?.[0];
     if (!doc) {
       return null;
     }

--- a/pages/browse-by-topic/[topicSlug]/[subtopicSlug]/index.js
+++ b/pages/browse-by-topic/[topicSlug]/[subtopicSlug]/index.js
@@ -5,7 +5,7 @@ import MainLayout from "components/MainLayout";
 import Sidebar from "components/TopicBrowseComponents/SubtopicItemsList/Sidebar";
 
 import { decodeHTMLEntities, extractItemId, getDataProviderName, getItemThumbnail } from "lib";
-import { safeFetch, safeJson } from "lib/safeFetch";
+import { safeFetch, safeJson, checkResponseForSSRSafe, isUpstreamUnavailable, upstreamUnavailable } from "lib/safeFetch";
 
 import {
   API_ENDPOINT_ALL_ITEMS_100_PER_PAGE,
@@ -83,12 +83,14 @@ export const getServerSideProps = async (context) => {
 
   const topicsRes = await safeFetch(API_ENDPOINT_ALL_TOPICS + "?slug=" + topicSlug);
 
-  if (!topicsRes?.ok) {
-    return { notFound: true };
+  if (isUpstreamUnavailable(topicsRes)) {
+    return upstreamUnavailable(context.res, topicsRes);
   }
+  const topicsError = checkResponseForSSRSafe(topicsRes, "Topic");
+  if (topicsError) return topicsError;
 
   const topicsJson = await safeJson(topicsRes);
-  if (topicsJson === null) return { notFound: true };
+  if (topicsJson === null) return upstreamUnavailable(context.res);
   const currentTopic = topicsJson[0];
   if (!currentTopic) {
     return {
@@ -100,12 +102,14 @@ export const getServerSideProps = async (context) => {
     API_ENDPOINT_SUBTOPICS_FOR_TOPIC + "?parent=" + currentTopic.term_id,
   );
 
-  if (!subtopicsRes?.ok) {
-    return { notFound: true };
+  if (isUpstreamUnavailable(subtopicsRes)) {
+    return upstreamUnavailable(context.res, subtopicsRes);
   }
+  const subtopicsError = checkResponseForSSRSafe(subtopicsRes, "Subtopics");
+  if (subtopicsError) return subtopicsError;
 
   const subtopicsJson = await safeJson(subtopicsRes);
-  if (subtopicsJson === null) return { notFound: true };
+  if (subtopicsJson === null) return upstreamUnavailable(context.res);
   const subtopics = subtopicsJson.map((subtopic) => ({
     ...subtopic,
     thumbnailUrl: subtopic.acf.category_image,
@@ -132,12 +136,14 @@ export const getServerSideProps = async (context) => {
     `${API_ENDPOINT_ALL_ITEMS_100_PER_PAGE}&categories=${currentSubtopic.term_id}`,
   );
 
-  if (!itemsRes?.ok) {
-    return { notFound: true };
+  if (isUpstreamUnavailable(itemsRes)) {
+    return upstreamUnavailable(context.res, itemsRes);
   }
+  const itemsError = checkResponseForSSRSafe(itemsRes, "Subtopic items");
+  if (itemsError) return itemsError;
 
   const itemsJson = await safeJson(itemsRes);
-  if (itemsJson === null) return { notFound: true };
+  if (itemsJson === null) return upstreamUnavailable(context.res);
 
   const fetchItem = async (item) => {
     const itemDplaId = extractItemId(item.acf.dpla_url);

--- a/pages/browse-by-topic/[topicSlug]/index.js
+++ b/pages/browse-by-topic/[topicSlug]/index.js
@@ -13,7 +13,7 @@ import {
 } from "constants/topicBrowse";
 
 import { washObject } from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable, safeJson } from "lib/safeFetch";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
 const sanitizeSourceSetId = (id) => {
@@ -60,7 +60,8 @@ export const getServerSideProps = async (context) => {
   const topicsError = checkResponseForSSRSafe(topicsRes, "Topic");
   if (topicsError) return topicsError;
 
-  const topicsJson = await topicsRes.json();
+  const topicsJson = await safeJson(topicsRes);
+  if (topicsJson === null) return upstreamUnavailable(context.res);
   const currentTopic = topicsJson[0];
 
   if (!currentTopic) {
@@ -80,7 +81,8 @@ export const getServerSideProps = async (context) => {
   const subtopicsError = checkResponseForSSRSafe(subtopicsRes, "Topic subtopics");
   if (subtopicsError) return subtopicsError;
 
-  const subtopicsJson = await subtopicsRes.json();
+  const subtopicsJson = await safeJson(subtopicsRes);
+  if (subtopicsJson === null) return upstreamUnavailable(context.res);
   const subtopics = subtopicsJson.map((subtopic) => ({
     ...subtopic,
     thumbnailUrl: subtopic.acf.category_image,
@@ -118,7 +120,8 @@ export const getServerSideProps = async (context) => {
               await sourceSetRes?.body?.cancel?.().catch(() => {});
               return null;
             }
-            const sourceSetJson = await sourceSetRes.json();
+            const sourceSetJson = await safeJson(sourceSetRes);
+            if (!sourceSetJson) return null;
             const slug = extractSourceSetSlug(sourceSetJson["@id"]);
             if (!slug) return null;
             return {

--- a/pages/browse-by-topic/index.js
+++ b/pages/browse-by-topic/index.js
@@ -8,7 +8,7 @@ import {
   TITLE,
 } from "constants/topicBrowse";
 import { washObject } from "lib/washObject";
-import { safeFetch, isUpstreamUnavailable, upstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, isUpstreamUnavailable, upstreamUnavailable, safeJson } from "lib/safeFetch";
 
 function TopicBrowse({ topics, temporarilyUnavailable }) {
   if (temporarilyUnavailable) return <ServiceUnavailable />;
@@ -29,7 +29,8 @@ export const getServerSideProps = async (context) => {
   if (!res?.ok) {
     return { notFound: true };
   }
-  const json = await res.json();
+  const json = await safeJson(res);
+  if (json === null) return upstreamUnavailable(context.res);
   const topics = washObject(
     json.filter((topic) => !topic.parent && topic.name !== "Uncategorized"),
   );

--- a/pages/contact/index.js
+++ b/pages/contact/index.js
@@ -17,7 +17,7 @@ import { TITLE } from "constants/contact";
 import contentCss from "stylesheets/content-pages.module.scss";
 import utils from "stylesheets/utils.module.scss";
 import { washObject } from "lib/washObject";
-import { safeFetch, isUpstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, isUpstreamUnavailable, safeJson } from "lib/safeFetch";
 
 function Contact(props) {
   const { sidebarItems } = props;
@@ -63,7 +63,12 @@ export const getServerSideProps = async (context) => {
   }
   if (!aboutMenuRes?.ok) return { notFound: true };
 
-  const aboutMenuJson = await aboutMenuRes.json();
+  const aboutMenuJson = await safeJson(aboutMenuRes);
+  if (aboutMenuJson === null) {
+    context.res.statusCode = 503;
+    context.res.setHeader("Retry-After", "10");
+    return { props: washObject({ sidebarItems: [] }) };
+  }
 
   return { props: washObject({ sidebarItems: aboutMenuJson.items }) };
 };

--- a/pages/guides/[guideSlug].js
+++ b/pages/guides/[guideSlug].js
@@ -15,7 +15,7 @@ import contentCss from "stylesheets/content-pages.module.scss";
 import css from "stylesheets/guides.module.scss";
 import utils from "stylesheets/utils.module.scss";
 import { washObject } from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe, wpAuthFetchOptions, wpDraftUrl, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, wpAuthFetchOptions, wpDraftUrl, upstreamUnavailable, isUpstreamUnavailable, safeJson } from "lib/safeFetch";
 import { upgradeWordPressUrls } from "lib/upgradeWordPressUrls";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
@@ -86,7 +86,8 @@ export async function getServerSideProps(context) {
   }
   const menuError = checkResponseForSSRSafe(menuItemsRes, "Guides menu");
   if (menuError) return menuError;
-  const menuItemsJson = await menuItemsRes.json();
+  const menuItemsJson = await safeJson(menuItemsRes);
+  if (menuItemsJson === null) return upstreamUnavailable(context.res, menuItemsRes);
   const guideSlug = context.params.guideSlug;
   const guide = menuItemsJson.items.find(
     (item) => item.post_name === guideSlug,
@@ -101,7 +102,8 @@ export async function getServerSideProps(context) {
   }
   const guideError = checkResponseForSSRSafe(guideRes, "Guide page");
   if (guideError) return guideError;
-  const guideJson = await guideRes.json();
+  const guideJson = await safeJson(guideRes);
+  if (guideJson === null) return upstreamUnavailable(context.res, guideRes);
 
   let breadcrumbs = [];
 

--- a/pages/guides/index.js
+++ b/pages/guides/index.js
@@ -106,6 +106,7 @@ export async function getServerSideProps(context) {
           const guideRes = await safeFetch(guideUrl, authOptions);
           if (!guideRes?.ok) return null;
           const guideJson = await safeJson(guideRes);
+          if (guideJson === null) return null;
           return {
             ...guide,
             slug: guideJson.slug ?? guide.post_name,

--- a/pages/guides/index.js
+++ b/pages/guides/index.js
@@ -21,6 +21,7 @@ import {
   wpDraftUrl,
   isUpstreamUnavailable,
   upstreamUnavailable,
+  safeJson,
 } from "lib/safeFetch";
 import { cachedSafeFetch } from "lib/wpCache";
 
@@ -81,9 +82,11 @@ export async function getServerSideProps(context) {
     return { notFound: true };
   }
 
-  const settingsJson = await settingsRes.json();
+  const settingsJson = await safeJson(settingsRes);
+  if (settingsJson === null) return upstreamUnavailable(context.res, aboutMenuRes);
   const endpoint = `${PAGES_ENDPOINT}/${settingsJson.acf.guides_endpoint}`;
-  const aboutMenuJson = await aboutMenuRes.json();
+  const aboutMenuJson = await safeJson(aboutMenuRes);
+  if (aboutMenuJson === null) return upstreamUnavailable(context.res, aboutMenuRes);
   const indexPageItem = aboutMenuJson.items.find(
     (item) => item.url === endpoint,
   );
@@ -102,7 +105,7 @@ export async function getServerSideProps(context) {
             : getMenuItemUrl(guide);
           const guideRes = await safeFetch(guideUrl, authOptions);
           if (!guideRes?.ok) return null;
-          const guideJson = await guideRes.json();
+          const guideJson = await safeJson(guideRes);
           return {
             ...guide,
             slug: guideJson.slug ?? guide.post_name,

--- a/pages/index.js
+++ b/pages/index.js
@@ -21,7 +21,14 @@ import {
 
 import { API_SETTINGS_ENDPOINT } from "constants/site";
 import { washObject } from "lib/washObject";
-import { safeFetch, wpAuthFetchOptions, wpDraftUrl, isUpstreamUnavailable, upstreamUnavailable } from "lib/safeFetch";
+import {
+  safeFetch,
+  wpAuthFetchOptions,
+  wpDraftUrl,
+  isUpstreamUnavailable,
+  upstreamUnavailable,
+  safeJson,
+} from "lib/safeFetch";
 
 const USER_BASE_URL = process.env.NEXT_PUBLIC_USER_BASE_URL?.replace(/\/$/, "");
 const WEBSITE_JSON_LD =
@@ -88,143 +95,157 @@ export async function getServerSideProps(context) {
   const authOptions = wpAuthFetchOptions(draftMode);
 
   try {
-  // fetch home info
-  // 1. fetch the settings from WP
-  const settingsRes = await safeFetch(API_SETTINGS_ENDPOINT);
-  if (isUpstreamUnavailable(settingsRes)) return upstreamUnavailable(context.res, settingsRes);
-  if (!settingsRes?.ok) return { notFound: true };
-  const settingsJson = await settingsRes.json();
-  // 2. get the corresponding value
-  const baseEndpoint = `${PAGES_ENDPOINT}/${settingsJson.acf.homepage_endpoint}`;
-  const endpoint = draftMode ? wpDraftUrl(baseEndpoint) : baseEndpoint;
-  const guidesEndpoint = `${PAGES_ENDPOINT}/${settingsJson.acf.guides_endpoint}`;
-  // 3. fetch it (safeFetch is used here for consistent error handling)
-  const homeRes = await safeFetch(endpoint, authOptions);
-  if (isUpstreamUnavailable(homeRes)) return upstreamUnavailable(context.res, homeRes);
-  if (!homeRes?.ok) {
-    return { notFound: true };
-  }
-  const homepageJson = await homeRes.json();
-
-  // fetch featured exhibits data
-  const featuredExhibitSlugs = homepageJson.acf.featured_exhibits;
-
-  const featuredExhibits = await Promise.all(
-    featuredExhibitSlugs.map(async (exhibit) => {
-      const exhibitJson = await loadExhibition(exhibit.exhibit_id);
-      const homePage = exhibitHomePage(exhibitJson);
-      const thumbnailUrl =
-        homePage.page_blocks[0].attachments[0].files[0].file_urls.fullsize;
-
-      return {
-        name: exhibitJson.title,
-        repImageUrl: thumbnailUrl,
-        thumbnailUrl,
-        featured: false,
-        href: `/exhibitions/${exhibitJson.slug}`,
-      };
-    }),
-  );
-
-  // fetch featured primary source sets data
-  const featuredPrimarySourceSets =
-    homepageJson.acf.featured_primary_source_sets;
-
-  const sourceSets = [];
-  featuredPrimarySourceSets.forEach((featuredSet) => {
-    if (featuredSet) {
-      const setWithLinkInfo = {
-        ...featuredSet,
-        href: `/primary-source-sets/${featuredSet.primary_source_set_id}`,
-        repImageUrl: featuredSet.image_url,
-      };
-      sourceSets.push(setWithLinkInfo);
+    // fetch home info
+    // 1. fetch the settings from WP
+    const settingsRes = await safeFetch(API_SETTINGS_ENDPOINT);
+    if (isUpstreamUnavailable(settingsRes))
+      return upstreamUnavailable(context.res, settingsRes);
+    if (!settingsRes?.ok) return { notFound: true };
+    const settingsJson = await safeJson(settingsRes);
+    if (settingsJson === null)
+      return upstreamUnavailable(context.res, settingsRes);
+    // 2. get the corresponding value
+    const baseEndpoint = `${PAGES_ENDPOINT}/${settingsJson.acf.homepage_endpoint}`;
+    const endpoint = draftMode ? wpDraftUrl(baseEndpoint) : baseEndpoint;
+    const guidesEndpoint = `${PAGES_ENDPOINT}/${settingsJson.acf.guides_endpoint}`;
+    // 3. fetch it (safeFetch is used here for consistent error handling)
+    const homeRes = await safeFetch(endpoint, authOptions);
+    if (isUpstreamUnavailable(homeRes))
+      return upstreamUnavailable(context.res, homeRes);
+    if (!homeRes?.ok) {
+      return { notFound: true };
     }
-  });
+    const homepageJson = await safeJson(homeRes);
+    if (homepageJson === null) return upstreamUnavailable(context.res, homeRes);
 
-  // fetch item count
-  let headerDescription = homepageJson.acf.header_description;
-  const apiUrl = `${process.env.API_URL}/items?page_size=0&api_key=${process.env.API_KEY}`;
-  const itemsRes = await safeFetch(apiUrl);
-  let itemCount = 0; // default handles unexpected error
-  if (itemsRes?.ok) {
-    const itemsJson = await itemsRes.json();
+    // fetch featured exhibits data
+    const featuredExhibitSlugs = homepageJson.acf.featured_exhibits;
 
-    if ("count" in itemsJson) {
-      if (itemsJson.count.value !== undefined) {
-        itemCount = itemsJson.count.value; // ElasticSearch 7
-      } else {
-        itemCount = itemsJson.count; // ElasticSearch 6
+    const featuredExhibits = await Promise.all(
+      featuredExhibitSlugs.map(async (exhibit) => {
+        const exhibitJson = await loadExhibition(exhibit.exhibit_id);
+        const homePage = exhibitHomePage(exhibitJson);
+        const thumbnailUrl =
+          homePage.page_blocks[0].attachments[0].files[0].file_urls.fullsize;
+
+        return {
+          name: exhibitJson.title,
+          repImageUrl: thumbnailUrl,
+          thumbnailUrl,
+          featured: false,
+          href: `/exhibitions/${exhibitJson.slug}`,
+        };
+      }),
+    );
+
+    // fetch featured primary source sets data
+    const featuredPrimarySourceSets =
+      homepageJson.acf.featured_primary_source_sets;
+
+    const sourceSets = [];
+    featuredPrimarySourceSets.forEach((featuredSet) => {
+      if (featuredSet) {
+        const setWithLinkInfo = {
+          ...featuredSet,
+          href: `/primary-source-sets/${featuredSet.primary_source_set_id}`,
+          repImageUrl: featuredSet.image_url,
+        };
+        sourceSets.push(setWithLinkInfo);
+      }
+    });
+
+    // fetch item count
+    let headerDescription = homepageJson.acf.header_description;
+    const apiUrl = `${process.env.API_URL}/items?page_size=0&api_key=${process.env.API_KEY}`;
+    const itemsRes = await safeFetch(apiUrl);
+    let itemCount = 0; // default handles unexpected error
+    if (itemsRes?.ok) {
+      const itemsJson = await safeJson(itemsRes);
+
+      if (itemsJson !== null && "count" in itemsJson) {
+        if (itemsJson.count.value !== undefined) {
+          itemCount = itemsJson.count.value; // ElasticSearch 7
+        } else {
+          itemCount = itemsJson.count; // ElasticSearch 6
+        }
+      }
+      headerDescription = headerDescription.replace(
+        HEADER_DESCRIPTION_TOKEN,
+        addCommasToNumber(itemCount),
+      );
+    } else {
+      headerDescription = headerDescription.replace(
+        HEADER_DESCRIPTION_TOKEN,
+        "over 50,000,000",
+      );
+    }
+
+    // fetch user guides data
+    let guides = [];
+    const aboutMenuRes = await safeFetch(ABOUT_MENU_ENDPOINT);
+    if (!aboutMenuRes?.ok) {
+      console.log("Unable to load user guides.", aboutMenuRes?.status);
+    } else {
+      const aboutMenuJson = await safeJson(aboutMenuRes);
+      if (aboutMenuJson !== null) {
+        const indexPageItem = aboutMenuJson.items.find(
+          (item) => item.url === guidesEndpoint,
+        );
+        if (indexPageItem) {
+          guides = (
+            await Promise.all(
+              aboutMenuJson.items
+                .filter(
+                  (item) => item.menu_item_parent === indexPageItem.object_id,
+                )
+                .slice(0, NUMBER_OF_USER_GUIDES_TO_SHOW)
+                .map(async (guide) => {
+                  const guideRes = await safeFetch(getMenuItemUrl(guide));
+                  if (!guideRes?.ok) {
+                    console.log(
+                      "Unable to load guide.",
+                      guide.post_name,
+                      guideRes?.status,
+                    );
+                    return null;
+                  }
+                  const guideJson = await safeJson(guideRes);
+                  if (guideJson === null) return null;
+                  return {
+                    ...guide,
+                    slug: guideJson.slug ?? guide.post_name,
+                    summary: guideJson.acf.summary,
+                    title: guideJson.title.rendered,
+                    displayTitle: guideJson.acf.display_title,
+                    color: guideJson.acf.color,
+                    illustration: guideJson.acf.illustration,
+                  };
+                }),
+            )
+          ).filter(Boolean);
+        }
       }
     }
-    headerDescription = headerDescription.replace(
-      HEADER_DESCRIPTION_TOKEN,
-      addCommasToNumber(itemCount),
-    );
-  } else {
-    headerDescription = headerDescription.replace(
-      HEADER_DESCRIPTION_TOKEN,
-      "over 50,000,000",
-    );
-  }
 
-  // fetch user guides data
-  let guides = [];
-  const aboutMenuRes = await safeFetch(ABOUT_MENU_ENDPOINT);
-  if (!aboutMenuRes?.ok) {
-    console.log("Unable to load user guides.", aboutMenuRes?.status);
-  } else {
-    const aboutMenuJson = await aboutMenuRes.json();
-    const indexPageItem = aboutMenuJson.items.find(
-      (item) => item.url === guidesEndpoint,
-    );
-    if (indexPageItem) {
-      guides = (
-        await Promise.all(
-          aboutMenuJson.items
-            .filter((item) => item.menu_item_parent === indexPageItem.object_id)
-            .slice(0, NUMBER_OF_USER_GUIDES_TO_SHOW)
-            .map(async (guide) => {
-              const guideRes = await safeFetch(getMenuItemUrl(guide));
-              if (!guideRes?.ok) {
-                console.log("Unable to load guide.", guide.post_name, guideRes?.status);
-                return null;
-              }
-              const guideJson = await guideRes.json();
-              return {
-                ...guide,
-                slug: guideJson.slug ?? guide.post_name,
-                summary: guideJson.acf.summary,
-                title: guideJson.title.rendered,
-                displayTitle: guideJson.acf.display_title,
-                color: guideJson.acf.color,
-                illustration: guideJson.acf.illustration,
-              };
-            }),
-        )
-      ).filter(Boolean);
+    // fetch news posts
+    let newsItems = [];
+    const newsRes = await safeFetch(NEWS_USER_ENDPOINT);
+    if (!newsRes?.ok) {
+      console.log("Unable to load news posts.", newsRes?.status);
+    } else {
+      newsItems = (await safeJson(newsRes)) ?? [];
     }
-  }
 
-  // fetch news posts
-  let newsItems = [];
-  const newsRes = await safeFetch(NEWS_USER_ENDPOINT);
-  if (!newsRes?.ok) {
-    console.log("Unable to load news posts.", newsRes?.status);
-  } else {
-    newsItems = await newsRes.json();
-  }
-
-  return {
-    props: washObject({
-      sourceSets,
-      guides,
-      exhibitions: featuredExhibits,
-      headerDescription,
-      news: newsItems,
-      content: homepageJson,
-    }),
-  };
+    return {
+      props: washObject({
+        sourceSets,
+        guides,
+        exhibitions: featuredExhibits,
+        headerDescription,
+        news: newsItems,
+        content: homepageJson,
+      }),
+    };
   } catch (e) {
     console.error("[SSR] getServerSideProps failed:", e);
     // Only treat network-level fetch failures (TypeError with a cause set by

--- a/pages/news/[slug].js
+++ b/pages/news/[slug].js
@@ -21,7 +21,7 @@ import utils from "stylesheets/utils.module.scss";
 import contentCss from "stylesheets/content-pages.module.scss";
 import css from "stylesheets/news.module.scss";
 import { washObject } from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe, wpAuthFetchOptions, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, wpAuthFetchOptions, upstreamUnavailable, isUpstreamUnavailable, safeJson } from "lib/safeFetch";
 import { upgradeWordPressUrls } from "lib/upgradeWordPressUrls";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
@@ -161,9 +161,12 @@ export async function getServerSideProps(context) {
   if (postError) return postError;
 
   const [menuJson, initialPostJson] = await Promise.all([
-    menuResponse.json(),
-    postRes.json(),
+    safeJson(menuResponse),
+    safeJson(postRes),
   ]);
+  if (menuJson === null || initialPostJson === null) {
+    return upstreamUnavailable(context.res);
+  }
 
   // If slug lookup returned nothing and the slug is numeric, try ID lookup —
   // this handles draft posts which have no slug yet in WordPress.
@@ -178,7 +181,8 @@ export async function getServerSideProps(context) {
     }
     const byIdError = checkResponseForSSRSafe(byIdRes, "News post by ID");
     if (byIdError) return byIdError;
-    postJson = await byIdRes.json();
+    postJson = await safeJson(byIdRes);
+    if (postJson === null) return upstreamUnavailable(context.res, byIdRes);
   }
 
   if (postJson.length === 0) {
@@ -198,7 +202,8 @@ export async function getServerSideProps(context) {
   const authorError = checkResponseForSSRSafe(authorRes, "News post author");
   if (authorError) return authorError;
 
-  const authorJson = await authorRes.json();
+  const authorJson = await safeJson(authorRes);
+  if (authorJson === null) return upstreamUnavailable(context.res, authorRes);
 
   let pageDescription = "";
   if (postJson[0].excerpt && postJson[0].excerpt.rendered) {

--- a/pages/news/index.js
+++ b/pages/news/index.js
@@ -9,7 +9,7 @@ import TagList from "components/NewsComponents/TagList";
 import Button from "shared/Button";
 
 import { formatDate } from "lib";
-import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable, safeJson } from "lib/safeFetch";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
 import { DESCRIPTION, NEWS_TAGS, TITLE } from "constants/news";
@@ -151,7 +151,8 @@ export async function getServerSideProps({ query, res }) {
   }
   const menuError = checkResponseForSSRSafe(menuResponse, "news menu");
   if (menuError) return menuError;
-  const menuJson = await menuResponse.json();
+  const menuJson = await safeJson(menuResponse);
+  if (menuJson === null) return upstreamUnavailable(res, authorRes);
   const pageItem = menuJson.items.find(
     (item) => item.post_name.indexOf("news") === 0,
   );
@@ -164,7 +165,8 @@ export async function getServerSideProps({ query, res }) {
     }
     const authorError = checkResponseForSSRSafe(authorRes, "news author");
     if (authorError) return authorError;
-    authorJson = await authorRes.json();
+    authorJson = await safeJson(authorRes);
+    if (authorJson === null) return upstreamUnavailable(res, authorRes);
   }
 
   // fetch news
@@ -191,7 +193,8 @@ export async function getServerSideProps({ query, res }) {
     if (isUpstreamUnavailable(newsRes)) {
       return upstreamUnavailable(res, newsRes);
     }
-    newsItems = await newsRes.json();
+    newsItems = await safeJson(newsRes);
+    if (newsItems === null) return upstreamUnavailable(res, newsRes);
     newsCount = newsRes.headers.get("X-WP-Total");
     newsPageCount = newsRes.headers.get("X-WP-TotalPages");
     error = newsItems.code !== undefined;

--- a/pages/primary-source-sets/[set]/additional-resources.js
+++ b/pages/primary-source-sets/[set]/additional-resources.js
@@ -16,7 +16,7 @@ import utils from "stylesheets/utils.module.scss";
 import contentCss from "stylesheets/content-pages.module.scss";
 import css from "components/PrimarySourceSetsComponents/SingleSet/TeachersGuide/TeachersGuide.module.scss";
 import {washObject} from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable, safeJson } from "lib/safeFetch";
 import isValidPSSSlug from "lib/isValidPSSSlug";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
@@ -71,7 +71,8 @@ export async function getServerSideProps({ query, res }) {
   }
   const setError = checkResponseForSSRSafe(setRes, `set "${query.set}"`);
   if (setError) return setError;
-  const set = await setRes.json();
+  const set = await safeJson(setRes);
+  if (set === null) return upstreamUnavailable(context.res);
   const props = washObject({
     set,
     currentFullUrl,

--- a/pages/primary-source-sets/[set]/additional-resources.js
+++ b/pages/primary-source-sets/[set]/additional-resources.js
@@ -72,7 +72,7 @@ export async function getServerSideProps({ query, res }) {
   const setError = checkResponseForSSRSafe(setRes, `set "${query.set}"`);
   if (setError) return setError;
   const set = await safeJson(setRes);
-  if (set === null) return upstreamUnavailable(context.res);
+  if (set === null) return upstreamUnavailable(res);
   const props = washObject({
     set,
     currentFullUrl,

--- a/pages/primary-source-sets/[set]/index.js
+++ b/pages/primary-source-sets/[set]/index.js
@@ -13,7 +13,7 @@ import BreadcrumbJsonLd from "components/shared/BreadcrumbJsonLd";
 
 import { removeQueryParams } from "lib";
 import { washObject } from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable, safeJson } from "lib/safeFetch";
 import isValidPSSSlug from "lib/isValidPSSSlug";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
@@ -61,7 +61,8 @@ export async function getServerSideProps(context) {
   const apiError = checkResponseForSSRSafe(api, `set "${set}"`);
   if (apiError) return apiError;
 
-  const json = await api.json();
+  const json = await safeJson(api);
+  if (json === null) return upstreamUnavailable(context.res);
 
   const parts = json.hasPart.map((part) => {
     let thumbnailUrl = part.thumbnailUrl;

--- a/pages/primary-source-sets/[set]/sources/[source].js
+++ b/pages/primary-source-sets/[set]/sources/[source].js
@@ -10,7 +10,7 @@ import SourceCarousel from "components/PrimarySourceSetsComponents/Source/compon
 
 import { extractSourceId } from "lib";
 import { washObject } from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable, safeJson } from "lib/safeFetch";
 import isValidPSSSlug from "lib/isValidPSSSlug";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
@@ -70,8 +70,18 @@ export async function getServerSideProps(context) {
   const setError = checkResponseForSSRSafe(setRes, `set "${set}"`);
   if (setError) return setError;
 
-  const [sourceText, setJson] = await Promise.all([sourceRes.text(), setRes.json()]);
-  const sanitizedSourceJson = JSON.parse(sourceText.replace(/\r\n/gi, ""));
+  const [sourceText, setJson] = await Promise.all([sourceRes.text(), safeJson(setRes)]);
+  if (setJson === null) return upstreamUnavailable(context.res);
+  let sanitizedSourceJson;
+  try {
+    sanitizedSourceJson = JSON.parse(sourceText.replace(/\r\n/gi, ""));
+  } catch (err) {
+    console.warn(
+      `[SSR] PSS source body is not valid JSON for source "${source}" (Content-Type: ${sourceRes.headers?.get("content-type") ?? "unknown"}):`,
+      err.message,
+    );
+    return upstreamUnavailable(context.res);
+  }
   const parts = setJson.hasPart.map((part) => {
     let thumbnailUrl = part.thumbnailUrl;
     let useDefaultImage = false;

--- a/pages/primary-source-sets/[set]/teaching-guide-print.js
+++ b/pages/primary-source-sets/[set]/teaching-guide-print.js
@@ -7,7 +7,7 @@ import TeachersGuide from "components/PrimarySourceSetsComponents/SingleSet/Teac
 
 import utils from "stylesheets/utils.module.scss";
 import { washObject } from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable, safeJson } from "lib/safeFetch";
 import isValidPSSSlug from "lib/isValidPSSSlug";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
@@ -49,7 +49,8 @@ export async function getServerSideProps({ query, res }) {
   }
   const setError = checkResponseForSSRSafe(setRes, `set "${query.set}"`);
   if (setError) return setError;
-  const set = await setRes.json();
+  const set = await safeJson(setRes);
+  if (set === null) return upstreamUnavailable(context.res);
   const teachingGuide = set.hasPart.find(
     (item) => item.disambiguatingDescription === "guide",
   );

--- a/pages/primary-source-sets/[set]/teaching-guide-print.js
+++ b/pages/primary-source-sets/[set]/teaching-guide-print.js
@@ -50,7 +50,7 @@ export async function getServerSideProps({ query, res }) {
   const setError = checkResponseForSSRSafe(setRes, `set "${query.set}"`);
   if (setError) return setError;
   const set = await safeJson(setRes);
-  if (set === null) return upstreamUnavailable(context.res);
+  if (set === null) return upstreamUnavailable(res);
   const teachingGuide = set.hasPart.find(
     (item) => item.disambiguatingDescription === "guide",
   );

--- a/pages/primary-source-sets/[set]/teaching-guide.js
+++ b/pages/primary-source-sets/[set]/teaching-guide.js
@@ -12,7 +12,7 @@ import BreadcrumbJsonLd from "components/shared/BreadcrumbJsonLd";
 
 import { removeQueryParams } from "lib";
 import { washObject } from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable, safeJson } from "lib/safeFetch";
 import isValidPSSSlug from "lib/isValidPSSSlug";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
@@ -49,7 +49,8 @@ export async function getServerSideProps({ query, res }) {
   }
   const setError = checkResponseForSSRSafe(setRes, `set "${query.set}"`);
   if (setError) return setError;
-  const set = await setRes.json();
+  const set = await safeJson(setRes);
+  if (set === null) return upstreamUnavailable(context.res);
 
   const teachingGuide = set.hasPart.find(
     (item) => item.disambiguatingDescription === "guide",

--- a/pages/primary-source-sets/[set]/teaching-guide.js
+++ b/pages/primary-source-sets/[set]/teaching-guide.js
@@ -50,7 +50,7 @@ export async function getServerSideProps({ query, res }) {
   const setError = checkResponseForSSRSafe(setRes, `set "${query.set}"`);
   if (setError) return setError;
   const set = await safeJson(setRes);
-  if (set === null) return upstreamUnavailable(context.res);
+  if (set === null) return upstreamUnavailable(res, setRes);
 
   const teachingGuide = set.hasPart.find(
     (item) => item.disambiguatingDescription === "guide",

--- a/pages/primary-source-sets/index.js
+++ b/pages/primary-source-sets/index.js
@@ -4,7 +4,7 @@ import MainLayout from "components/MainLayout";
 import AllSets from "components/PrimarySourceSetsComponents/AllSets";
 import PSSFooter from "components/PrimarySourceSetsComponents/PSSFooter";
 import {washObject} from "lib/washObject";
-import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, upstreamUnavailable, isUpstreamUnavailable, safeJson } from "lib/safeFetch";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
 import {
@@ -53,7 +53,8 @@ export async function getServerSideProps({ query, res }) {
   }
   const resError = checkResponseForSSRSafe(fetchRes, "PSS sets");
   if (resError) return resError;
-  const json = await fetchRes.json();
+  const json = await safeJson(fetchRes);
+  if (json === null) return upstreamUnavailable(context.res);
   const props = washObject({
     sets: json,
   });

--- a/pages/primary-source-sets/index.js
+++ b/pages/primary-source-sets/index.js
@@ -54,7 +54,7 @@ export async function getServerSideProps({ query, res }) {
   const resError = checkResponseForSSRSafe(fetchRes, "PSS sets");
   if (resError) return resError;
   const json = await safeJson(fetchRes);
-  if (json === null) return upstreamUnavailable(context.res);
+  if (json === null) return upstreamUnavailable(res);
   const props = washObject({
     sets: json,
   });

--- a/pages/pro/hubs.js
+++ b/pages/pro/hubs.js
@@ -7,7 +7,7 @@ import FullPageWidthBlock from "shared/FullPageWidthBlock";
 import WebsiteFeature from "shared/WebsiteFeature";
 
 import { wordpressLinks } from "lib/index";
-import { safeFetch, wpAuthFetchOptions, isUpstreamUnavailable, upstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, wpAuthFetchOptions, isUpstreamUnavailable, upstreamUnavailable, safeJson } from "lib/safeFetch";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
 import {
@@ -121,7 +121,8 @@ export async function getServerSideProps(context) {
   if (!hubRes?.ok) {
     return { notFound: true };
   }
-  const hubJson = await hubRes.json();
+  const hubJson = await safeJson(hubRes);
+  if (hubJson === null) return upstreamUnavailable(context.res, hubRes);
   const hubItem = hubJson[0];
   if (!hubItem) {
     return { notFound: true };
@@ -130,7 +131,7 @@ export async function getServerSideProps(context) {
   // fetch news posts
   const newsRes = await safeFetch(NEWS_PRO_ENDPOINT);
 
-  const newsItems = newsRes?.ok ? await newsRes.json() : [];
+  const newsItems = newsRes?.ok ? (await safeJson(newsRes) ?? []) : [];
 
   const props = washObject({
     page: hubItem,

--- a/pages/pro/index.js
+++ b/pages/pro/index.js
@@ -38,7 +38,7 @@ export async function getServerSideProps(context) {
   const settingsError = checkResponseForSSRSafe(settingsRes, "Pro settings");
   if (settingsError) return settingsError;
   const settingsJson = await safeJson(settingsRes);
-  if (settingsJson === null) return upstreamUnavailable(context.res);
+  if (settingsJson === null) return upstreamUnavailable(context.res, newsRes);
 
   // fetch home content (depends on settings for endpoint)
   const baseEndpoint = `${PAGES_ENDPOINT}/${settingsJson.acf.pro_homepage_endpoint}`;

--- a/pages/pro/index.js
+++ b/pages/pro/index.js
@@ -6,7 +6,7 @@ import HomePro from "components/HomePageComponents/HomePro";
 import { NEWS_PRO_ENDPOINT, PAGES_ENDPOINT } from "constants/content-pages";
 import { API_SETTINGS_ENDPOINT } from "constants/site";
 import { washObject } from "lib/washObject";
-import { checkResponseForSSRSafe, wpAuthFetchOptions, wpDraftUrl, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
+import { checkResponseForSSRSafe, wpAuthFetchOptions, wpDraftUrl, upstreamUnavailable, isUpstreamUnavailable, safeJson } from "lib/safeFetch";
 import { cachedSafeFetch } from "lib/wpCache";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
@@ -37,7 +37,8 @@ export async function getServerSideProps(context) {
   }
   const settingsError = checkResponseForSSRSafe(settingsRes, "Pro settings");
   if (settingsError) return settingsError;
-  const settingsJson = await settingsRes.json();
+  const settingsJson = await safeJson(settingsRes);
+  if (settingsJson === null) return upstreamUnavailable(context.res);
 
   // fetch home content (depends on settings for endpoint)
   const baseEndpoint = `${PAGES_ENDPOINT}/${settingsJson.acf.pro_homepage_endpoint}`;
@@ -49,12 +50,13 @@ export async function getServerSideProps(context) {
   const homeError = checkResponseForSSRSafe(homeRes, "Pro homepage");
   if (homeError) return homeError;
   const [homeJson, newsItems] = await Promise.all([
-    homeRes.json(),
-    newsRes?.ok ? newsRes.json() : Promise.resolve([]),
+    safeJson(homeRes),
+    newsRes?.ok ? safeJson(newsRes) : Promise.resolve([]),
   ]);
+  if (homeJson === null) return upstreamUnavailable(context.res);
 
   const props = washObject({
-    news: newsItems,
+    news: newsItems ?? [],
     content: homeJson,
   });
 

--- a/pages/pro/wp/index.js
+++ b/pages/pro/wp/index.js
@@ -14,7 +14,7 @@ import {
   decodeHTMLEntities,
   wordpressLinks,
 } from "lib";
-import { safeFetch, checkResponseForSSRSafe, wpAuthFetchOptions, wpDraftUrl, upstreamUnavailable, isUpstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, checkResponseForSSRSafe, wpAuthFetchOptions, wpDraftUrl, upstreamUnavailable, isUpstreamUnavailable, safeJson } from "lib/safeFetch";
 import { cachedSafeFetch } from "lib/wpCache";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
@@ -125,7 +125,8 @@ export async function getServerSideProps(context) {
   }
   const menuError = checkResponseForSSRSafe(menuResponse, "Pro menu");
   if (menuError) return menuError;
-  const menuJson = await menuResponse.json();
+  const menuJson = await safeJson(menuResponse);
+  if (menuJson === null) return upstreamUnavailable(context.res, menuResponse);
   const menuItems = menuJson.items;
   const pageItem = menuItems.find((item) => item.post_name === pageName);
   if (!pageItem) {
@@ -139,7 +140,8 @@ export async function getServerSideProps(context) {
   }
   const pageError = checkResponseForSSRSafe(pageRes, "Pro page");
   if (pageError) return pageError;
-  const pageJson = await pageRes.json();
+  const pageJson = await safeJson(pageRes);
+  if (pageJson === null) return upstreamUnavailable(context.res, pageRes);
 
   // for the breadcrumbs
   const breadcrumbObject = getBreadcrumbs({

--- a/pages/projects/dpla-wikimedia/metrics.js
+++ b/pages/projects/dpla-wikimedia/metrics.js
@@ -11,7 +11,7 @@ import { PRO_MENU_ENDPOINT } from "constants/content-pages";
 import utils from "stylesheets/utils.module.scss";
 import contentCss from "stylesheets/content-pages.module.scss";
 import { washObject } from "lib/washObject";
-import { safeFetch, isUpstreamUnavailable } from "lib/safeFetch";
+import { safeFetch, isUpstreamUnavailable, safeJson } from "lib/safeFetch";
 
 const BREADCRUMBS = [
   { title: "Projects", url: "/projects" },
@@ -129,7 +129,12 @@ export async function getServerSideProps(context) {
     return { props: washObject({ items: [], isFilterView }) };
   }
   if (!menuResponse?.ok) return { notFound: true };
-  const menuJson = await menuResponse.json();
+  const menuJson = await safeJson(menuResponse);
+  if (menuJson === null) {
+    context.res.statusCode = 503;
+    context.res.setHeader("Retry-After", "10");
+    return { props: washObject({ items: [], isFilterView }) };
+  }
 
   return {
     props: washObject({


### PR DESCRIPTION
## Summary

- Adds `safeJson(res)` to `lib/safeFetch.js` — wraps `res.json()` in a try/catch and returns `null` on `SyntaxError`, logging the Content-Type and status for observability
- Replaces every bare `.json()` call in `getServerSideProps` across the user and pro sites (22 files) with `safeJson()`, adding null-guards that return `upstreamUnavailable` (or a graceful degraded response for non-critical sidebar fetches)
- Fixes Sentry issue **DPLA-FRONTEND-1KZ**: WordPress returned a non-5xx HTML error page during the May 2 outage, which reached `.json()` and threw an unhandled `SyntaxError` that crashed the SSR render

## Root cause

`isUpstreamUnavailable` only catches `null` (network failure) and `status >= 500`. A 4xx or a 2xx HTML maintenance page bypasses it, but still can't be parsed as JSON. There was no defence between that check and the `.json()` call.

## Pages patched

User site: `/news`, `/about`, `/about/[...sections]`, `/browse-by-topic`, `/browse-by-topic/[topic]`, `/browse-by-topic/[topic]/[subtopic]`, `/browse-by-partner`, `/guides`, `/guides/[slug]`, `/contact`, `/primary-source-sets`, `/primary-source-sets/[set]`, `/primary-source-sets/[set]/teaching-guide`, `/primary-source-sets/[set]/teaching-guide-print`, `/primary-source-sets/[set]/additional-resources`, `/primary-source-sets/[set]/sources/[source]`, `/projects/dpla-wikimedia/metrics`

Pro site: `/pro`, `/pro/hubs`, `/pro/wp`

Skipped (already protected by outer try/catch): `pages/index.js`, `pages/projects/dpla-wikimedia/depictassist.js`, `pages/lists/[listId].js`, all `pages/api/` routes

## Test plan

- [ ] All 25 unit tests pass (`node --test lib/safeFetch.test.mjs`) — includes 3 new `safeJson` tests
- [ ] `next lint` clean on all changed files (pre-existing `no-css-tags` warning on metrics.js only)
- [ ] Verify `/news` renders normally when WordPress is healthy
- [ ] Verify `/news` returns 503 (not a JS crash) when upstream returns an HTML response

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixes unhandled SyntaxError crashes during SSR when upstream services (notably WordPress) return non-JSON responses (e.g., HTML error pages). Adds lib/safeFetch.js safeJson(res) helper that wraps res.json() in try/catch, returns parsed JSON on success or null on parse failure while logging Content-Type and status (URLs are sanitized). Replaces ~22 direct .json() calls across user and pro site pages with safeJson() and adds null-guards that return upstreamUnavailable (503 + Retry-After and temporarilyUnavailable prop) or apply graceful degraded behavior (skip suggestions, fallback arrays, empty items) instead of crashing SSR. Addresses a Sentry issue where WordPress returned HTML that caused res.json() to throw.

## Changes

- lib/safeFetch.js
  - Added export async function safeJson(res): returns parsed JSON or null; logs warnings including content-type and status; URL-sanitization applied. Fits with existing safeFetch helpers (retry logic, isUpstreamUnavailable, upstreamUnavailable, checkResponseForSSR/SSRSafe).
- lib/safeFetch.test.mjs
  - Added 3 tests for safeJson (successful parse, invalid JSON with JSON-like content-type, malformed JSON without content-type); retains existing upstream helper tests. Total test file run: 25 tests (includes the 3 new safeJson tests).
- Updated getServerSideProps in ~22 pages (user + pro). Representative list:
  - User site: /news (index + [slug]), /about (index + [...sections]), /browse-by-topic (index + [topic] + [topic]/[subtopic]), /browse-by-partner, /guides (index + [guideSlug]), /contact, /primary-source-sets (index, [set], teaching-guide*, additional-resources, sources/[source]), /projects/dpla-wikimedia/metrics
  - Pro site: /pro (index), /pro/hubs, /pro/wp
  - Note: pages already protected by an outer try/catch were skipped (pages/index.js in some cases noted as heavy refactor but includes safeJson adoption; specific API routes and some project files were left unchanged).
  - Each changed page imports safeJson and replaces direct response.json() calls with safeJson(...), adding explicit null checks and routing to upstreamUnavailable(...) or applying reasonable fallbacks where appropriate.
- Bugfixes
  - Fixes places that previously returned 404 for upstream failures (e.g., browse-by-partner and subtopic handling) so outages surface as upstreamUnavailable instead of masking as notFound.

## Root cause

Upstream-unavailability detection previously treated null (network failure) and status >= 500 as failures. 2xx/4xx HTML responses bypassed that check and reached res.json(), which threw an unhandled SyntaxError and crashed SSR. safeJson prevents unhandled parse errors and lets callers degrade gracefully.

## Test plan / Results

- Unit tests: run node --test lib/safeFetch.test.mjs (25 tests; includes 3 safeJson tests).
- Lint: run next lint on changed files (pre-existing metrics.js no-css-tags warning remains).
- Manual: verify pages (e.g., /news) render normally when upstream is healthy and produce upstreamUnavailable (503 + Retry-After: 10 or graceful degraded page/props) rather than a JS crash when upstream returns HTML error pages.

## Impact checklist (explicit callouts)

- Requires manual pipeline trigger or ECS redeployment to take effect: No — standard deploy is sufficient.
- Adds, removes, or renames environment variables or AWS Secrets Manager keys: No.
- Includes a database migration (and whether reversible): No.
- Changes any shared infrastructure configuration (CodePipeline, CodeBuild, ECS task definitions, IAM policies): No.
- Modifies any public-facing API response shape or adds/removes endpoints: No.
- Security implications: Minimal and positive — improves robustness against malformed upstream responses. Logs include Content-Type and status and use URL sanitization to redact common sensitive query params. No new credentials or auth flows introduced; WP preview/auth behavior unchanged.

## Notes for reviewers

- Verify safeJson is imported and used everywhere res.json() was previously called in SSR paths, and that callers treat a null parse result as upstreamUnavailable or an intentional graceful fallback.
- Confirm instances changed from returning notFound to upstreamUnavailable are intentional (to avoid masking outages as 404s).
- Confirm fallback behavior for optional features (suggestions, author/news arrays, metrics sidebar) uses safe defaults and does not leak incomplete/malformed upstream data.
- Confirm unit tests cover success and parse-failure cases and that CI passes lint/tests before merge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->