### PR TITLE
fix(sitemap): Increase sitemap generation GitHub Action script duration to 3 hours

### DIFF
--- a/.github/workflows/generate-hub-sitemaps.yml
+++ b/.github/workflows/generate-hub-sitemaps.yml
@@ -31,6 +31,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::283408157088:role/github-actions-hub-sitemaps
+          role-duration-seconds: 10800
           aws-region: us-east-1
 
       - name: Generate hub sitemaps


### PR DESCRIPTION
The sitemap generation script now takes over 1 hour to complete, due to the number of items to process + following API rate limiting. 3 hours should be enough to finish.

The respective IAM role on AWS has also been updated to allow a maximum runtime of 3 hours.

# CodeRabbit Summary
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR increases the maximum runtime for the GitHub Actions workflow that generates hub sitemaps from the default duration to 3 hours (10800 seconds). The sitemap generation script currently takes over 1 hour to complete due to the large number of items being processed and API rate limiting constraints.

## Changes

- Updated `.github/workflows/generate-hub-sitemaps.yml` to set `role-duration-seconds: 10800` in the AWS OIDC credentials configuration step when assuming the `github-actions-hub-sitemaps` IAM role

## Infrastructure Impact

**Changes shared infrastructure configuration**: This PR modifies the AWS IAM role assumption duration. The corresponding AWS IAM role (`github-actions-hub-sitemaps`) must be pre-configured to permit a maximum runtime of 3 hours for this change to be effective.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/dpla-frontend/pull/1545?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->