### PR TITLE
fix: extend Google Translate DOM patch to cover replaceChild and appendChild

### DIFF
--- a/lib/patchDOMForGoogleTranslate.js
+++ b/lib/patchDOMForGoogleTranslate.js
@@ -1,6 +1,6 @@
 /**
- * Patches Node.prototype.removeChild and insertBefore to handle DOM mutations
- * from Google Translate gracefully instead of crashing React.
+ * Patches Node.prototype DOM mutation methods to handle reparented nodes from
+ * Google Translate gracefully instead of crashing React.
  *
  * Google Translate wraps text nodes in <font> elements, which breaks React's
  * virtual DOM reconciliation (React issue #11538). This patch makes the
@@ -28,5 +28,13 @@ export function patchDOMForGoogleTranslate() {
       return newNode;
     }
     return originalInsertBefore.call(this, newNode, referenceNode);
+  };
+
+  const originalReplaceChild = Node.prototype.replaceChild;
+  Node.prototype.replaceChild = function (newChild, oldChild) {
+    if (oldChild.parentNode !== this) {
+      return oldChild;
+    }
+    return originalReplaceChild.call(this, newChild, oldChild);
   };
 }

--- a/lib/patchDOMForGoogleTranslate.js
+++ b/lib/patchDOMForGoogleTranslate.js
@@ -37,4 +37,12 @@ export function patchDOMForGoogleTranslate() {
     }
     return originalReplaceChild.call(this, newChild, oldChild);
   };
+
+  const originalAppendChild = Node.prototype.appendChild;
+  Node.prototype.appendChild = function (child) {
+    if (child.parentNode && child.parentNode !== this) {
+      return child;
+    }
+    return originalAppendChild.call(this, child);
+  };
 }


### PR DESCRIPTION
## Summary

- Extends the existing `patchDOMForGoogleTranslate` (introduced in March 2026) to cover `replaceChild` and `appendChild` in addition to `removeChild` and `insertBefore`
- Google Translate wraps text nodes in `<font>` elements, reparenting them out from under React's virtual DOM — any of the four DOM mutation methods can crash React reconciliation (React issue [#11538](https://github.com/facebook/react/issues/11538))
- The patch makes all four methods fail silently when called with nodes that have been reparented by the translator
- Motivated by DPLA-FRONTEND-TW ("call stack overflow"), which is 100% iOS (Chrome Mobile iOS + Google App — both use Google Translate), and first appeared June 2025

## Test plan

- [ ] Enable Google Translate on a page with dynamic content (search results, item page)
- [ ] Translate to a non-English language and interact with the page — confirm no console errors about `removeChild`/`insertBefore`/`replaceChild`/`appendChild` with mismatched parent nodes
- [ ] Confirm no Sentry events for call stack overflow on iOS after the patch ships (monitor DPLA-FRONTEND-TW)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## DOM Patch Extension for Google Translate Compatibility

This PR extends the `patchDOMForGoogleTranslate()` function to protect against React reconciliation crashes caused by Google Translate's DOM manipulation. The existing patches for `removeChild` and `insertBefore` are supplemented with new guards for `replaceChild` and `appendChild`.

### Changes Made
- **`Node.prototype.replaceChild`**: Now checks if `oldChild.parentNode` matches the target node; returns the `oldChild` without performing the replacement if the parentage is invalid
- **`Node.prototype.appendChild`**: Now checks if `child.parentNode` exists and doesn't match the target node; returns the `child` without performing the append if the parentage is invalid

### Why This Matters
Google Translate wraps text nodes in `<font>` elements and reparents them outside React's virtual DOM. When React's reconciliation methods subsequently attempt to manipulate these reparented nodes (via removeChild, insertBefore, replaceChild, or appendChild), a mismatch between expected and actual parent nodes occurs, causing crashes—particularly a call stack overflow observed on iOS Chrome/Google app (DPLA-FRONTEND-TW, first observed June 2025).

The patch makes all four DOM mutation methods fail gracefully by returning the node argument instead of throwing errors when parentage doesn't match, allowing React to continue execution without crashing.

### No Special Deployment Requirements
No pipeline triggers, redeployments, environment variable changes, database migrations, infrastructure configuration changes, API modifications, or security implications.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/dpla-frontend/pull/1520)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->