### PR TITLE
fix(ci): expose SENTRY_AUTH_TOKEN to Docker build so source maps upload

### DIFF
--- a/.github/workflows/local-aviation.yml
+++ b/.github/workflows/local-aviation.yml
@@ -54,6 +54,7 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
           BRANCH_NAME: ${{ env.BRANCH_NAME }}
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           docker build \
           --platform linux/amd64 \

--- a/.github/workflows/local-florida.yml
+++ b/.github/workflows/local-florida.yml
@@ -54,6 +54,7 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
           BRANCH_NAME: ${{ env.BRANCH_NAME }}
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           docker build \
           --platform linux/amd64 \

--- a/.github/workflows/local-illinois.yml
+++ b/.github/workflows/local-illinois.yml
@@ -54,6 +54,7 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
           BRANCH_NAME: ${{ env.BRANCH_NAME }}
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           docker build \
           --platform linux/amd64 \

--- a/.github/workflows/local-njde.yml
+++ b/.github/workflows/local-njde.yml
@@ -54,6 +54,7 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
           BRANCH_NAME: ${{ env.BRANCH_NAME }}
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           docker build \
           --platform linux/amd64 \

--- a/.github/workflows/local-nwdh.yml
+++ b/.github/workflows/local-nwdh.yml
@@ -54,6 +54,7 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
           BRANCH_NAME: ${{ env.BRANCH_NAME }}
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           docker build \
           --platform linux/amd64 \

--- a/.github/workflows/local-oklahoma.yml
+++ b/.github/workflows/local-oklahoma.yml
@@ -54,6 +54,7 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
           BRANCH_NAME: ${{ env.BRANCH_NAME }}
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           docker build \
           --platform linux/amd64 \

--- a/.github/workflows/local-plains2peaks.yml
+++ b/.github/workflows/local-plains2peaks.yml
@@ -54,6 +54,7 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
           BRANCH_NAME: ${{ env.BRANCH_NAME }}
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           docker build \
           --platform linux/amd64 \

--- a/.github/workflows/local-texas.yml
+++ b/.github/workflows/local-texas.yml
@@ -54,6 +54,7 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
           BRANCH_NAME: ${{ env.BRANCH_NAME }}
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           docker build \
           --platform linux/amd64 \

--- a/.github/workflows/local-vermont.yml
+++ b/.github/workflows/local-vermont.yml
@@ -54,6 +54,7 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
           BRANCH_NAME: ${{ env.BRANCH_NAME }}
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           docker build \
           --platform linux/amd64 \

--- a/.github/workflows/local-wisconsin.yml
+++ b/.github/workflows/local-wisconsin.yml
@@ -54,6 +54,7 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
           BRANCH_NAME: ${{ env.BRANCH_NAME }}
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           docker build \
           --platform linux/amd64 \

--- a/.github/workflows/pro-production.yml
+++ b/.github/workflows/pro-production.yml
@@ -54,6 +54,7 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
           BRANCH_NAME: ${{ env.BRANCH_NAME }}
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           docker build \
           --platform linux/amd64 \

--- a/.github/workflows/pro-staging.yml
+++ b/.github/workflows/pro-staging.yml
@@ -59,6 +59,7 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
           BRANCH_NAME: ${{ env.BRANCH_NAME }}
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           docker build \
           --platform linux/amd64 \

--- a/.github/workflows/user-production.yml
+++ b/.github/workflows/user-production.yml
@@ -54,6 +54,7 @@ jobs:
           BRANCH_NAME: ${{ env.BRANCH_NAME }}
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           GA_TRACKING_ID: ${{ env.GA_TRACKING_ID }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           docker build \
           --platform linux/amd64 \

--- a/.github/workflows/user-staging.yml
+++ b/.github/workflows/user-staging.yml
@@ -54,6 +54,7 @@ jobs:
           BRANCH_NAME: ${{ env.BRANCH_NAME }}
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           GA_TRACKING_ID: ${{ env.GA_TRACKING_ID }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           docker build \
           --platform linux/amd64 \


### PR DESCRIPTION
## Summary

- All 14 CI workflow files were missing `SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}` in the `env:` block of the Docker build step
- The `Dockerfile` correctly uses `--secret id=sentry_auth,env=SENTRY_AUTH_TOKEN` and `withSentryConfig` in `next.config.js` is correctly wired, but Docker never received the token
- Two prior fix attempts (`281ba79`, `9acc3bd`) addressed Docker `ARG`/`ENV` leakage and `authToken` in `next.config.js` but missed this root cause
- Affects: all local sites, pro-production, pro-staging, user-production, user-staging

## Test plan

- [ ] Trigger any one workflow (e.g. `user-staging`) and confirm the build log shows Sentry source map upload activity (look for "Sentry" in the `yarn build` output)
- [ ] After a deploy, open a Sentry issue and confirm source-mapped stack frames appear

Closes DPLA-FRONTEND-TW (partial — real stack traces needed to diagnose the call stack overflow root cause)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes Sentry source map upload during CI builds by exposing the `SENTRY_AUTH_TOKEN` secret to the Docker build step environment in 14 GitHub Actions workflow files across all environments (local sites, pro-production, pro-staging, user-production, user-staging).

Each workflow file's "Build, tag, and push image to Amazon ECR" step now includes `SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}` in the step's `env` block. This supplies the token referenced by the existing Docker build argument `--secret id=sentry_auth,env=SENTRY_AUTH_TOKEN`, allowing the Dockerfile and `next.config.js` to successfully upload source maps to Sentry during the build.

## Changes

- **14 workflow files modified:** All local site workflows, `pro-production.yml`, `pro-staging.yml`, `user-production.yml`, `user-staging.yml`
- **Change per file:** +1 line (adds `SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}` to the Docker build step's `env`)

## Important Notes

**Requires manual pipeline trigger:** The updated workflows must be triggered (e.g., via a new commit or manual run) to take effect. Subsequent builds will now pass the Sentry auth token to Docker during image builds.

**Security implications:** This PR adds proper credential handling by exposing an existing secret to the Docker build process in a controlled manner via Docker's `--secret` mechanism, preventing the token from being baked into the image layer.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/dpla-frontend/pull/1519)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->