### PR TITLE
fix: Filter out "load" errors from thumbnail error reporting

### DIFF
--- a/lib/probeImage.js
+++ b/lib/probeImage.js
@@ -64,6 +64,12 @@ async function detectErrorType(url, fallbackType) {
     if (Number.isInteger(response?.status) && response.status >= 400) {
       return String(response.status);
     }
+
+    // If an <img> onerror fires but HEAD returns non-error status,
+    // treat it as a non-actionable mismatch and skip.
+    if (fallbackType === "load") {
+      return null;
+    }
   } catch {
     // Ignore; fallbackType is returned below.
   } finally {
@@ -121,6 +127,7 @@ const probeImage = (url, onError, provider, sourceUrl) => {
     if (!cancelled) {
       const pageUrl = typeof window !== "undefined" ? window.location?.href || "" : "";
       void detectErrorType(url, "load").then((errorType) => {
+        if (!errorType) return;
         reportThumbnailError(url, provider, sourceUrl, pageUrl, errorType);
       });
       onError();

--- a/lib/probeImage.js
+++ b/lib/probeImage.js
@@ -61,7 +61,7 @@ async function detectErrorType(url, fallbackType) {
       mode: "cors",
       signal: controller.signal,
     });
-    if (Number.isInteger(response?.status) && response.status > 0) {
+    if (Number.isInteger(response?.status) && response.status >= 400) {
       return String(response.status);
     }
   } catch {
@@ -109,7 +109,7 @@ const probeImage = (url, onError, provider, sourceUrl) => {
 
   img.onload = () => {
     if (!cancelled && img.naturalWidth === 0) {
-      const pageUrl = window.location?.href || "";
+      const pageUrl = typeof window !== "undefined" ? window.location?.href || "" : "";
       void detectErrorType(url, "decode").then((errorType) => {
         reportThumbnailError(url, provider, sourceUrl, pageUrl, errorType);
       });
@@ -119,7 +119,7 @@ const probeImage = (url, onError, provider, sourceUrl) => {
   };
   img.onerror = () => {
     if (!cancelled) {
-      const pageUrl = window.location?.href || "";
+      const pageUrl = typeof window !== "undefined" ? window.location?.href || "" : "";
       void detectErrorType(url, "load").then((errorType) => {
         reportThumbnailError(url, provider, sourceUrl, pageUrl, errorType);
       });


### PR DESCRIPTION
Our new thumbnail error reporting is filled with `load` errors. When looking into them, I found that the thumbnails loaded fine in my browser. But digging it into more, I believe the root cause is that our thumbnails don't have a `Content-Type` header. This may cause thumbnails to silently fail in the background, or potentially in cases of scrapers/crawlers trying to "view" them.

I've created two PRs on the `thumbnail-api` and `thumbnailer-lambda` repos to fix this, by attaching a correct `Content-Type` to our thumbnails:
https://github.com/dpla/thumbnail-api/pull/31
https://github.com/dpla/thumbnailer-lambda/pull/12

In the meantime, this PR removes "load" errors from our logging to cut back on the noise. We may restore it if we want once the `Content-Type` fixes are deployed.