### PR TITLE
JsonLdMarkup code quality improvements

### DIFF
--- a/components/ItemComponents/Content/JsonLdMarkup.js
+++ b/components/ItemComponents/Content/JsonLdMarkup.js
@@ -20,7 +20,8 @@ function JsonLdMarkup({ item }) {
     * @return String, date range in ISO 8601 format
    */
   function dateRange(begin, end) {
-    return `${begin}/${end}`;
+    if (begin && end) return `${begin}/${end}`;
+    return begin || end || null;
   }
 
   /**
@@ -101,14 +102,12 @@ function JsonLdMarkup({ item }) {
     */
   const collection = () => {
     const all = definedAndFlattened([item.collection]);
-    return all.map(x => {
-      return {
-        "@type": "Collection",
-        "@id": x["@id"],
-        name: x.title,
-        description: x.description
-      };
-    });
+    return all.map(x => ({
+      "@type": "Collection",
+      "@id": x["@id"],
+      name: x.title,
+      description: x.description
+    }));
   };
 
   /**
@@ -116,7 +115,7 @@ function JsonLdMarkup({ item }) {
     */
   const contributor = () => {
     return definedAndFlattened([item.contributor])
-        .map(x => {return { "@type": "Thing", name: x }});
+        .map(x => ({ "@type": "Thing", name: x }));
   };
 
   /**
@@ -124,7 +123,7 @@ function JsonLdMarkup({ item }) {
     */
   const creator = () => {
     return definedAndFlattened([item.creator])
-        .map(x => {return { "@type": "Thing", name: x }});
+        .map(x => ({ "@type": "Thing", name: x }));
   };
 
   /**
@@ -142,9 +141,7 @@ function JsonLdMarkup({ item }) {
     */
   const date = () => {
     const all = definedAndFlattened([item.date]);
-    return all.map(x => {
-      return dateRange(x.begin, x.end);
-    });
+    return all.map(x => dateRange(x.begin, x.end)).filter(Boolean);
   };
 
   /**
@@ -153,12 +150,10 @@ function JsonLdMarkup({ item }) {
     * the ISO label.
     */
   const language = () => {
-    return definedAndFlattened([item.language]).map(x => {
-      return {
-        "@type": "Language",
-        name: x
-      };
-    });
+    return definedAndFlattened([item.language]).map(x => ({
+      "@type": "Language",
+      name: x
+    }));
   };
 
   /**
@@ -201,9 +196,7 @@ function JsonLdMarkup({ item }) {
     */
   const publisher = () => {
     const all = definedAndFlattened([item.publisher]);
-    return all.map(x => {
-      return { "@type": "Organization", name: x };
-    });
+    return all.map(x => ({ "@type": "Organization", name: x }));
   };
 
   /**
@@ -211,9 +204,7 @@ function JsonLdMarkup({ item }) {
     */
   const subject = () => {
     const all = definedAndFlattened([item.subject]);
-    return all.map(x => {
-      return { "@type": "Thing", name: x.name };
-    });
+    return all.map(x => ({ "@type": "Thing", name: x.name }));
   };
 
   /**
@@ -221,9 +212,7 @@ function JsonLdMarkup({ item }) {
     */
   const temporal = () => {
     const all = definedAndFlattened([item.temporal]);
-    return all.map(x => {
-      return dateRange(x.begin, x.end);
-    });
+    return all.map(x => dateRange(x.begin, x.end)).filter(Boolean);
   };
 
   /**
@@ -262,4 +251,4 @@ function JsonLdMarkup({ item }) {
   );
 }
 
-export default JsonLdMarkup;
+export default React.memo(JsonLdMarkup);


### PR DESCRIPTION
Code quality improvements in `JsonLdMarkup.js`, to resolve https://github.com/dpla/dpla-frontend/issues/1523

* Fixed a bug in `dateRange()` that could generate malformed dates (e.g., "undefined/2023-01-01") on incomplete input.
* Unpacked verbose `.map()` callbacks.
* Wrapped the exported component in `React.memo()` to prevent unnecessary re-renders.

# CodeRabbit Summary
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR contains code quality improvements to the JSON-LD schema generation component. The changes fix a bug in date range handling, improve code style consistency, and optimize component rendering performance.

### Changes

**`components/ItemComponents/Content/JsonLdMarkup.js`**

- **Date range bug fix**: The `dateRange()` function now correctly handles incomplete date inputs. Previously, it could produce malformed ISO 8601 ranges like "undefined/2023-01-01" when only one boundary was provided. Now it returns whichever boundary is available or `null` when neither exists.

- **Code style improvements**: Refactored `.map()` callbacks in `collection()`, `contributor()`, and `creator()` methods to use concise implicit-return arrow syntax instead of verbose block returns.

- **Filtering optimizations**: The `date()` and `temporal()` methods now filter out falsy results (e.g., `null` date ranges) using `.filter(Boolean)` instead of including them in the output.

- **Performance optimization**: Wrapped the `JsonLdMarkup` component export with `React.memo()` to prevent unnecessary re-renders when parent components re-render with unchanged props.

The component is used in `components/ItemComponents/Content/index.js` to generate JSON-LD structured data for item pages. These are internal improvements with no impact on public-facing functionality or APIs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/dpla-frontend/pull/1525)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->