### PR TITLE
fix(a11y): add optional captionsUrl prop to VideoPlayer

### DIFF
--- a/components/shared/mediaViewers/VideoPlayer.js
+++ b/components/shared/mediaViewers/VideoPlayer.js
@@ -2,11 +2,20 @@ import React from "react";
 
 import css from "./mediaViewers.module.scss";
 
-function VideoPlayer({ pathToFile, fileFormat }) {
+function VideoPlayer({ pathToFile, fileFormat, captionsUrl }) {
   return (
     <div className={css.videoPlayerWrapper}>
       <video className={css.videoPlayer} controls controlsList="nodownload">
         <source src={pathToFile} />
+        {captionsUrl && (
+          <track
+            kind="captions"
+            src={captionsUrl}
+            srclang="en"
+            label="English"
+            default
+          />
+        )}
       </video>
     </div>
   );


### PR DESCRIPTION
## Summary

Follow-up to #1506. Thanks to @megannp4 for the original accessibility report that kicked off this investigation.

`VideoPlayer` — used on Primary Source Sets source pages and Exhibition viewer pages — had no mechanism to display captions even if a caption file URL were available. This PR adds an optional `captionsUrl` prop; when provided, a `<track kind="captions">` element is rendered and the browser automatically surfaces a CC button in the video controls.

**The prop is intentionally inert for now.** Neither the PSS API nor the Exhibitions data currently exposes caption file URLs in their schemas. A companion issue tracks the content and API work needed to make captions actually appear. Once those URLs are wired up, callers simply pass `captionsUrl={source.captionsUrl}` and it works.

## Changes

- `components/shared/mediaViewers/VideoPlayer.js`: accepts new optional `captionsUrl` prop; conditionally renders `<track kind="captions" srclang="en" label="English" default />` when the prop is present

## Test plan

- [ ] Verify Primary Source Sets video sources render unchanged (no CC button, no console errors)
- [ ] Verify Exhibition video items render unchanged
- [ ] Manually pass a valid `.vtt` URL as `captionsUrl` in dev and confirm CC button appears and captions display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Fix(a11y): Add optional captionsUrl prop to VideoPlayer

**Accessibility enhancement** - Adds support for video captions in the VideoPlayer component to address accessibility requirements identified in `#1506`.

## Changes
- Adds optional `captionsUrl` prop to `VideoPlayer` component in `components/shared/mediaViewers/VideoPlayer.js`
- Conditionally renders a `<track>` element with `kind="captions"`, `src={captionsUrl}`, `srclang="en"`, `label="English"`, and `default` attributes when `captionsUrl` is provided
- When a caption file URL is supplied, the browser's native video player will display a CC (closed captions) control

## Current scope
The prop is intentionally non-functional at this stage—neither the Primary Source Sets (PSS) API nor Exhibitions data currently expose caption file URLs. This PR lays the groundwork for future integration; once APIs expose `captionsUrl`, callers can pass the value directly to the component.

## Testing notes
- Existing PSS and Exhibition video sources should render without changes (no CC button, no console errors)
- Manual testing with a valid `.vtt` URL as `captionsUrl` should display the CC button and render captions correctly

## No impact on:
- Deployment/infrastructure (no pipeline trigger, ECS redeployment, or configuration changes required)
- Environment variables or secrets
- Database (no migrations)
- Public APIs or response shapes
- Security posture

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/dpla-frontend/pull/1541?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->