### PR TITLE
fix: broken breadcrumb links on about pages

### DIFF
--- a/pages/about/[...sections].js
+++ b/pages/about/[...sections].js
@@ -16,7 +16,6 @@ import {
 
 import {
   getBreadcrumbs,
-  getItemWithId,
   wordpressLinks,
   getMenuItemUrl,
   decodeHTMLEntities,
@@ -120,7 +119,7 @@ export const getServerSideProps = async (context) => {
   if (
     !pageItem ||
     pageItem === guidesPageItem ||
-    pageItem?.menu_item_parent === guidesPageItem.object_id
+    pageItem?.menu_item_parent === guidesPageItem?.object_id
   ) {
     return { notFound: true };
   }
@@ -135,19 +134,18 @@ export const getServerSideProps = async (context) => {
 
   if (JSON.stringify(breadcrumbObject) !== "{}") {
     Object.values(breadcrumbObject).forEach((crumb) => {
-      let slug = "/";
-      // if this is a child item the url is /:topsection/:thisitem
-      if (crumb.menu_item_parent !== "0") {
-        const parent = getItemWithId({
-          items: json.items,
-          id: crumb.menu_item_parent,
-        });
-        slug = slug + parent.post_name + "/";
+      let url;
+      if (String(crumb.object_id) === String(guidesPageItem?.object_id)) {
+        // Link to guides index
+        url = "/guides";
+      } else if (String(crumb.menu_item_parent) === String(guidesPageItem?.object_id)) {
+        // Guide pages (direct children of the guides landing) live at /guides/:slug
+        url = `/guides/${crumb.post_name}`;
+      } else {
+        // All other about-section pages use a flat /about/:post_name URL
+        url = `/about/${crumb.post_name}`;
       }
-      breadcrumbs.push({
-        title: crumb.title,
-        url: slug + crumb.post_name,
-      });
+      breadcrumbs.push({ title: crumb.title, url });
     });
     breadcrumbs.push({ title: pageItem.title });
   }


### PR DESCRIPTION
Breacrumbs on guide/about pages were broken in some situations.

For example, on this page:
https://dp.la/about/using-dplas-primary-source-sets

The parent breadcrumb links were the following, neither of which exist:
https://dp.la/how-can-i-use-dpla/the-education-guide-to-dpla
https://dp.la/how-can-i-use-dpla

With this PR, those breadcrumbs become the following correct links:
http://dp.la/guides/the-education-guide-to-dpla
http://dp.la/guides

The fix handles the various "types" of parent pages:
* The "How Can I Use DPLA?" landing -> `/guides`
* Guide pages (Education Guide, Family Research, etc.) -> `/guides/:slug`
* Everything else -> `/about/:slug`

# CodeRabbit Summary
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes incorrect breadcrumb parent links on guide and about pages. The breadcrumbs were previously producing hierarchical paths to non-existent URLs. The fix simplifies breadcrumb URL generation to use a branching strategy based on page type rather than calculating nested parent paths.

## Changes

Only one file is modified: `pages/about/[...sections].js`

The breadcrumb URL construction logic was rewritten to:
1. Map the guides landing page to `/guides`
2. Map guide pages (direct children of the guides landing) to `/guides/:slug`
3. Map all other about-section pages to `/about/:slug`

The previous implementation removed the `getItemWithId` helper function and recursive parent menu logic that was building incorrect nested `/about/...` paths. Added optional chaining when validating `guidesPageItem?.object_id` for safer null checking.

**Lines changed**: +12/-14

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/dpla-frontend/pull/1533?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->