### PR TITLE
fix(sitemap gen): wrap provider names in quotes

### DIFF
--- a/scripts/generate-hub-sitemaps.py
+++ b/scripts/generate-hub-sitemaps.py
@@ -215,7 +215,9 @@ def iter_ids_from_api(hub_id):
     seen = set()
     for provider, provider_count in providers:
         if provider is not None:
-            provider_param = f"dataProvider={urllib.parse.quote(provider, safe='')}"
+            # Wrap provider in double quotes to prevent parsing errors (e.g. HTTP 400 with '/')
+            quoted_provider = '"' + provider.replace('"', '\\"') + '"'
+            provider_param = f"dataProvider={urllib.parse.quote(quoted_provider, safe='')}"
             print(
                 f"  {hub_id}: dataProvider={provider!r} ({provider_count} items)",
                 flush=True,


### PR DESCRIPTION
Fix for https://github.com/dpla/dpla-frontend/issues/1518

It was reported that the `generate-hub-sitemaps.yml` workflow fails with `HTTP Error 400: Bad Request` when paginating through a hub whose `dataProvider` name contains a `/`.

This PR wraps provider names in double-quotes to prevent the slash from being interpreted as a special character.

## Testing

To test, I did a dry-run on a modified version of the script that only runs on `National Museum of the Pacific War/Admiral Nimitz Foundation`.

Existing error example:
```
generate-hub-sitemaps: dry-run generating for: aviation
  aviation: collecting IDs...
  aviation: 49847 total items in API
  aviation: segmenting by 500 dataProviders
  aviation: dataProvider='National Museum of the Pacific War/Admiral Nimitz Foundation' (81 items)
Traceback (most recent call last):
...
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 400: Bad Request
```

After this PR update:
```
generate-hub-sitemaps: dry-run generating for: aviation
  aviation: collecting IDs...
  aviation: 49847 total items in API
  aviation: segmenting by 500 dataProviders
  aviation: dataProvider='National Museum of the Pacific War/Admiral Nimitz Foundation' (81 items)
    National Museum of the Pacific War/Admiral Nimitz Foundation: count=81

--- sitemap/aviation/20260514-192727/all_item_urls_1.xml.gz (first 3 URLs) ---
  https://dp.la/item/60e8f26d0b573569ba300907fee78f68
  https://dp.la/item/c6b33d5135f4f29e70f5c2d96f7e6118
  https://dp.la/item/e05e523ece34fbf91a3e30ed93b1521b
  ... (81 total)
  aviation: 81 IDs

--- sitemap/aviation/all_item_urls.xml ---
<?xml version="1.0" encoding="UTF-8"?>
<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <sitemap>
    <loc>https://sitemaps.dp.la/sitemap/aviation/20260514-192727/all_item_urls_1.xml.gz</loc>
    <lastmod>2026-05-14T19:27:27Z</lastmod>
  </sitemap>
</sitemapindex>
generate-hub-sitemaps: done
```

# CodeRabbit Summary
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a bug in the hub sitemap generation script where the `generate-hub-sitemaps.yml` workflow fails with "HTTP Error 400: Bad Request" when paginating a tag-based hub (aviation or blackwomensuffrage) that contains a dataProvider with a forward slash (/) in its name.

## Changes

**File: `scripts/generate-hub-sitemaps.py`**

Modified the `iter_ids_from_api()` function to wrap provider names in double quotes before URL-encoding when constructing the dataProvider query parameter for DPLA API requests. The change includes:
- Wrapping the provider term in double quotes
- Escaping any embedded quotes within the provider name using backslash escaping
- URL-encoding the quoted string with `safe=''` to preserve the quotes

This prevents special characters like forward slashes from being misinterpreted by the API during pagination.

**File: `.github/workflows/generate-hub-sitemaps.yml`** (New)

GitHub Actions workflow that:
- Runs automatically on the 5th of each month at 06:00 UTC
- Can be manually triggered via `workflow_dispatch` with an optional hub parameter
- Uses AWS OIDC authentication to assume the `github-actions-hub-sitemaps` IAM role
- Uses the existing `DPLA_API_KEY` secret

## Testing

Validated with a dry-run on the "National Museum of the Pacific War/Admiral Nimitz Foundation" provider (81 items), which previously failed with HTTP 400. After the fix, the dry-run completes successfully and generates proper sitemap output.

## Impact

The fix will automatically take effect on the next scheduled workflow run (5th of each month at 06:00 UTC) or can be triggered manually. No manual pipeline trigger or redeployment is required. Assumes the referenced AWS IAM role (`github-actions-hub-sitemaps`) and `DPLA_API_KEY` secret are already configured in the repository.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/dpla-frontend/pull/1526)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->