### PR TITLE
fix(exhibitions): skip loadDplaItem when exhibit item has no DPLA ID

### DIFF
--- a/lib/exhibitionsStatic.js
+++ b/lib/exhibitionsStatic.js
@@ -28,6 +28,7 @@ export const findPage = (exhibit, pageSlug) =>
   exhibit.pages.find((page) => page.slug === pageSlug);
 
 export const loadDplaItem = async (dplaItemId) => {
+  if (!dplaItemId) return null;
   const itemUrl = new URL(process.env.API_URL);
   itemUrl.pathname += `/items/${dplaItemId}`;
   itemUrl.searchParams.set("api_key", process.env.API_KEY);


### PR DESCRIPTION
## Summary

- `getDplaItemIdFromExhibit` returns `undefined` when an exhibit item has no \"Has Version\" element text
- Without a guard, `loadDplaItem` constructed and fired URLs like `/v2/items/undefined?api_key=undefined` against the internal API
- ALB logs showed ~15 such requests per 2-minute window, all resulting in 404s
- Fix: add `if (!dplaItemId) return null;` at the top of `loadDplaItem` — covers both call sites (`processPageBlocks` and `getStaticProps` in the exhibition home page) with a single change

## Test plan

- [ ] Existing test suite passes (25 tests, all green)
- [ ] Deploy and confirm no more `api_key=undefined` requests in ALB logs for api-internal.dp.la
- [ ] Verify exhibition pages with and without DPLA-linked items still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix for undefined DPLA item ID requests

**Scope:** Adds a guard clause to prevent invalid API requests when exhibition items lack DPLA IDs.

**Change:** Added an early return in `loadDplaItem` (lib/exhibitionsStatic.js, line 31) that returns `null` if `dplaItemId` is falsy, preventing construction and execution of malformed requests like `/v2/items/undefined?api_key=undefined`.

**Problem addressed:** The `getDplaItemIdFromExhibit` function can return `undefined` when an exhibit item has no "Has Version" element text. Previously, this would cause `loadDplaItem` to attempt API calls with invalid IDs, resulting in ~15 404 responses per 2-minute window in ALB logs for api-internal.dp.la.

**Call sites covered:** The guard covers both usage locations:
- `processPageBlocks` in lib/exhibitionsStatic.js (exhibition page block processing)
- `getStaticProps` in pages/exhibitions/[exhibitionSlug]/index.js (exhibition home page generation)

**Testing:** Existing test suite (25 tests) verified to pass. No changes to public API responses, environment variables, infrastructure, or database required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->