### PR TITLE
Update external link icon to match link color

### DIFF
--- a/stylesheets/global.scss
+++ b/stylesheets/global.scss
@@ -25,20 +25,6 @@ a {
   color: var(--linkColor);
   text-decoration: none;
 
-  &:global.external {
-    background-image: url("/static/images/external-link-blue.svg");
-    background-position: center right;
-    background-repeat: no-repeat;
-    background-size: 0.7em;
-    padding-right: 1em;
-
-    &.white {
-      background-image: url("/static/images/external-link-white.svg");
-      background-position: 90% center;
-      padding-right: 0;
-    }
-  }
-
   &:visited {
     color: var(--visitedLinkColor);
   }
@@ -48,17 +34,19 @@ a {
   }
 }
 
-.external {
-  background-image: url("/static/images/external-link-blue.svg");
-  background-position: center right;
-  background-repeat: no-repeat;
-  background-size: 0.7em;
-  padding-right: 1em;
-
-  &.white {
-    background-image: url("/static/images/external-link-white.svg");
-    background-position: 90% center;
-    padding-right: 0;
-  }
+.external::after {
+  content: "";
+  display: inline-block;
+  width: 0.7em;
+  height: 0.7em;
+  margin-left: 0.3em;
+  vertical-align: middle;
+  background-color: currentColor;
+  -webkit-mask-image: url("/static/images/external-link-black.svg");
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-size: contain;
+  mask-image: url("/static/images/external-link-black.svg");
+  mask-repeat: no-repeat;
+  mask-size: contain;
 }
 

--- a/stylesheets/global.scss
+++ b/stylesheets/global.scss
@@ -41,7 +41,7 @@ a {
   height: 0.7em;
   margin-left: 0.3em;
   vertical-align: middle;
-  background-color: currentColor;
+  background-color: currentcolor;
   -webkit-mask-image: url("/static/images/external-link-black.svg");
   -webkit-mask-repeat: no-repeat;
   -webkit-mask-size: contain;


### PR DESCRIPTION
The external link icon that shows up next to some external links is currently a light-blue color (#5ab4dc). As pointed out in https://github.com/dpla/dpla-frontend/issues/1508, this can cause accessibility issues across the site and its hubs depending on background color.

Examples of current state on DPLA and Illinois hub:
<img width="500" src="https://github.com/user-attachments/assets/aff0f635-7e6e-4c32-baf2-dfda355059c5" />
<img width="500" src="https://github.com/user-attachments/assets/03da012c-97c8-4f7c-b7b5-fb8ca9caa2bb" />

With this PR, we've updated the global stylesheet so the external link icon matches the color of the link text itself. This creates a more consistent design, while also inheriting the same accessibility considerations applied to external link styling.

<img width="500" src="https://github.com/user-attachments/assets/811094f4-59aa-4265-9e05-5d41124b8f04" />
<img width="500" src="https://github.com/user-attachments/assets/b9a9ab88-52cc-432a-a84c-cf42534a70fc" />

And in dark mode via browser extension:
<img width="500" src="https://github.com/user-attachments/assets/36b738a1-b349-4cda-91c6-9ea160cd283f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/dpla-frontend/pull/1527)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->