### PR TITLE
fix: Move err.message into single template literal

### DIFF
--- a/pages/primary-source-sets/[set]/sources/[source].js
+++ b/pages/primary-source-sets/[set]/sources/[source].js
@@ -77,8 +77,7 @@ export async function getServerSideProps(context) {
     sanitizedSourceJson = JSON.parse(sourceText.replace(/\r\n/gi, ""));
   } catch (err) {
     console.warn(
-      `[SSR] PSS source body is not valid JSON for source "${source}" (Content-Type: ${sourceRes.headers?.get("content-type") ?? "unknown"}):`,
-      err.message,
+      `[SSR] PSS source body is not valid JSON for source "${source}" (Content-Type: ${sourceRes.headers?.get("content-type") ?? "unknown"}): ${err.message}`,
     );
     return upstreamUnavailable(context.res);
   }


### PR DESCRIPTION
There is a code quality issue with a `console.warn` in `pages/primary-source-sets/[set]/sources/[source].js`

> Functions like the Node.js standard library function util.format accept a format string that is used to format the remaining arguments by providing inline format specifiers. If the format string contains unsanitized input from an untrusted source, then that string may contain unexpected format specifiers that cause garbled output.

This resolves the concern by moving the `err.message` value into the single template literal.