### PR TITLE
fix: For thumbnail error logging, only log status codes >= 400

### DIFF
--- a/lib/probeImage.js
+++ b/lib/probeImage.js
@@ -61,7 +61,7 @@ async function detectErrorType(url, fallbackType) {
       mode: "cors",
       signal: controller.signal,
     });
-    if (Number.isInteger(response?.status) && response.status > 0) {
+    if (Number.isInteger(response?.status) && response.status >= 400) {
       return String(response.status);
     }
   } catch {
@@ -109,7 +109,7 @@ const probeImage = (url, onError, provider, sourceUrl) => {
 
   img.onload = () => {
     if (!cancelled && img.naturalWidth === 0) {
-      const pageUrl = window.location?.href || "";
+      const pageUrl = typeof window !== "undefined" ? window.location?.href || "" : "";
       void detectErrorType(url, "decode").then((errorType) => {
         reportThumbnailError(url, provider, sourceUrl, pageUrl, errorType);
       });
@@ -119,7 +119,7 @@ const probeImage = (url, onError, provider, sourceUrl) => {
   };
   img.onerror = () => {
     if (!cancelled) {
-      const pageUrl = window.location?.href || "";
+      const pageUrl = typeof window !== "undefined" ? window.location?.href || "" : "";
       void detectErrorType(url, "load").then((errorType) => {
         reportThumbnailError(url, provider, sourceUrl, pageUrl, errorType);
       });


### PR DESCRIPTION
For thumbnail probing, we could report any HTTP status (including 200). This appears to cause misleading logs when a server recovered between the time the image failed and the probe ran, or when a 200 response contained non-image content the browser still managed to render the image.

Now only 4xx/5xx status codes are reported. For 2xx/3xx responses the error type can still fall back to "decode" or "load", which accurately reflects what the browser actually observed.