### PR TITLE
fix(a11y): Adjust colors for accessibility

### DIFF
--- a/stylesheets/colors.scss
+++ b/stylesheets/colors.scss
@@ -84,7 +84,7 @@ transforms are complicated (color spaces, algorithms, etc).
   --silver: #ccc;
   --rockBrown: #ece9da;
   --bonjourRed: #e4dada;
-  --dimmerGray: #6d6d6d;
+  --dimmerGray: #545454;
   --visualBrown: #f9f8f5;
   --softPeach: #f6ecf0;
   --cranberry: #e04f8e;

--- a/stylesheets/themes/illinois/theme.scss
+++ b/stylesheets/themes/illinois/theme.scss
@@ -29,7 +29,7 @@
   --mobileNavColor: rgb(50, 41.5, 32.5) !important;
   --mobileNavMenuButtonOpen: rgb(43.75, 43.75, 43.75) !important;
   --darkSecondaryButtonColor: rgb(50, 41.5, 32.5) !important;
-  --warmerBackgroundColor: rgb(243.7475728155, 238.1213592233, 230.7524271845) !important;
+  --warmerBackgroundColor: var(--theme-background-color) !important;
   --colderBackgroundColor: rgb(248, 245.75, 241.25) !important;
   --subLinkColorHover: rgb(141.55, 7.45, 35.015) !important;
   --outlineColor: rgb(238.45, 12.55, 58.985) !important;


### PR DESCRIPTION
Resolves https://github.com/dpla/dpla-frontend/issues/1474

This PR slightly darkens the `dimmerGray` text color value to improve contrast for accessibility. It also sets the sidebar/header color for the Illinois hub to the standard `theme-background-color`, replacing the previously darker variation that did not provide sufficient contrast with the text.

Before/After below (subtle, but can see the Axe accessibility concerns resolved).

## Before
<img width="800" src="https://github.com/user-attachments/assets/aa06eb08-fffc-4ae8-9bba-c27220b7f89d" />

## After
<img width="800" src="https://github.com/user-attachments/assets/9d45b98d-71d0-4fa8-bdaa-9dc846b551f0" />
