### PR TITLE
feat: For thumbnail error logging, log pageUrl and errorType / Add timeout

### DIFF
--- a/lib/probeImage.js
+++ b/lib/probeImage.js
@@ -12,6 +12,7 @@
 // without triggering a document fetch (unlike img.src = "")
 const BLANK_IMAGE =
   "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
+const STATUS_PROBE_TIMEOUT_MS = 3000;
 
 // Each broken URL is reported at most once per browser session.
 // Persist in sessionStorage to check across navigation.
@@ -40,10 +41,40 @@ if (storageAvailable) {
   }
 }
 
-function reportThumbnailError(url, provider, sourceUrl) {
+async function detectErrorType(url, fallbackType) {
+  if (typeof window === "undefined" || typeof fetch !== "function") {
+    return fallbackType;
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), STATUS_PROBE_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      method: "HEAD",
+      cache: "no-store",
+      mode: "cors",
+      signal: controller.signal,
+    });
+    if (Number.isInteger(response?.status) && response.status > 0) {
+      return String(response.status);
+    }
+  } catch {
+    // Ignore; fallbackType is returned below.
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  return fallbackType;
+}
+
+function reportThumbnailError(url, provider, sourceUrl, errorType) {
   if (typeof window === "undefined") return;
   if (!url || reportedUrls.has(url)) return;
   reportedUrls.add(url);
+
+  const pageUrl = window.location?.href || "";
+
   if (storageAvailable) {
     try {
       sessionStorage.setItem(STORAGE_KEY, JSON.stringify([...reportedUrls]));
@@ -54,7 +85,7 @@ function reportThumbnailError(url, provider, sourceUrl) {
   fetch("/api/thumbnail-error", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ url, provider, sourceUrl }),
+    body: JSON.stringify({ url, provider, sourceUrl, pageUrl, errorType }),
     keepalive: true,
   }).catch(() => {});
 }
