### PR TITLE
fix(exhibitions): guard subsectionSlug in item viewer and nav links

### DIFF
--- a/components/ExhibitionsComponents/ExhibitionSection/FooterNav.js
+++ b/components/ExhibitionsComponents/ExhibitionSection/FooterNav.js
@@ -14,7 +14,7 @@ function NavButton({queryParams, nextOrPrevious = "next"}) {
     if (queryParams) {
         return (
             <Link
-                href={["/exhibitions/", queryParams.exhibitionSlug, "/", queryParams.sectionSlug, "/", queryParams.subsectionSlug ? queryParams.subsectionSlug : ""].join("")}
+                href={["/exhibitions/", queryParams.exhibitionSlug, "/", queryParams.sectionSlug, queryParams.subsectionSlug ? "/" + queryParams.subsectionSlug : ""].join("")}
                 className={nextOrPrevious === "next" ? css.nextButton : css.prevButton}
             >
                 {nextOrPrevious === "previous" && <BlackChevron className={css.previousChevron} alt=""/>}

--- a/components/ExhibitionsComponents/ExhibitionSection/Sidebar.js
+++ b/components/ExhibitionsComponents/ExhibitionSection/Sidebar.js
@@ -36,7 +36,7 @@ function Sidebar({
                     ].join(" ")}
                   >
                     <Link
-                      href={`/exhibitions/${exhibitionSlug}/${section.slug}/${subsection.slug !== section.slug ? subsection.slug : ""}`}
+                      href={`/exhibitions/${exhibitionSlug}/${section.slug}${subsection.slug ? "/" + subsection.slug : ""}`}
                     >
                       {subsection.title}
                     </Link>

--- a/components/ExhibitionsComponents/ExhibitionSection/Viewer.js
+++ b/components/ExhibitionsComponents/ExhibitionSection/Viewer.js
@@ -158,8 +158,7 @@ class Viewer extends React.Component {
                     router.query.exhibitionSlug,
                     "/",
                     router.query.sectionSlug,
-                    "/",
-                    router.query.subsectionSlug,
+                    router.query.subsectionSlug ? "/" + router.query.subsectionSlug : "",
                     "?item=",
                     previousBlock.id,
                   ].join("")}
@@ -182,8 +181,7 @@ class Viewer extends React.Component {
                     router.query.exhibitionSlug,
                     "/",
                     router.query.sectionSlug,
-                    "/",
-                    router.query.subsectionSlug,
+                    router.query.subsectionSlug ? "/" + router.query.subsectionSlug : "",
                     "?item=",
                     nextBlock.id,
                   ].join("")}


### PR DESCRIPTION
## Summary

- **Root cause (Sentry DPLA-FRONTEND-W4):** On section-level exhibition pages (no `subsectionSlug` in the route), the previous/next item buttons in `Viewer.js` included `router.query.subsectionSlug` directly in the URL array. When the router param is absent, JavaScript coerces it to the string `"undefined"`, producing URLs like `.../staying-neutral/undefined?item=1743`. This 404s and triggers `_error.js` with an undefined error object.
- **Viewer.js** — both the previous-item and next-item `<Link>` hrefs now use `router.query.subsectionSlug ? "/" + router.query.subsectionSlug : ""`, matching the existing guard in `ItemLink` within the same component.
- **Sidebar.js** — the Introduction entry in `subsectionMap` has `slug: ""`. The old condition `subsection.slug !== section.slug` was always true for the Introduction (empty string is never equal to the section slug), emitting `""` as the last segment and creating a trailing slash. New code uses the same truthiness pattern.
- **FooterNav.js** — the old href array always included `"/"` before `subsectionSlug`, producing a trailing slash (`/exhibitions/foo/bar/`) when no subsectionSlug was present. Now consistent with the server-side canonical URL construction.

## Test plan

- [ ] Navigate to an exhibition section page (e.g. `/exhibitions/[exhibition]/[section]`) that has multiple items in the viewer — confirm prev/next item buttons navigate correctly without "undefined" in the URL
- [ ] Navigate to an exhibition subsection page — confirm prev/next item buttons still include the subsection slug correctly
- [ ] Open the sidebar on an exhibition page — confirm the Introduction link navigates to the section root (no trailing slash), and subsection links navigate to the correct subsection
- [ ] Use the footer Previous/Next nav to move between sections and subsections — confirm URLs are correct with no trailing slash on section-level targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes URL construction bugs in exhibition section navigation that were causing 404 errors and undefined slug handling on section-level exhibition pages.

### Problem
When `subsectionSlug` was absent on section-level exhibition pages, the code was directly inserting `router.query.subsectionSlug` into URLs, which coerced to the string `"undefined"`. This produced malformed URLs like `/staying-neutral/undefined?item=1743` and caused the error handler to receive an undefined error object (Sentry DPLA-FRONTEND-W4).

### Changes

**Viewer.js** — Updated previous/next item link hrefs to guard `router.query.subsectionSlug` with a conditional: `router.query.subsectionSlug ? "/" + router.query.subsectionSlug : ""`. This prevents "undefined" from being appended to the URL path.

**Sidebar.js** — Modified subsection navigation link URL construction to append the subsection slug only when `subsection.slug` is truthy, replacing the prior comparison logic that was emitting empty string segments.

**FooterNav.js** — Updated NavButton's link-building logic to use the same guarded pattern (`slug ? "/" + slug : ""`) for the subsection slug, matching the server-side canonical URL construction and preventing trailing slashes for section-level targets.

### Testing
The fix ensures that:
- Previous/next item buttons work without "undefined" in URLs on section-level pages
- Subsection slug is correctly included on subsection pages
- Sidebar Introduction link navigates to section root without trailing slash
- Footer navigation builds URLs without trailing slashes for section-level targets

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/dpla-frontend/pull/1546?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->