### PR TITLE
Suppress iOS WebKit SVG canvas rejection in Sentry beforeSend

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -15,14 +15,27 @@ Sentry.init({
   debug: false,
 
   beforeSend(event, hint) {
+    const ex = hint?.originalException;
+    const rawMsg = typeof ex === "string" ? ex : ex?.message;
+    const msg = typeof rawMsg === "string" ? rawMsg : "";
+
     // Stale JS chunks after a deploy cause Next.js to attempt a hard navigation
     // to the current URL, throwing this invariant. _app.js already handles it
     // with a window.location.reload(). Suppress the Sentry noise.
-    const ex = hint?.originalException;
-    const msg = (typeof ex === "string" ? ex : ex?.message) ?? "";
     if (msg.startsWith("Invariant: attempted to hard navigate to the same URL")) {
       return null;
     }
+
+    // Sentry Replay serialises <img> elements by drawing them to a 2D canvas.
+    // On iOS WebKit, drawing an SVG data-URI to canvas throws an unhandled
+    // rejection with this message. The rejection is from Sentry's own
+    // infrastructure, not from application code, and is not actionable.
+    // The prefix covers both base64 (data:image/svg+xml;base64,...) and
+    // URL-encoded (data:image/svg+xml,...) SVG data-URI forms.
+    if (msg.startsWith("Unable to load image data:image/svg+xml")) {
+      return null;
+    }
+
     return event;
   },
 });


### PR DESCRIPTION
## Summary

- Adds a `beforeSend` filter in `sentry.client.config.js` to suppress the `Unable to load image data:image/svg+xml` unhandled rejection that was flooding Sentry (DPLA-FRONTEND-1M0)
- The error originates from `@sentry-internal/replay`, which draws `<img>` elements to a 2D canvas for session replay serialization. On iOS WebKit, drawing an SVG data-URI to canvas throws an unhandled rejection — this is noise from Sentry's own infrastructure, not from application code
- The filter prefix (`data:image/svg+xml` without a trailing semicolon) covers both base64 (`data:image/svg+xml;base64,...`) and URL-encoded (`data:image/svg+xml,...`) SVG data-URI forms
- Also tightens the `msg` extraction to a two-step type check, ensuring `msg` is always a `string` before calling `.startsWith()` on it (guards against non-string `ex.message` values like numbers)

## Test plan

- [ ] No Sentry errors of type `Unable to load image data:image/svg+xml` appear after deploy
- [ ] Other unhandled rejections still reach Sentry (filter is narrow)
- [ ] Existing "hard navigate to same URL" filter still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds client-side Sentry configuration with a `beforeSend` hook to suppress noisy unhandled rejections that don't require action.

## Changes

**sentry.client.config.js** (new file, 41 lines)
- Initializes Sentry for the Next.js frontend with the Sentry DSN
- Implements a `beforeSend` filter that suppresses two categories of errors:
  1. **Next.js hard navigation invariant**: Stale JavaScript chunks after deployments cause Next.js to attempt hard navigation to the current URL, triggering an invariant rejection. The application already handles this with `window.location.reload()` in `_app.js`, so the Sentry error is noise.
  2. **iOS WebKit SVG canvas rejection**: Sentry Replay serializes `<img>` elements by drawing them to a 2D canvas. On iOS WebKit, drawing SVG data-URIs to canvas throws an unhandled rejection from Sentry's own infrastructure (not application code). The filter uses the prefix `"Unable to load image data:image/svg+xml"` to match both base64-encoded (`data:image/svg+xml;base64,...`) and URL-encoded (`data:image/svg+xml,...`) SVG data-URIs.

- Message extraction uses two-step type checking (`typeof rawMsg === "string"`) to safely normalize `hint.originalException` to a string before calling `.startsWith()`, guarding against non-string values (e.g., numeric error codes).

## Deployment Notes

No manual pipeline trigger, environment variable changes, database migrations, infrastructure configuration changes, API modifications, or security implications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/dpla-frontend/pull/1549?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->