### PR TITLE
fix(guides): fall back to WP slug query when post_name doesn't match URL slug

### DIFF
--- a/pages/guides/[guideSlug].js
+++ b/pages/guides/[guideSlug].js
@@ -9,7 +9,7 @@ import BreadcrumbsModule from "shared/BreadcrumbsModule";
 
 import { getMenuItemUrl, wordpressLinks } from "lib/index";
 
-import { ABOUT_MENU_ENDPOINT, SEO_TYPE } from "constants/content-pages";
+import { ABOUT_MENU_ENDPOINT, PAGES_ENDPOINT, SEO_TYPE } from "constants/content-pages";
 
 import contentCss from "stylesheets/content-pages.module.scss";
 import css from "stylesheets/guides.module.scss";
@@ -89,21 +89,36 @@ export async function getServerSideProps(context) {
   const menuItemsJson = await safeJson(menuItemsRes);
   if (menuItemsJson === null) return upstreamUnavailable(context.res, menuItemsRes);
   const guideSlug = context.params.guideSlug;
-  const guide = menuItemsJson.items.find(
-    (item) => item.post_name === guideSlug,
-  );
-  if (!guide) {
-    return { notFound: true };
+
+  // Falls back to a WP slug query when post_name diverges from the page slug (e.g. WP page was renamed).
+  let guide = menuItemsJson.items.find((item) => item.post_name === guideSlug);
+  let guideJson;
+
+  if (guide) {
+    const guideUrl = draftMode ? wpDraftUrl(getMenuItemUrl(guide)) : getMenuItemUrl(guide);
+    const guideRes = await safeFetch(guideUrl, authOptions);
+    if (isUpstreamUnavailable(guideRes)) return upstreamUnavailable(context.res, guideRes);
+    const guideError = checkResponseForSSRSafe(guideRes, "Guide page");
+    if (guideError) return guideError;
+    guideJson = await safeJson(guideRes);
+    if (guideJson === null) return upstreamUnavailable(context.res, guideRes);
+  } else {
+    const slugUrl = `${PAGES_ENDPOINT}?slug=${encodeURIComponent(guideSlug)}`;
+    const slugRes = await safeFetch(
+      draftMode ? wpDraftUrl(slugUrl) : slugUrl,
+      authOptions,
+    );
+    if (isUpstreamUnavailable(slugRes)) return upstreamUnavailable(context.res, slugRes);
+    if (!slugRes?.ok) return { notFound: true };
+    const pages = await safeJson(slugRes);
+    if (pages === null) return upstreamUnavailable(context.res, slugRes);
+    if (!pages.length) return { notFound: true };
+    guideJson = pages[0];
+    guide = menuItemsJson.items.find(
+      (item) => item.url === `${PAGES_ENDPOINT}/${guideJson.id}`,
+    );
+    if (!guide) return { notFound: true };
   }
-  const guideUrl = draftMode ? wpDraftUrl(getMenuItemUrl(guide)) : getMenuItemUrl(guide);
-  const guideRes = await safeFetch(guideUrl, authOptions);
-  if (isUpstreamUnavailable(guideRes)) {
-    return upstreamUnavailable(context.res, guideRes);
-  }
-  const guideError = checkResponseForSSRSafe(guideRes, "Guide page");
-  if (guideError) return guideError;
-  const guideJson = await safeJson(guideRes);
-  if (guideJson === null) return upstreamUnavailable(context.res, guideRes);
 
   let breadcrumbs = [];
 

--- a/pages/guides/[guideSlug].js
+++ b/pages/guides/[guideSlug].js
@@ -79,7 +79,9 @@ class Guides extends React.Component {
 
 export async function getServerSideProps(context) {
   const { draftMode } = context;
+  const guideSlug = context.params.guideSlug;
   const authOptions = wpAuthFetchOptions(draftMode);
+
   const menuItemsRes = await safeFetch(ABOUT_MENU_ENDPOINT);
   if (isUpstreamUnavailable(menuItemsRes)) {
     return upstreamUnavailable(context.res, menuItemsRes);
@@ -88,7 +90,6 @@ export async function getServerSideProps(context) {
   if (menuError) return menuError;
   const menuItemsJson = await safeJson(menuItemsRes);
   if (menuItemsJson === null) return upstreamUnavailable(context.res, menuItemsRes);
-  const guideSlug = context.params.guideSlug;
 
   // Falls back to a WP slug query when post_name diverges from the page slug (e.g. WP page was renamed).
   let guide = menuItemsJson.items.find((item) => item.post_name === guideSlug);
@@ -115,7 +116,13 @@ export async function getServerSideProps(context) {
     if (!pages.length) return { notFound: true };
     guideJson = pages[0];
     guide = menuItemsJson.items.find(
-      (item) => item.url === `${PAGES_ENDPOINT}/${guideJson.id}`,
+      (item) => {
+        const menuItemUrl = getMenuItemUrl(item);
+        return (
+          String(item.object_id) === String(guideJson.id) ||
+          menuItemUrl.endsWith(`/${guideJson.id}`)
+        );
+      },
     );
     if (!guide) return { notFound: true };
   }

--- a/pages/guides/[guideSlug].js
+++ b/pages/guides/[guideSlug].js
@@ -16,6 +16,7 @@ import css from "stylesheets/guides.module.scss";
 import utils from "stylesheets/utils.module.scss";
 import { washObject } from "lib/washObject";
 import { safeFetch, checkResponseForSSRSafe, wpAuthFetchOptions, wpDraftUrl, upstreamUnavailable, isUpstreamUnavailable, safeJson } from "lib/safeFetch";
+import { cachedSafeFetch } from "lib/wpCache";
 import { upgradeWordPressUrls } from "lib/upgradeWordPressUrls";
 import ServiceUnavailable from "components/shared/ServiceUnavailable";
 
@@ -60,11 +61,13 @@ class Guides extends React.Component {
                 role="main"
                 className={`${css.content} ${contentCss.content}`}
               >
-                <img
-                  src={guide.bannerImage}
-                  alt=""
-                  className={css.bannerImage}
-                />
+                {guide.bannerImage && (
+                  <img
+                    src={guide.bannerImage}
+                    alt=""
+                    className={css.bannerImage}
+                  />
+                )}
                 <h1 className={css.guideTitle}>{guide.title}</h1>
                 <HeadingRule />
                 <div dangerouslySetInnerHTML={{ __html: guide.content }} />
@@ -82,7 +85,7 @@ export async function getServerSideProps(context) {
   const guideSlug = context.params.guideSlug;
   const authOptions = wpAuthFetchOptions(draftMode);
 
-  const menuItemsRes = await safeFetch(ABOUT_MENU_ENDPOINT);
+  const menuItemsRes = await cachedSafeFetch(ABOUT_MENU_ENDPOINT);
   if (isUpstreamUnavailable(menuItemsRes)) {
     return upstreamUnavailable(context.res, menuItemsRes);
   }
@@ -127,14 +130,13 @@ export async function getServerSideProps(context) {
     if (!guide) return { notFound: true };
   }
 
-  let breadcrumbs = [];
-
-  breadcrumbs.push({
-    title: "Guides",
-    url: "/guides",
-  });
-
-  breadcrumbs.push({ title: guideJson.title.rendered });
+  const breadcrumbs = [
+    {
+      title: "Guides",
+      url: "/guides",
+    },
+    { title: guideJson.title.rendered },
+  ];
 
   const props = washObject({
     sidebarItems: menuItemsJson.items,
@@ -142,10 +144,10 @@ export async function getServerSideProps(context) {
     guide: {
       ...guideJson,
       slug: guide.url,
-      summary: guideJson.acf.summary,
+      summary: guideJson.acf?.summary,
       title: guideJson.title.rendered,
-      color: guideJson.acf.color,
-      bannerImage: guideJson.acf.banner_image,
+      color: guideJson.acf?.color,
+      bannerImage: guideJson.acf?.banner_image,
       content: upgradeWordPressUrls(guideJson.content?.rendered),
     },
   });


### PR DESCRIPTION
## Summary

- Guide pages (`/guides/[slug]`) were returning 404 for valid URLs linked from the home page and `/guides` index.
- Root cause: two earlier commits (`b37ad4e`, `f8dc2cb`) changed link generation to use `guideJson.slug` (the WP page's canonical slug) instead of `guide.post_name`, but the individual guide page's SSR lookup still matched on `post_name` only. Three guides whose WP slugs have been renamed diverged: `the-education-guide-to-dpla` → `education-guide`, `the-family-research-guide-to-dpla` → `for-family-research-guide-to-dpla`, `for-developers` → `dpla-developer-resources`.
- Fix: when `post_name` lookup misses, fall back to fetching the WP page by slug directly (`/wp/v2/pages?slug=…`), then verify the result belongs to the guides menu by matching on page ID before serving the content.

## Test plan

- [ ] Visit `/guides/education-guide` — should load "The Education Guide to DPLA" (previously 404)
- [ ] Visit `/guides/for-family-research-guide-to-dpla` — should load "The Family Research Guide to DPLA" (previously 404)
- [ ] Visit `/guides/dpla-developer-resources` — should load "DPLA Developer Resources" (previously 404)
- [ ] Visit `/guides/the-guide-to-lifelong-learning-with-dpla` and `/guides/the-scholarly-research-guide-to-dpla` — still load (fast path, `post_name` matches)
- [ ] Visit `/guides` — index still loads all guides
- [ ] Home page "How can I use DPLA?" cards link to the correct guides without 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fix for Guide Page 404s Due to WordPress Slug Mismatch

This PR adds a fallback lookup mechanism in the guides page resolver to handle cases where WordPress has renamed pages, causing the canonical `slug` to diverge from the menu item's `post_name`.

### Changes

pages/guides/[guideSlug].js
- Adds `PAGES_ENDPOINT` and switches to `cachedSafeFetch` when loading the Guides menu.
- Modified `getServerSideProps` to implement a two-stage guide lookup:
  1. Fast path: find the menu item by matching `post_name` to the URL slug (existing behavior), fetch the guide by the menu item URL, and parse it.
  2. Fallback path: if no menu item matches, query the WP REST API by slug (`/wp/v2/pages?slug=<guideSlug>`), take the first returned page, and verify the page belongs to the guides menu by matching page `id` to the menu item `object_id` or by checking for a menu item URL that ends with `/<id>`.
- Returns `{ notFound: true }` only when neither the fast path nor the fallback resolves a suitable page/menu item.
- Populates `guide` fields (summary, color, bannerImage) using optional chaining and sets `guide.slug` from the resolved guide URL; rendering now conditions the banner `<img>` on `guide.bannerImage`.
- No exported/public API signatures changed (e.g., `getServerSideProps` and default export remain intact).

### Rationale

Three WP pages had diverged `post_name` vs canonical slug, causing valid guide URLs to 404. The change restores access to those guides while preserving the fast-path behavior for normally-configured pages.

### Deployment & Impact Notes

- No manual pipeline trigger or ECS redeployment required specifically for this change.
- No new, removed, or renamed environment variables or AWS Secrets Manager keys.
- No database migrations.
- No changes to shared infrastructure (CodePipeline, CodeBuild, ECS task definitions, IAM policies).
- No public-facing API response shape changes or new/removed endpoints; the PR only queries the existing WP REST API endpoint.
- Security: no new credential handling or auth model changes; fallback uses the same wpAuthFetchOptions/draft handling and existing safeFetch patterns, so there are no new security implications beyond existing WP fetches.

### Test Plan

- Visit /guides/education-guide, /guides/for-family-research-guide-to-dpla, /guides/dpla-developer-resources — each should load the respective guide (previously 404).
- Verify fast-path guides still load when `post_name` matches.
- Ensure /guides index still loads all guides.
- Confirm home page guide links no longer produce 404s.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/dpla-frontend/pull/1532?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->