### PR TITLE
fix(json-ld): provider() returns array length instead of array

### DIFF
--- a/components/ItemComponents/Content/JsonLdMarkup.js
+++ b/components/ItemComponents/Content/JsonLdMarkup.js
@@ -9,7 +9,7 @@ function JsonLdMarkup({ item }) {
     */
   function definedAndFlattened(values) {
     const defined = values.filter(function(x) {
-      return x !== undefined;
+      return x !== undefined && x !== null;
     });
     return [].concat(...defined);
   }
@@ -169,11 +169,19 @@ function JsonLdMarkup({ item }) {
     return all.map(x => {
       let lat = null;
       let lon = null;
-      let coordinates = joinIfArray(x.coordinates);
-      if (coordinates !== undefined) {
-        const [latStr, lonStr] = coordinates.split(",");
-        lat = Number(latStr);
-        lon = Number(lonStr.trim());
+      const coordinates = joinIfArray(x.coordinates);
+      if (typeof coordinates === "string") {
+        const [latStr, lonStr, ...rest] = coordinates
+          .split(",")
+          .map(value => value.trim());
+        if (latStr && lonStr && rest.length === 0) {
+          const parsedLat = Number(latStr);
+          const parsedLon = Number(lonStr);
+          if (Number.isFinite(parsedLat) && Number.isFinite(parsedLon)) {
+            lat = parsedLat;
+            lon = parsedLon;
+          }
+        }
       }
       return {
         "@type": "Place",

--- a/components/ItemComponents/Content/JsonLdMarkup.js
+++ b/components/ItemComponents/Content/JsonLdMarkup.js
@@ -61,9 +61,7 @@ function JsonLdMarkup({ item }) {
       url: "https://dp.la/"
     };
 
-    return all.map(x => {
-      return { "@type": "Organization", name: x };
-    }).push(dpla);
+    return [...all.map(x => ({ "@type": "Organization", name: x })), dpla];
   };
 
   /**
@@ -173,8 +171,9 @@ function JsonLdMarkup({ item }) {
       let lon = null;
       let coordinates = joinIfArray(x.coordinates);
       if (coordinates !== undefined) {
-        lat = Number(coordinates.split(",")[0]);
-        lon = Number(coordinates.split(",")[1].trim());
+        const [latStr, lonStr] = coordinates.split(",");
+        lat = Number(latStr);
+        lon = Number(lonStr.trim());
       }
       return {
         "@type": "Place",


### PR DESCRIPTION
## Summary

- `provider()` in `JsonLdMarkup.js` called `.push(dpla)` on the result of `.map()` and returned it. `Array.push()` returns the new length of the array (a number), not the array itself — so the schema.org JSON-LD output had `"provider": 2` (or similar integer) instead of an array of `Organization` objects.
- Also fixed a pre-existing double `.split(",")` call in `spatial()` — the coordinates string was split twice when once is sufficient.

## Test plan

- [ ] Verify JSON-LD on any item page has `"provider"` as an array of objects, not a number
- [ ] Confirm no regressions on item page rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/dpla-frontend/pull/1522)

Summary
- Fixes JsonLdMarkup.js bugs so schema.org JSON-LD output is correct:
  - provider(): no longer returns the array length (number); now returns an array of Organization objects (maps partner/intermediateProvider/contributor into Organization objects and appends the DPLA Organization).
  - spatial(): removes the double-split bug and hardens coordinate parsing — splits coordinates once, trims segments, ignores extra segments, and only sets latitude/longitude when both parse to finite Numbers.
  - definedAndFlattened(): now excludes both undefined and null before flattening.
- Additional commit message: "fix: harden JsonLdMarkup coordinate parsing to prevent runtime crashes" — coordinate parsing made more robust to avoid runtime crashes.

Testing / QA notes
- Verify item pages' embedded JSON-LD: "provider" is an array of Organization objects (not a number).
- Confirm no regressions to item page rendering.

Impact checklist (explicit)
- Manual pipeline/ECS redeploy: No.
- Env vars / AWS Secrets Manager: No additions, removals, or renames.
- Database migrations: None.
- Shared infra (CodePipeline/CodeBuild/ECS/IAM): No changes.
- Public-facing API / response shape: Yes — the JSON-LD embedded in item pages now provides "provider" as an array of Organization objects instead of a numeric value. This is a change to a public-facing page's structured data output (schema.org JSON-LD).
- Security implications: None introduced by these changes (no auth/credential handling or new external inputs).

Files changed (summary)
- components/ItemComponents/Content/JsonLdMarkup.js — logic fixes and robustness improvements; +15 / -8.

Review notes
- No exported/public API signatures changed.
- Medium review effort: focus on JsonLdMarkup unit/visual tests and validate structured data via a JSON-LD/schema validator (e.g., Google Rich Results Test).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/dpla-frontend/pull/1522)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->