### PR TITLE
fix: repair ZoomableImageViewer lifecycle and PDFViewer initial scroll

### DIFF
--- a/components/shared/mediaViewers/PDFViewer.js
+++ b/components/shared/mediaViewers/PDFViewer.js
@@ -7,7 +7,7 @@ function PDFViewer({ pathToFile, height = "650px" }) {
     <div className={css.pdfViewer} style={{ height }}>
       <iframe
         title="dpla-pdf-viewer"
-        src={`/static/pdfjs/web/viewer.html?file=${pathToFile}#zoom=page-width`}
+        src={`/static/pdfjs/web/viewer.html?file=${pathToFile}#page=1&zoom=page-width`}
         style={{ width: "100%", height }}
       />
     </div>

--- a/components/shared/mediaViewers/ZoomableImageViewer.js
+++ b/components/shared/mediaViewers/ZoomableImageViewer.js
@@ -3,8 +3,6 @@ import ReactDOM from "react-dom/server";
 
 import css from "./mediaViewers.module.scss";
 
-const viewerId = "openseadragon1";
-
 function Noscript({ children }) {
   const staticMarkup = ReactDOM.renderToStaticMarkup(children);
   return <noscript dangerouslySetInnerHTML={{ __html: staticMarkup }} />;
@@ -16,16 +14,17 @@ export default class ZoomableImageViewer extends React.Component {
     super(props);
     this.viewer = null;
     this.loading = false;
+    this.containerRef = React.createRef();
   }
 
   componentDidMount() {
-    if (!this.viewer && !this.loading) {
+    if (!this.viewer && !this.loading && this.containerRef.current) {
       this.loading = true;
       try {
         const OpenSeaDragon = require("openseadragon");
         const url = this.props.pathToFile;
         this.viewer = new OpenSeaDragon({
-          id: viewerId,
+          element: this.containerRef.current,
           tileSources: {type: "image", url},
           prefixUrl: "/static/images/openseadragon/",
         });
@@ -36,20 +35,21 @@ export default class ZoomableImageViewer extends React.Component {
   }
 
   componentWillUnmount() {
+    if (this.viewer) {
+      this.viewer.destroy();
+    }
     this.viewer = null;
-    document.getElementById(viewerId).innerHTML = "";
   }
 
   componentDidUpdate(prevProps, prevState, snapshot) {
-    if (this.props.pathToFile !== prevProps.pathToFile) {
-      // this works locally. might be necessary to preload the image like in: https://jsfiddle.net/ashraffayad/074navyp/
+    if (this.props.pathToFile !== prevProps.pathToFile && this.viewer) {
       this.viewer.open({ type: "image", url: this.props.pathToFile });
     }
   }
 
   render() {
     return (
-      <div id={viewerId} className={css.zoomableImageViewer}>
+      <div ref={this.containerRef} className={css.zoomableImageViewer}>
         <Noscript>
           <div className={css.noscriptContainer}>
             <img


### PR DESCRIPTION
## Summary

- **ZoomableImageViewer crash on fast navigation** (Sentry DPLA-FRONTEND-1MX, 1MY, 1MW): Replace the hardcoded `id="openseadragon1"` DOM lookup with a React ref. The original `document.getElementById(viewerId)` call in `componentWillUnmount` returned null whenever React committed a new page's DOM before the old page unmounted (a race on fast SPA navigation), crashing with `Cannot set properties of null`. The old code also never called `viewer.destroy()`, leaving ghost OpenSeaDragon instances alive with their canvas, event listeners, and animation timers still running.
- **PDF viewer opens mid-document** (GitHub #859): Add `#page=1` to the pdfjs iframe URL so PDFs always open at page 1 rather than at the browser's remembered scroll offset.
- **Null guard on `componentDidUpdate`**: If `componentDidMount` throws before assigning `this.viewer`, a subsequent prop change would crash on `this.viewer.open()`. Added `&& this.viewer` guard.

## Test plan

- [ ] Navigate to a Primary Source Set that has an image viewer; verify images pan/zoom normally
- [ ] Navigate away and back quickly (e.g. use browser back/forward rapidly) — no crash
- [ ] Navigate to a PSS with a PDF item; verify the PDF opens at page 1
- [ ] Open a PSS with multiple images and page through them; verify each image loads in the viewer

Fixes Sentry DPLA-FRONTEND-1MX, DPLA-FRONTEND-1MY, DPLA-FRONTEND-1MW
Closes #859

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/dpla-frontend/pull/1537?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->