### PR TITLE
fix(a11y): Adjust sidebar link color

### DIFF
--- a/components/SearchComponents/MainContent/Sidebar/Sidebar.module.scss
+++ b/components/SearchComponents/MainContent/Sidebar/Sidebar.module.scss
@@ -39,7 +39,7 @@
 }
 
 .facetLink, .facetLink:visited {
-  color: black;
+  color: var(--linkColor);
 }
 
 .facetName {


### PR DESCRIPTION
This PR resolves https://github.com/dpla/dpla-frontend/issues/1476

Currently, the links to various filters in the sidebar (rights status, type, language, etc.) appear as black links, same as standard body text on the page. With this PR, these filtering links now appear as the link color, for accessibility and design consistency (to better make clear that these are clickable links).

Current sidebar link appearance:
<img width="400" src="https://github.com/user-attachments/assets/9c0243ef-02ab-42de-a0f3-bf66213ce6f8" />

With this PR (DPLA + Illinois hub):
<img width="400" src="https://github.com/user-attachments/assets/6e1baf9e-c717-49a4-bc8f-adecee4608c0" />

<img width="400" src="https://github.com/user-attachments/assets/abb14e09-f2d2-446e-8bad-7dd362354c43" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR fixes an accessibility issue where sidebar facet links (such as rights status, type, and language filters) were styled in black text, identical to non-clickable label text, making them difficult to distinguish as interactive elements and failing WCAG 2 Link to Body Text Contrast criteria.

## Changes
Updated the `.facetLink` and `.facetLink:visited` CSS classes in `components/SearchComponents/MainContent/Sidebar/Sidebar.module.scss` to use the theme's CSS link color variable (`var(--linkColor)`) instead of hardcoded black (`#000000`). This makes the sidebar filter links visually consistent with the site's standard link styling while maintaining appropriate contrast ratios against the sidebar background.

## Impact
- **Accessibility**: Resolves WCAG 2 Link to Body Text Contrast requirement for sidebar facet links
- **User Experience**: Improves visual clarity by making sidebar filters appear as clickable links
- **Design**: Maintains consistency with the site's standard link color across themes (e.g., `#be0a2f` for Illinois theme, `#ca4316` for DPLA main)

## Notes
This is a CSS-only change with no deployment, infrastructure, or configuration implications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/dpla-frontend/pull/1530?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->