### PR TITLE
fix: return 503 instead of 404 when DPLA API is unavailable

### DIFF
--- a/pages/browse-by-partner/index.js
+++ b/pages/browse-by-partner/index.js
@@ -64,7 +64,7 @@ export const getServerSideProps = async ({ res }) => {
   const json = await fetchRes.json();
   const terms = json?.facets?.[facetName]?.terms;
   if (!Array.isArray(terms)) {
-    return { notFound: true };
+    return upstreamUnavailable(res);
   }
 
   const partners = washObject(

--- a/pages/browse-by-topic/[topicSlug]/[subtopicSlug]/index.js
+++ b/pages/browse-by-topic/[topicSlug]/[subtopicSlug]/index.js
@@ -5,7 +5,8 @@ import MainLayout from "components/MainLayout";
 import Sidebar from "components/TopicBrowseComponents/SubtopicItemsList/Sidebar";
 
 import { decodeHTMLEntities, extractItemId, getDataProviderName, getItemThumbnail } from "lib";
-import { safeFetch } from "lib/safeFetch";
+import { safeFetch, isUpstreamUnavailable, upstreamUnavailable } from "lib/safeFetch";
+import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
 import {
   API_ENDPOINT_ALL_ITEMS_100_PER_PAGE,
@@ -19,7 +20,8 @@ import utils from "stylesheets/utils.module.scss";
 import { washObject } from "lib/washObject";
 
 function SubtopicItemsList(props) {
-  const { topic, subtopic, previousSubtopic, nextSubtopic, items } = props;
+  const { topic, subtopic, previousSubtopic, nextSubtopic, items, temporarilyUnavailable } = props;
+  if (temporarilyUnavailable) return <ServiceUnavailable />;
   if (!topic || !subtopic) return null;
   return (
     <MainLayout pageTitle={subtopic.name} pageImage={subtopic.thumbnailUrl}>
@@ -83,9 +85,8 @@ export const getServerSideProps = async (context) => {
 
   const topicsRes = await safeFetch(API_ENDPOINT_ALL_TOPICS + "?slug=" + topicSlug);
 
-  if (!topicsRes?.ok) {
-    return { notFound: true };
-  }
+  if (isUpstreamUnavailable(topicsRes)) return upstreamUnavailable(context.res, topicsRes);
+  if (!topicsRes?.ok) return { notFound: true };
 
   const topicsJson = await topicsRes.json();
   const currentTopic = topicsJson[0];
@@ -99,9 +100,8 @@ export const getServerSideProps = async (context) => {
     API_ENDPOINT_SUBTOPICS_FOR_TOPIC + "?parent=" + currentTopic.term_id,
   );
 
-  if (!subtopicsRes?.ok) {
-    return { notFound: true };
-  }
+  if (isUpstreamUnavailable(subtopicsRes)) return upstreamUnavailable(context.res, subtopicsRes);
+  if (!subtopicsRes?.ok) return { notFound: true };
 
   const subtopicsJson = await subtopicsRes.json();
   const subtopics = subtopicsJson.map((subtopic) => ({
@@ -130,9 +130,8 @@ export const getServerSideProps = async (context) => {
     `${API_ENDPOINT_ALL_ITEMS_100_PER_PAGE}&categories=${currentSubtopic.term_id}`,
   );
 
-  if (!itemsRes?.ok) {
-    return { notFound: true };
-  }
+  if (isUpstreamUnavailable(itemsRes)) return upstreamUnavailable(context.res, itemsRes);
+  if (!itemsRes?.ok) return { notFound: true };
 
   const itemsJson = await itemsRes.json();
 


### PR DESCRIPTION
## Summary

- **browse-by-partner**: when the API returns valid JSON without the expected facets structure (common in degraded states), the missing `terms` array fell through to `{ notFound: true }`. Changed to `upstreamUnavailable(res)` so visitors see the "temporarily unavailable" page instead of a 404.
- **browse-by-topic/[topicSlug]/[subtopicSlug]**: had no upstream unavailability handling at all — any network error or 5xx from the WordPress API became a 404. Added `isUpstreamUnavailable` guards before each `!res?.ok` check, and wired up `ServiceUnavailable` so the component renders correctly when `temporarilyUnavailable` is true.

Both pages already had `ServiceUnavailable` / `upstreamUnavailable` infrastructure available; they just weren't using it consistently.

## Test plan

- [ ] Confirm browse-by-partner shows "temporarily unavailable" (503) rather than 404 when the DPLA API is down
- [ ] Confirm browse-by-topic subtopic pages show "temporarily unavailable" (503) rather than 404 when WordPress is unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix: Return 503 instead of 404 when DPLA API is unavailable

This PR improves error handling on two browse pages to gracefully degrade when upstream APIs are unavailable, returning HTTP 503 (Service Unavailable) instead of 404 (Not Found).

### Changes

**pages/browse-by-partner/index.js**
- Modified `getServerSideProps` to return `upstreamUnavailable(res)` when the expected facets structure is missing (specifically when `json.facets[facetName].terms` is not an array), instead of returning `{ notFound: true }`
- The component already had `ServiceUnavailable` infrastructure in place; this change ensures it's used correctly when the API response lacks expected data

**pages/browse-by-topic/[topicSlug]/[subtopicSlug]/index.js**
- Added upstream unavailability detection for three API fetch operations: topics, subtopics, and items fetches
- Integrated `isUpstreamUnavailable` and `upstreamUnavailable` utilities from `lib/safeFetch`
- Component now conditionally renders `ServiceUnavailable` UI when `temporarilyUnavailable` prop is true
- Maintains existing 404 behavior for cases where resources genuinely don't exist (e.g., topic/subtopic slug not found)

### Test Verification
- Browse-by-partner page displays "temporarily unavailable" (503) when DPLA API is down instead of 404
- Browse-by-topic subtopic pages display "temporarily unavailable" (503) when WordPress API is unreachable instead of 404

<!-- end of auto-generated comment: release notes by coderabbit.ai -->