@@ -75,14 +106,18 @@ const probeImage = (url, onError, provider, sourceUrl) => {
 
   img.onload = () => {
     if (!cancelled && img.naturalWidth === 0) {
-      reportThumbnailError(url, provider, sourceUrl);
+      void detectErrorType(url, "decode").then((errorType) => {
+        reportThumbnailError(url, provider, sourceUrl, errorType);
+      });
       onError();
     }
     cleanup();
   };
   img.onerror = () => {
     if (!cancelled) {
-      reportThumbnailError(url, provider, sourceUrl);
+      void detectErrorType(url, "load").then((errorType) => {
+        reportThumbnailError(url, provider, sourceUrl, errorType);
+      });
       onError();
     }
     cleanup();

--- a/lib/probeImage.js
+++ b/lib/probeImage.js
@@ -41,6 +41,11 @@ if (storageAvailable) {
   }
 }
 
+// Possible errorType values:
+// * HTTP status codes as strings (e.g., "404", "500") when HEAD request succeeds
+// * "decode" when image loads but has no displayable pixels (naturalWidth === 0)
+// * "load" when image load fails (img.onerror)
+// * "unknown" as fallback in API when errorType is missing
 async function detectErrorType(url, fallbackType) {
   if (typeof window === "undefined" || typeof fetch !== "function") {
     return fallbackType;

--- a/lib/probeImage.js
+++ b/lib/probeImage.js
@@ -73,12 +73,10 @@ async function detectErrorType(url, fallbackType) {
   return fallbackType;
 }
 
-function reportThumbnailError(url, provider, sourceUrl, errorType) {
+function reportThumbnailError(url, provider, sourceUrl, pageUrl, errorType) {
   if (typeof window === "undefined") return;
   if (!url || reportedUrls.has(url)) return;
   reportedUrls.add(url);
-
-  const pageUrl = window.location?.href || "";
 
   if (storageAvailable) {
     try {
@@ -111,8 +109,9 @@ const probeImage = (url, onError, provider, sourceUrl) => {
 
   img.onload = () => {
     if (!cancelled && img.naturalWidth === 0) {
+      const pageUrl = window.location?.href || "";
       void detectErrorType(url, "decode").then((errorType) => {
-        reportThumbnailError(url, provider, sourceUrl, errorType);
+        reportThumbnailError(url, provider, sourceUrl, pageUrl, errorType);
       });
       onError();
     }
@@ -120,8 +119,9 @@ const probeImage = (url, onError, provider, sourceUrl) => {
   };
   img.onerror = () => {
     if (!cancelled) {
+      const pageUrl = window.location?.href || "";
       void detectErrorType(url, "load").then((errorType) => {
-        reportThumbnailError(url, provider, sourceUrl, errorType);
+        reportThumbnailError(url, provider, sourceUrl, pageUrl, errorType);
       });
       onError();
     }

--- a/pages/api/thumbnail-error.js
+++ b/pages/api/thumbnail-error.js
@@ -1,6 +1,8 @@
 const MAX_URL_LENGTH = 2048;
 const MAX_PROVIDER_LENGTH = 256;
 const MAX_SOURCE_URL_LENGTH = 2048;
+const MAX_PAGE_URL_LENGTH = 2048;
+const MAX_ERROR_TYPE_LENGTH = 64;
 const WINDOW_MS = 60_000; // 1 minute window for rate limiting
 const LIMIT = 60; // Rate limit: Max requests per window
 const ipWindows = new Map(); // ip -> { count, windowStart }
@@ -51,6 +53,14 @@ export default function handler(req, res) {
     typeof req.body?.sourceUrl === "string"
       ? req.body.sourceUrl.slice(0, MAX_SOURCE_URL_LENGTH)
       : "";
+  const pageUrl =
+    typeof req.body?.pageUrl === "string"
+      ? req.body.pageUrl.slice(0, MAX_PAGE_URL_LENGTH)
+      : "";
+  const errorType =
+    typeof req.body?.errorType === "string"
+      ? req.body.errorType.slice(0, MAX_ERROR_TYPE_LENGTH)
+      : "unknown";
 
   if (!url) {
     res.status(400).end();
@@ -60,7 +70,17 @@ export default function handler(req, res) {
   // Strip query strings and hashes before logging
   const redactedUrl = url.split(/[?#]/)[0];
   const redactedSourceUrl = sourceUrl ? sourceUrl.split(/[?#]/)[0] : "";
+  const redactedPageUrl = pageUrl ? pageUrl.split(/[?#]/)[0] : "";
 
-  console.log(JSON.stringify({ event: "thumbnail_error", url: redactedUrl, provider, sourceUrl: redactedSourceUrl }));
+  console.log(
+    JSON.stringify({
+      event: "thumbnail_error",
+      url: redactedUrl,
+      provider,
+      sourceUrl: redactedSourceUrl,
+      pageUrl: redactedPageUrl,
+      errorType,
+    })
+  );
   res.status(204).end();
 }


### PR DESCRIPTION
For thumbnail error logging, we are adding two new fields to the console log:
* `pageUrl` logs the page where the thumbnail error occured (individual item page, search page, etc.), to help view and diagnose issues.
* `errorType` shows what type of error occured. One of the following:
  * HTTP status codes as strings (e.g. `404`, `500`) when HEAD request succeeds
  * `decode` when image loads but has no displayable pixels (`naturalWidth === 0`)
  * `load` when image load fails (`img.onerror`)
  * `unknown` as fallback in API when `errorType` is missing

Also adding a 3-second timeout when probing images, to prevent indefinite hanging.

# CodeRabbit Summary
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR enhances thumbnail error logging by introducing error type classification and page context. The client-side probing logic now distinguishes between different failure modes (HTTP status codes, decode errors, load failures), and both the probe and API endpoint are updated to capture and log the page URL where errors occur.

### Changes in `lib/probeImage.js`

- Adds `STATUS_PROBE_TIMEOUT_MS` constant (3000ms) to prevent indefinite hanging during image probes
- Introduces new `detectErrorType()` async function that:
  - Probes the image URL with a timed HEAD request (3-second timeout)
  - Returns the HTTP status code as a string when available
  - Falls back to caller-provided error type ("decode" for `naturalWidth === 0`, "load" for `img.onerror`)
- Updates `reportThumbnailError()` to:
  - Accept `errorType` parameter
  - Extract `pageUrl` from `window.location.href`
  - Include both `pageUrl` and `errorType` in the request body
- Modifies `img.onload` and `img.onerror` handlers to call `detectErrorType()` and pass the classification to error reporting

### Changes in `pages/api/thumbnail-error.js`

- Adds input validation with max length constraints:
  - `pageUrl`: 2048 characters
  - `errorType`: 64 characters
- Extracts and validates `pageUrl` and `errorType` from request body
- Defaults `errorType` to "unknown" when absent
- Strips query strings and hashes from all URLs (pageUrl, url, sourceUrl) before logging for privacy
- Updates logging to include the new `pageUrl` and `errorType` fields in a structured JSON format

### Deployment & Infrastructure

No special deployment actions required. This is a standard frontend code change deployable through normal Next.js build/deployment processes. No database migrations, environment variables, AWS configuration, or infrastructure changes are involved.

### Security Considerations

New client-supplied inputs (`pageUrl` and `errorType`) are validated with strict length limits. The HEAD request probe respects CORS, includes a 3-second timeout, and no sensitive information is transmitted. Existing rate limiting (60 requests/minute per IP) remains active. URL query strings and fragments are redacted before logging to prevent accidental capture of sensitive parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->