### PR TITLE
fix(analytics): suppress broken PSS GA4 events

### DIFF
--- a/lib/getContributor.js
+++ b/lib/getContributor.js
@@ -2,13 +2,12 @@
 // return the contributor name.
 
 const getContributor = source => {
-  let contributor = "";
-  try {
-    contributor = source.mainEntity[0]["provider"].filter(
-      ref => ref["disambiguationDescription"] == "contributing institution"
-    )[0]["name"];
-  } catch (e) {}
-  return contributor;
+  const provider = source?.mainEntity?.[0]?.provider;
+  if (!Array.isArray(provider)) return "";
+  const entry = provider.find(
+    ref => ref.disambiguationDescription === "contributing institution"
+  );
+  return entry ? entry.name : "";
 };
 
 export default getContributor;

--- a/lib/getContributor.js
+++ b/lib/getContributor.js
@@ -7,7 +7,7 @@ const getContributor = source => {
   const entry = provider.find(
     ref => ref.disambiguationDescription === "contributing institution"
   );
-  return entry ? entry.name : "";
+  return entry?.name ?? "";
 };
 
 export default getContributor;

--- a/lib/getPartner.js
+++ b/lib/getPartner.js
@@ -2,20 +2,12 @@
 // return the partner name.
 
 const getPartner = source => {
-  const provider = source.mainEntity[0]["provider"]
-    ? source.mainEntity[0]["provider"]
-    : "";
-  let providerName = "";
-  if (provider instanceof Array) {
-    // This works with a more recent iteration of the PSS API.
-    providerName = provider.filter(
-      ref => ref["disambiguationDescription"] == "partner"
-    )[0]["name"];
-  } else {
-    // This works with the original version of the PSS API.
-    providerName = provider.name;
-  }
-  return providerName;
+  const provider = source?.mainEntity?.[0]?.provider;
+  if (!Array.isArray(provider)) return "";
+  const entry = provider.find(
+    ref => ref.disambiguationDescription === "partner"
+  );
+  return entry ? entry.name : "";
 };
 
 export default getPartner;

--- a/lib/getPartner.js
+++ b/lib/getPartner.js
@@ -7,7 +7,7 @@ const getPartner = source => {
   const entry = provider.find(
     ref => ref.disambiguationDescription === "partner"
   );
-  return entry ? entry.name : "";
+  return entry?.name ?? "";
 };
 
 export default getPartner;

--- a/lib/gtag.js
+++ b/lib/gtag.js
@@ -13,8 +13,8 @@ export const pageview = ({ url, title }) => {
 
 // https://developers.google.com/analytics/devguides/collection/gtagjs/events
 export const event = (gaEvent) => {
-  const action = gaEvent.contributor ? gaEvent.contributor : "Broken ID";
-  invokeGtag("event", action, {
+  if (!gaEvent.contributor || !gaEvent.partner) return;
+  invokeGtag("event", gaEvent.contributor, {
     event_category: `${gaEvent.type} : ${gaEvent.partner}`,
     event_label: `${gaEvent.itemId} : ${gaEvent.title}`,
   });


### PR DESCRIPTION
Resolves https://github.com/dpla/dpla-frontend/issues/1504

PSS source views and click-throughs have been firing GA4 events with `Broken ID` as the institution name and `undefined` as the hub, making them invisible in DPLA's Analytics Dashboard. The underlying issue is that PSS item JSON has never had provider data populated.

With this PR:
* `gtag.event()` now drops events when `contributor` or `partner` are absent (the data is otherwise just noise)
* `getPartner()` is fixed to return empty string instead of `undefined` when provider data is missing
* `getPartner()` and `getContributor()` now won't crash if no matching entry exists

# CodeRabbit Summary
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## GA4 Event Suppression for PSS Sources with Missing Attribution

This PR fixes a data quality issue in Google Analytics 4 events for Primary Source Sets (PSS) by preventing events with missing or incomplete attribution data from being sent to analytics.

### Changes

Three utility files in `lib/` were updated:

1. **`lib/gtag.js`**: The `event()` function now early-returns (drops the event) unless both `contributor` and `partner` fields are present in the `gaEvent` object. This prevents PSS sources lacking provider data from generating events with `"Broken ID"` contributor or `undefined` partner values.

2. **`lib/getPartner.js`**: Refactored to safely handle missing provider data using optional chaining and `.find()`. Returns an empty string (`""`) instead of `undefined` when `source.mainEntity[0].provider` is absent or not an array, or when no provider entry with `disambiguationDescription === "partner"` is found.

3. **`lib/getContributor.js`**: Refactored similarly to return an empty string when `source.mainEntity[0].provider` is absent or not an array, or when no provider entry with `disambiguationDescription === "contributing institution"` is found. Both functions now use consistent defensive programming with optional chaining and `.find()` instead of previous array indexing patterns.

### Impact

- **GA4 events**: PSS sources will not send attribution events until upstream PSS JSON enrichment provides complete provider data. This prevents synthetic "Broken ID" institutions from appearing in the Analytics Dashboard.
- **No retroactive changes**: This only affects future events; historical GA4 records remain unchanged.
- **Code robustness**: Both accessor functions are hardened against undefined/null values and missing array entries.

### Deployment

This is a standard application code change (JavaScript utility functions) with no impact on:
- Environment variables or AWS Secrets Manager keys
- Database migrations
- Infrastructure configuration or ECS task definitions
- Public-facing API shapes
- Security/auth mechanisms

The changes deploy through the normal CI/CD pipeline with no manual interventions required.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/dpla-frontend/pull/1534?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->