### PR TITLE
fix(a11y): refactor Accordion headers for accessibility

### DIFF
--- a/components/shared/Accordion/Accordion.module.scss
+++ b/components/shared/Accordion/Accordion.module.scss
@@ -37,10 +37,15 @@
   padding: 10px 11px;
 }
 
-.itemTitle {
+.titleAndInfo {
   align-items: center;
   display: flex;
   flex: 1;
+}
+
+.itemTitle {
+  align-items: center;
+  display: flex;
   font-size: 0.9375rem;
   font-weight: 600;
 

--- a/components/shared/Accordion/Accordion.module.scss
+++ b/components/shared/Accordion/Accordion.module.scss
@@ -43,6 +43,10 @@
   flex: 1;
   font-size: 0.9375rem;
   font-weight: 600;
+
+  h3 {
+    margin: 0;
+  }
 }
 
 .titleButton {

--- a/components/shared/Accordion/Accordion.module.scss
+++ b/components/shared/Accordion/Accordion.module.scss
@@ -26,27 +26,50 @@
   border-bottom: 0.1rem solid rgba(0, 0, 0, 0.08);
 }
 
-.itemHeader {
+.itemHeaderRow {
   align-items: center;
   background-color: var(--warmerBackgroundColor);
   border-bottom: 0.1rem solid rgba(0, 0, 0, 0.08);
+  cursor: pointer;
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
   line-height: 1.1875;
-  padding: 10px 13px 10px 11px;
-  text-align: left;
-  width: 100%;
-
-  & h3 {
-    flex-grow: 1;
-    font-size: 0.9375rem;
-    font-weight: 600;
-  }
+  padding: 10px 11px;
 }
 
-.inactive:last-of-type .itemHeader {
+.itemTitle {
+  align-items: center;
+  display: flex;
+  flex: 1;
+  font-size: 0.9375rem;
+  font-weight: 600;
+}
+
+.titleButton {
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  margin: 0;
+  padding: 0;
+  text-align: left;
+}
+
+.iconWrapper {
+  align-items: center;
+  display: flex;
+  padding: 0 2px;
+}
+
+.inactive:last-of-type .itemHeaderRow {
   border-bottom: none;
+}
+
+.infoLink {
+  align-items: center;
+  display: inline-flex;
+  margin-left: 0.25rem;
 }
 
 .addIcon, .subtractIcon {

--- a/components/shared/Accordion/index.js
+++ b/components/shared/Accordion/index.js
@@ -70,27 +70,37 @@ class Accordion extends React.Component {
                 key={item.name}
                 className={item.active ? css.active : css.inactive}
               >
-                <button
-                  className={css.itemHeader}
-                  aria-controls={`facets_${i}`}
-                  aria-expanded={item.active}
+                <div
+                  className={css.itemHeaderRow}
                   onClick={() => this.onClickItem(i)}
                 >
-                  <h3>
-                    {item.name}
+                  <h3 className={css.itemTitle}>
+                    <button
+                      type="button"
+                      className={css.titleButton}
+                      aria-controls={`facets_${i}`}
+                      aria-expanded={item.active}
+                      onClick={(e) => { e.stopPropagation(); this.onClickItem(i); }}
+                    >
+                      {item.name}
+                    </button>
                     {item.name === "How Can I Use It?" && (
                       <a
                         href={"https://dp.la/about/rights-categories"}
                         title={facetLabel}
                         aria-label={facetLabel}
+                        className={css.infoLink}
+                        onClick={(e) => e.stopPropagation()}
                       >
-                        <InformationIcon className={css.informationIcon} />
+                        <InformationIcon className={css.informationIcon} aria-hidden="true" />
                       </a>
                     )}
                   </h3>
-                  {item.active && <SubtractIcon className={css.subtractIcon} />}
-                  {!item.active && <AddIcon className={css.addIcon} />}
-                </button>
+                  <div className={css.iconWrapper} aria-hidden="true">
+                    {item.active && <SubtractIcon className={css.subtractIcon} aria-hidden="true" />}
+                    {!item.active && <AddIcon className={css.addIcon} aria-hidden="true" />}
+                  </div>
+                </div>
                 {item.type === "term" && (
                   <ul id={`facets_${i}`} className={css.subitems}>
                     {item.subitems.map((subitem, index) => (

--- a/components/shared/Accordion/index.js
+++ b/components/shared/Accordion/index.js
@@ -74,16 +74,18 @@ class Accordion extends React.Component {
                   className={css.itemHeaderRow}
                   onClick={() => this.onClickItem(i)}
                 >
-                  <h3 className={css.itemTitle}>
-                    <button
-                      type="button"
-                      className={css.titleButton}
-                      aria-controls={`facets_${i}`}
-                      aria-expanded={item.active}
-                      onClick={(e) => { e.stopPropagation(); this.onClickItem(i); }}
-                    >
-                      {item.name}
-                    </button>
+                  <div className={css.titleAndInfo}>
+                    <h3 className={css.itemTitle}>
+                      <button
+                        type="button"
+                        className={css.titleButton}
+                        aria-controls={`facets_${i}`}
+                        aria-expanded={item.active}
+                        onClick={(e) => { e.stopPropagation(); this.onClickItem(i); }}
+                      >
+                        {item.name}
+                      </button>
+                    </h3>
                     {item.name === "How Can I Use It?" && (
                       <a
                         href={"https://dp.la/about/rights-categories"}
@@ -95,7 +97,7 @@ class Accordion extends React.Component {
                         <InformationIcon className={css.informationIcon} aria-hidden="true" />
                       </a>
                     )}
-                  </h3>
+                  </div>
                   <div className={css.iconWrapper} aria-hidden="true">
                     {item.active && <SubtractIcon className={css.subtractIcon} aria-hidden="true" />}
                     {!item.active && <AddIcon className={css.addIcon} aria-hidden="true" />}


### PR DESCRIPTION
This PR is to resolve issues pointed out in https://github.com/dpla/dpla-frontend/issues/1507

> Ensure interactive controls are not nested as they are not always announced by screen readers or can cause focus problems for assistive technologies

This PR does the following:
* Refactors the accordion header to follow the standard [Accordion](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/) pattern (the `<h3>` now wraps the target `<button>`, rather than the other way around).
* The "How Can I Use It?" info link now sits next to the toggle button as a sibling element.
* Converted the +/- expand/collapse buttons into an aria-hidden visual icon wrapper

# CodeRabbit Review
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Accordion Component Accessibility Refactor (WAI-ARIA Compliance)

### Overview
Refactors the Accordion component to follow the WAI-ARIA Accordion pattern and fix accessibility issues around nested interactive controls (resolves issue #1507). Markup and styles were updated so interactive controls are not nested, improving semantic structure, keyboard behavior, and screen-reader announcements. Component API/signature unchanged.

### Key Changes

- HTML/behavior (components/shared/Accordion/index.js)
  - Header wrapper changed from a button-wrapping-heading pattern to a header row div containing an <h3> that wraps the toggle <button> (WAI-ARIA pattern).
  - "How Can I Use It?" info link moved to be a sibling of the toggle button and stops event propagation so it doesn't trigger the toggle.
  - Toggle button retains aria-expanded and aria-controls.
  - Expand/collapse +/- indicators and the info icon converted to aria-hidden visual icons.
  - Click handlers adjusted so title button toggles item; info link/icon stopPropagation().

- Styles (components/shared/Accordion/Accordion.module.scss)
  - Renamed `.itemHeader` → `.itemHeaderRow`.
  - Added `.itemTitle`, `.titleButton`, `.titleAndInfo`, `.iconWrapper`, `.infoLink`.
  - Updated selector `.inactive:last-of-type .itemHeader` → `.inactive:last-of-type .itemHeaderRow`.
  - Header layout/spacing and typography reorganized to support new markup.

### Impact Assessment
- No exported/public API changes.
- No infrastructure changes (no env var/secrets updates, no CI/CD or ECS redeploy required).
- No database migrations.
- No public-facing API shape or endpoint changes.
- Security implications: none beyond accessibility improvements (no new external inputs or credential handling).

### Notes for Reviewers
- Verify keyboard focus/activation for accordion toggles and that the info link does not trigger expand/collapse.
- Confirm screen reader announces expanded/collapsed state via aria-expanded and that icons are ignored due to aria-hidden.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/dpla-frontend/pull/1528?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->