### PR TITLE
fix(lists): fix crash and race condition in list item fetching

### DIFF
--- a/pages/api/items/ITEMS-API.md
+++ b/pages/api/items/ITEMS-API.md
@@ -95,8 +95,9 @@ On success, the route passes through the raw DPLA Search API response:
 | Condition | Status | Body |
 |-----------|--------|------|
 | Zero valid IDs after filtering | 404 | `{}` |
-| Upstream DPLA API error | 404 | `Not found.` (text) |
-| Exception during fetch | 404 | `{}` |
+| Upstream DPLA API returned 404 | 404 | `{ "error": "Not found." }` |
+| Upstream DPLA API error (non-404) | 502 | `{ "error": "Upstream service error." }` |
+| Exception during fetch or stream | 502 | `{ "error": "Upstream service error." }` |
 
 Errors are logged to the server console but not surfaced in the response body.
 

--- a/pages/api/items/[idListString].js
+++ b/pages/api/items/[idListString].js
@@ -72,7 +72,7 @@ export default async function handler(req, res) {
             if (fetchRes.status === 404) {
                 res.status(404).json({ error: "Not found." });
             } else {
-                res.status(fetchRes.status).json({ error: "Upstream service error." });
+                res.status(502).json({ error: "Upstream service error." });
             }
         }
 

