### PR TITLE
fix(a11y): add WebVTT caption tracks to tutorial videos on Lists page

### DIFF
--- a/components/ListComponents/index.js
+++ b/components/ListComponents/index.js
@@ -64,6 +64,7 @@ export function ListEmpty() {
       >
         <source src="/static/video/list-add.mp4" type="video/mp4" />
         <source src="/static/video/list-add.ogv" type="video/ogg" />
+        <track kind="captions" src="/static/video/list-add.vtt" srclang="en" label="English" default />
         <p>
           Your browser doesn&apos;t support HTML5 video. Here is a{" "}
           <a href="/static/video/list-add.mp4">link to the video</a> instead.
@@ -108,6 +109,7 @@ export function ListsEmpty() {
       >
         <source src="/static/video/list-new.mp4" type="video/mp4" />
         <source src="/static/video/list-new.ogv" type="video/ogg" />
+        <track kind="captions" src="/static/video/list-new.vtt" srclang="en" label="English" default />
         <p>
           Your browser doesn&apos;t support HTML5 video. Here is a{" "}
           <a href="/static/video/list-new.mp4">link to the video</a> instead.
@@ -130,6 +132,7 @@ export function ListsEmpty() {
       >
         <source src="/static/video/list-download.mp4" type="video/mp4" />
         <source src="/static/video/list-download.ogv" type="video/ogg" />
+        <track kind="captions" src="/static/video/list-download.vtt" srclang="en" label="English" default />
         <p>
           Your browser doesn&apos;t support HTML5 video. Here is a{" "}
           <a href="/static/video/list-download.mp4">link to the video</a>{" "}

--- a/public/static/video/list-add.vtt
+++ b/public/static/video/list-add.vtt
@@ -1,0 +1,4 @@
+WEBVTT
+
+00:00:00.000 --> 00:00:07.233
+[No audio] Demonstrates adding items to a list from search results

--- a/public/static/video/list-download.vtt
+++ b/public/static/video/list-download.vtt
@@ -1,0 +1,4 @@
+WEBVTT
+
+00:00:00.000 --> 00:00:07.066
+[No audio] Demonstrates downloading a list

--- a/public/static/video/list-new.vtt
+++ b/public/static/video/list-new.vtt
@@ -1,0 +1,4 @@
+WEBVTT
+
+00:00:00.000 --> 00:00:06.633
+[No audio] Demonstrates creating a list and adding items


### PR DESCRIPTION
## Summary

Fixes #1506.

The three `<video>` elements on the My Lists page had no captions, violating [WCAG 2.1 SC 1.2.1](https://www.w3.org/TR/WCAG21/#audio-only-and-video-only-prerecorded) (Audio-only and Video-only, Prerecorded). Although the `title` attribute noted "video with no audio", accessibility checkers don't accept it as a programmatic time-based media alternative.

**Fix:** Added a WebVTT `.vtt` file for each video (in `public/static/video/`) and wired each one in with `<track kind="captions" srclang="en" label="English" default />`.

Each caption file has a single cue spanning the video's full duration (7.2s, 6.6s, 7.1s respectively) with text:

```
[No audio] Demonstrates <action>
```

**Why `kind="captions"` and not `kind="descriptions"`?** For silent/visual-only content, `kind="descriptions"` is marginally more semantically correct per WCAG H96, but `kind="captions"` has broader assistive-technology support and is the standard recommendation for satisfying the SC 1.2.1 automated checker requirement for `<video>` elements.

## Test plan

- [ ] Open `/lists` and `/search` (where `ListEmpty` / `ListsEmpty` components render)
- [ ] Confirm videos play and display a CC button in the controls bar
- [ ] Enable captions — verify `[No audio] Demonstrates…` text appears
- [ ] Run an accessibility checker (axe, WAVE, or Lighthouse) against the page and confirm the video caption violation is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds WebVTT caption tracks to three tutorial videos on the My Lists page to improve accessibility and meet WCAG 2.1 SC 1.2.1 (Audio-only and Video-only, Prerecorded) requirements.

## Changes

**components/ListComponents/index.js:**
- Added three `<track>` elements to the "add items," "create your lists," and "download lists" video components
- Each track element specifies `kind="captions"`, `srclang="en"`, `label="English"`, and `default` attributes
- Tracks reference corresponding WebVTT files in `public/static/video/`

**New WebVTT caption files:**
- `public/static/video/list-add.vtt` — single cue spanning 00:00:00.000 → 00:00:07.233 with text "[No audio] Demonstrates adding items to a list from search results"
- `public/static/video/list-new.vtt` — single cue spanning 00:00:00.000 → 00:00:06.633 with text "[No audio] Demonstrates creating a list and adding items"
- `public/static/video/list-download.vtt` — single cue spanning 00:00:00.000 → 00:00:07.066 with text "[No audio] Demonstrates downloading a list"

## Notes

No manual pipeline trigger, environment variable changes, database migrations, infrastructure configuration modifications, API changes, or security implications are introduced by this PR. The changes consist entirely of static media files and HTML markup additions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/dpla-frontend/pull/1539?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->