--- a/pages/lists/[listId].js
+++ b/pages/lists/[listId].js
@@ -113,7 +113,14 @@ const List = () => {
       try {
         const json = await res.json();
         if (cancelled) return;
-        const items = (json.docs ?? [])
+        if (!Array.isArray(json.docs)) {
+          setInitialized(true);
+          setList(list);
+          setItems([]);
+          setItemsFetchError(true);
+          return;
+        }
+        const items = json.docs
           .filter((result) => result.error === undefined)
           .map((result) => {
             const thumbnailUrl = getItemThumbnail(result);

--- a/pages/lists/[listId].js
+++ b/pages/lists/[listId].js
@@ -250,7 +250,7 @@ const List = () => {
             )}
             {items.length === 0 && (
               itemsFetchError
-                ? <p className={css.listItemsError}>We couldn&apos;t load your saved items right now. Please try again later.</p>
+                ? <p role="alert" className={css.listItemsError}>We couldn&apos;t load your saved items right now. Please try again later.</p>
                 : <ListEmpty />
             )}
             {list.name && (

--- a/pages/lists/[listId].js
+++ b/pages/lists/[listId].js
@@ -47,7 +47,11 @@ const List = () => {
         return;
       }
 
-      // Clear stale fetch errors when a new load starts
+      // Reset state for a new load
+      setInitialized(false);
+      setList(null);
+      setItems([]);
+      setStorageUnavailable(false);
       setItemsFetchError(false);
 
       let list;
@@ -68,17 +72,15 @@ const List = () => {
       if (!list) {
         setInitialized(true);
         setItems([]);
-        setItemsFetchError(false);
         return;
       }
 
-      const itemIds = list?.selectedHash ? Object.keys(list?.selectedHash) : [];
+      const itemIds = list.selectedHash ? Object.keys(list.selectedHash) : [];
 
       if (itemIds.length === 0) {
         setInitialized(true);
         setList(list);
         setItems([]);
-        setItemsFetchError(false);
         return;
       }
 
@@ -131,7 +133,6 @@ const List = () => {
         setInitialized(true);
         setList(list);
         setItems(items);
-        setItemsFetchError(false);
       } catch {
         if (cancelled) return;
         setInitialized(true);
@@ -231,7 +232,7 @@ const List = () => {
               <strong>Note:</strong> The link to this list won&apos;t work for
               someone else or in another browser.
             </p>
-            {items && listId && (
+            {items.length > 0 && listId && (
               <ListView
                 name={list.name}
                 exportable={true}

--- a/pages/lists/[listId].js
+++ b/pages/lists/[listId].js
@@ -35,9 +35,13 @@ const List = () => {
   const [items, setItems] = useState([]);
   const [initialized, setInitialized] = useState(false);
   const [storageUnavailable, setStorageUnavailable] = useState(false);
+  const [itemsFetchError, setItemsFetchError] = useState(false);
   const isRenamingRef = useRef(false);
 
   useEffect(() => {
+    let cancelled = false;
+    const controller = new AbortController();
+
     const fetchList = async () => {
       if (!listId) {
         return;
@@ -47,6 +51,7 @@ const List = () => {
       try {
         list = await localforage.getItem(listId);
       } catch (err) {
+        if (cancelled) return;
         console.error("fetchList error", err);
         if (err.message === STORAGE_UNAVAILABLE_ERROR) {
           setStorageUnavailable(true);
@@ -54,6 +59,8 @@ const List = () => {
         setInitialized(true);
         return;
       }
+
+      if (cancelled) return;
 
       if (!list) {
         setInitialized(true);
@@ -72,21 +79,34 @@ const List = () => {
 
       const ids = itemIds.join(",");
 
-      const url = `/api/items/${ids}`;
-      const res = await fetch(url);
+      let res;
+      try {
+        res = await fetch(`/api/items/${ids}`, { signal: controller.signal });
+      } catch (err) {
+        if (cancelled) return;
+        console.error("Failed to fetch list items:", err);
+        setInitialized(true);
+        setList(list);
+        setItems([]);
+        setItemsFetchError(true);
+        return;
+      }
+
+      if (cancelled) return;
+
       if (!res.ok) {
-        if (res.status === 404) {
-          setInitialized(true);
-          setList(list);
-          setItems([]);
-          return;
-        }
-        throw new Error("Couldn't load items.");
+        console.error("Failed to fetch list items:", res.status);
+        setInitialized(true);
+        setList(list);
+        setItems([]);
+        setItemsFetchError(true);
+        return;
       }
 
       try {
         const json = await res.json();
-        const items = json.docs
+        if (cancelled) return;
+        const items = (json.docs ?? [])
           .filter((result) => result.error === undefined)
           .map((result) => {
             const thumbnailUrl = getItemThumbnail(result);
@@ -107,13 +127,20 @@ const List = () => {
         setList(list);
         setItems(items);
       } catch {
+        if (cancelled) return;
         setInitialized(true);
         setList(list);
         setItems([]);
+        setItemsFetchError(true);
       }
     };
 
     fetchList();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
   }, [listId]);
 
   const onNameChange = useCallback(
@@ -207,7 +234,11 @@ const List = () => {
                 viewingList={listId}
               />
             )}
-            {items.length === 0 && <ListEmpty />}
+            {items.length === 0 && (
+              itemsFetchError
+                ? <p className={css.listItemsError}>We couldn&apos;t load your saved items right now. Please try again later.</p>
+                : <ListEmpty />
+            )}
             {list.name && (
               <ConfirmModal
                 className={css.listDeleteConfirm}

--- a/pages/lists/[listId].js
+++ b/pages/lists/[listId].js
@@ -47,6 +47,9 @@ const List = () => {
         return;
       }
 
+      // Clear stale fetch errors when a new load starts
+      setItemsFetchError(false);
+
       let list;
       try {
         list = await localforage.getItem(listId);
@@ -65,6 +68,7 @@ const List = () => {
       if (!list) {
         setInitialized(true);
         setItems([]);
+        setItemsFetchError(false);
         return;
       }
 
@@ -74,6 +78,7 @@ const List = () => {
         setInitialized(true);
         setList(list);
         setItems([]);
+        setItemsFetchError(false);
         return;
       }
 
@@ -126,6 +131,7 @@ const List = () => {
         setInitialized(true);
         setList(list);
         setItems(items);
+        setItemsFetchError(false);
       } catch {
         if (cancelled) return;
         setInitialized(true);


### PR DESCRIPTION
## Summary

Fixes Sentry issue **DPLA-FRONTEND-1N6** ("Invalid hook call" on `/lists/[listId]`).

**Root cause:** The items API (`/api/items/[idListString]`) proxied upstream error status codes verbatim to the browser. When the DPLA API returned a 405, the browser received a 405. In `[listId].js`, the fetch handler only caught 404 specially — any other non-OK status hit an uncaught `throw new Error(...)` inside an `async fetchList()` that was called without `await` or `.catch()`. The unhandled rejection caused React to call `useContext` outside a component while trying to surface the error, producing "Invalid hook call."

**Changes:**

- **[listId].js — crash fix:** Replace the unhandled `throw` with graceful error handling. All non-OK responses (not just 404) now set state cleanly and return.
- **[listId].js — user-visible error state:** On fetch failure the page shows "We couldn't load your saved items right now" instead of silently rendering `<ListEmpty>` ("This list is empty") — which would look identical to a real empty list and could prompt a user to delete their saved items.
- **[listId].js — race condition fix:** Added `AbortController` + `cancelled` flag to the `fetchList` `useEffect`. SPA navigation between list pages (`/lists` → `/lists/[uuid]`) changes `listId` without a full page load, so a stale in-flight fetch could overwrite the new list's state with stale data. The cleanup return now aborts the old request and guards every state setter.
- **[listId].js — null guard:** `json.docs ?? []` prevents a silent `TypeError` if the upstream API returns a response body without a `docs` field.
- **[idListString].js — status code fix:** Non-404 upstream errors now return `502` instead of proxying the upstream status code through (the proxied 405 is what triggered this incident).

## Test plan

- [ ] Navigate to a list page with saved items — items load correctly
- [ ] Navigate to a list page then immediately navigate to another list page — second list data appears (no stale first-list items)
- [ ] With network devtools: block `/api/items/*` and navigate to a list with items — "couldn't load your saved items" message appears instead of "This list is empty"
- [ ] Navigate to a list with no saved items — `<ListEmpty>` still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fixes crash and race condition in list item fetching

Resolves Sentry DPLA-FRONTEND-1N6 ("Invalid hook call" on /lists/[listId]) caused by an unhandled rejection from an unawaited fetch when the items API returned non-OK status codes.

### Changes

**API route (pages/api/items/[idListString].js)**
- When upstream fetch response is non-OK and not 404, return HTTP 502 with a normalized body `{ "error": "Upstream service error." }` instead of proxying the upstream status code. 404 responses remain `{ "error": "Not found." }`.
- Behavior for streaming and single-item handling otherwise unchanged.
- Documentation updated (pages/api/items/ITEMS-API.md) to match the new error responses.

**List page/component (pages/lists/[listId].js)**
- Replace unhandled throw on non-OK responses with graceful error handling: add `itemsFetchError` state, clear `items`, and set `initialized` so failures do not produce unhandled rejections.
- Make item fetching abortable with `AbortController` and a `cancelled` guard; abort in-flight requests on effect cleanup to avoid stale-state race conditions during SPA navigation.
- Reset list/items/loading/error state when starting a new load.
- Use `json.docs ?? []` and check `Array.isArray(json.docs)` to avoid TypeError when `docs` is missing; treat missing/invalid docs as a fetch error.
- Rendering: show `ListView` only when `items.length > 0`. When `items.length === 0`, render a user-visible error message ("We couldn't load your saved items right now") if `itemsFetchError` is true; otherwise render `ListEmpty` for genuinely empty lists.

### Tests / QA
- Lists with saved items load correctly.
- Rapid navigation between lists no longer shows stale data.
- Blocking `/api/items/*` surfaces the user-visible error message instead of crashing or showing `ListEmpty`.
- Genuinely empty lists still render `ListEmpty`.

### Impact & Notes
- No manual pipeline trigger or ECS redeploy required.
- No environment variable or AWS Secrets Manager additions/removals/renames.
- No database migrations.
- No shared infrastructure (CodePipeline/CodeBuild/ECS task defs/IAM) changes.
- Public API surface: endpoint path and successful JSON responses unchanged; only upstream non-404 error responses are normalized to return 502 with a consistent JSON error body.
- Security: no auth/credential handling changes or new external credentials introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->