### PR TITLE
feat(lists): Revamp lists to support import, pagination, and 1,000-item limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ There are seventeen workflows in `.github/workflows/`:
 
 ### Lists
 
-Users can save items to named lists stored locally in the browser via `localforage` (IndexedDB). Lists are capped at **50 items** (`MAX_LIST_ITEMS` in `constants/site.js`). When viewing a list, the page fetches full item metadata from `GET /api/items/{ids}` at runtime — only IDs are stored locally, not metadata. There is no server-side list storage or user account system.
+Users can save items to named lists stored locally in the browser via `localforage` (IndexedDB). Lists are capped at **1,000 items** (`MAX_LIST_ITEMS` in `constants/site.js`). When viewing a list, the page fetches full item metadata from `GET /api/items/{ids}` at runtime — only IDs are stored locally, not metadata. There is no server-side list storage or user account system.
 
 See [`pages/api/items/ITEMS-API.md`](pages/api/items/ITEMS-API.md) for the full API route specification.
 

--- a/components/ListComponents/CheckableLists/index.js
+++ b/components/ListComponents/CheckableLists/index.js
@@ -7,7 +7,7 @@ import {ListCheckbox} from "components/ListComponents";
 import {createUUID} from "lib";
 import {getLocalForageLists, setLocalForageItem} from "lib/localForage";
 
-import {MESSAGE_DELAY} from "constants/site";
+import {MAX_LIST_ITEMS, MESSAGE_DELAY} from "constants/site";
 
 import css from "../ListComponents.module.scss";
 
@@ -159,7 +159,7 @@ function CheckableLists({itemId}) {
       <ul className={css.listOfLists}>
         {state.lists.map((l) => {
           const isChecked = state.checkedLists.indexOf(l.uuid) !== -1;
-          const shouldDisable = (l.count > 50 && !isChecked) || !!state.updatingLists[l.uuid];
+          const shouldDisable = (l.count >= MAX_LIST_ITEMS && !isChecked) || !!state.updatingLists[l.uuid];
           return (
             <ListCheckbox
               key={`l_${l.uuid}`}

--- a/components/ListComponents/ListComponents.module.scss
+++ b/components/ListComponents/ListComponents.module.scss
@@ -25,7 +25,65 @@
 }
 
 .createList {
+  flex-shrink: 0;
+}
+
+.listActions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.importPageActions {
+  margin: 1.5rem 0;
+  max-width: 14rem;
+}
+
+.importLabel {
+  color: var(--linkColor);
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.importInput {
+  display: none;
+}
+
+.importNameField {
   margin-bottom: 1rem;
+}
+
+.importNameLabel {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+}
+
+.importNameInput {
+  border: 0.1rem solid var(--grayBorderColor);
+  border-radius: 0.2rem;
+  font-size: 1rem;
+  margin-bottom: 1rem;
+  padding: 0.4rem 0.6rem;
+  width: 100%;
+  max-width: 30rem;
+
+  &:focus {
+    border-color: var(--linkColor);
+    outline: none;
+  }
+}
+
+.importError {
+  color: var(--errorColor);
+  font-size: 0.85rem;
+  margin-top: 0.25rem;
+  max-width: 60ch;
 }
 
 .listDetailWrapper {
@@ -34,18 +92,43 @@
 }
 
 .listDetailName {
+  align-items: center;
   display: flex;
+  flex-wrap: wrap;
   font-size: 1.625rem;
   font-weight: 600;
+  gap: 0.75rem;
   margin-bottom: 1rem;
 }
 
+.listNameText {
+  flex: 1 1 auto;
+  min-width: 0;
+  word-break: break-word;
+}
+
+.listHeaderActions {
+  align-items: center;
+  display: flex;
+  flex-shrink: 0;
+  gap: 0.5rem;
+
+  @media (max-width: $mediumRem) {
+    flex-basis: 100%;
+  }
+}
+
 .listRenameButton {
-  margin-left: 1rem;
+  flex-shrink: 0;
+}
+
+.listDownloadButton {
+  flex-shrink: 0;
 }
 
 .listDeleteConfirm {
   display: flex;
+  flex-shrink: 0;
 }
 
 .lists {

--- a/components/ListComponents/ListComponents.module.scss
+++ b/components/ListComponents/ListComponents.module.scss
@@ -104,7 +104,7 @@
 .listNameText {
   flex: 1 1 auto;
   min-width: 0;
-  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 .listHeaderActions {

--- a/components/ListComponents/index.js
+++ b/components/ListComponents/index.js
@@ -79,7 +79,7 @@ export function ListNote() {
     <div className={`${css.note} ${utils.colXs12}`}>
       <p>
         <strong>Note:</strong> Your lists are stored locally in your browser.
-        You won't see lists created in another browser here. If you want to save a list long-term, you may wish to use the "download list" feature to export your lists as CSV files.
+        You won&apos;t see lists created in another browser here. If you want to save a list long-term, you may wish to use the &quot;download list&quot; feature to export your lists as CSV files.
       </p>
     </div>
   );

--- a/components/ListComponents/index.js
+++ b/components/ListComponents/index.js
@@ -53,7 +53,7 @@ export function ListEmpty() {
     <div className={`${css.empty}`}>
       <p>This list is empty.</p>
       <p>
-        Add up to {MAX_LIST_ITEMS} items from our <Link href="/browse-by-topic">topics</Link>{" "}
+        Add up to {addCommasToNumber(MAX_LIST_ITEMS)} items from our <Link href="/browse-by-topic">topics</Link>{" "}
         or <Link href="/search">search results</Link>:
       </p>
       <video
@@ -78,9 +78,8 @@ export function ListNote() {
   return (
     <div className={`${css.note} ${utils.colXs12}`}>
       <p>
-        <strong>Note:</strong> You won&apos;t see lists created in another
-        browser here. To view those lists, open the browser you used when
-        creating them.
+        <strong>Note:</strong> Your lists are stored locally in your browser.
+        You won't see lists created in another browser here. If you want to save a list long-term, you may wish to use the "download list" feature to export your lists as CSV files.
       </p>
     </div>
   );
@@ -98,7 +97,7 @@ export function ListsEmpty() {
             our <Link href="/browse-by-topic">topics</Link> or{" "}
           </>
         )}
-        <Link href="/search">search results</Link> (up to {MAX_LIST_ITEMS} items in each
+        <Link href="/search">search results</Link> (up to {addCommasToNumber(MAX_LIST_ITEMS)} items in each
         list):
       </p>
       <video
@@ -181,13 +180,18 @@ export function ListsContent({ initialized, lists, onCreateList, storageUnavaila
           <>
             {lists.length > 0 && <ListNote />}
             {lists.length === 0 && <ListsEmpty />}
-            <ListNameModal
-              className={css.createList}
-              type="create"
-              value=""
-              onChange={onCreateList}
-              name="Create new list"
-            />
+            <div className={`${utils.colXs12} ${css.listActions}`}>
+              <ListNameModal
+                className={css.createList}
+                type="create"
+                value=""
+                onChange={onCreateList}
+                name="Create new list"
+              />
+              <Link href="/lists/import" className={css.importLabel}>
+                Import list from CSV
+              </Link>
+            </div>
             {lists.length > 0 && <Lists lists={lists} />}
           </>
         )}

--- a/components/ListComponents/index.js
+++ b/components/ListComponents/index.js
@@ -53,7 +53,7 @@ export function ListEmpty() {
     <div className={`${css.empty}`}>
       <p>This list is empty.</p>
       <p>
-        Add up to 50 items from our <Link href="/browse-by-topic">topics</Link>{" "}
+        Add up to {MAX_LIST_ITEMS} items from our <Link href="/browse-by-topic">topics</Link>{" "}
         or <Link href="/search">search results</Link>:
       </p>
       <video
@@ -98,7 +98,7 @@ export function ListsEmpty() {
             our <Link href="/browse-by-topic">topics</Link> or{" "}
           </>
         )}
-        <Link href="/search">search results</Link> (up to 50 items in each
+        <Link href="/search">search results</Link> (up to {MAX_LIST_ITEMS} items in each
         list):
       </p>
       <video

--- a/components/shared/ConfirmModal/index.js
+++ b/components/shared/ConfirmModal/index.js
@@ -37,9 +37,10 @@ class ConfirmModal extends React.Component {
 
   render() {
     const { active } = this.state;
-    const { className, text, buttonText: buttonTextProp } = this.props;
+    const { className, text, buttonText: buttonTextProp, confirmButtonText } = this.props;
     const confirmText = text || DEFAULT_CONFIRM_TEXT;
     const buttonText = buttonTextProp || DEFAULT_BUTTON_TEXT;
+    const confirmBtnText = confirmButtonText || buttonText;
     const modal = active
       ? <AriaModal
           titleText={confirmText}
@@ -72,7 +73,7 @@ class ConfirmModal extends React.Component {
                 mustSubmit={true}
                 className={utils.modalContinueButton}
               >
-                {buttonText}
+                {confirmBtnText}
               </Button>
             </div>
           </form>

--- a/components/shared/ListView/ListView.module.scss
+++ b/components/shared/ListView/ListView.module.scss
@@ -13,30 +13,6 @@
   margin-right: 0.5rem;
 }
 
-.downloadLink {
-  display: flex;
-  margin: 0.5rem 0;
-
-  & a {
-    cursor: pointer;
-  }
-}
-
-.csvExplainer {
-  color: var(--dimmedTextColor);
-  font-size: 0.8rem;
-  font-style: italic;
-}
-
-.preformatted {
-  font-family: var(--monoFont), monospace;
-  white-space: pre-wrap;
-}
-
-.listAddToList {
-  display: flex;
-}
-
 .listSelectLabel {
   display: none;
 

--- a/components/shared/ListView/index.js
+++ b/components/shared/ListView/index.js
@@ -40,7 +40,6 @@ function ItemDescription({ description }) {
 /**
  *
  * @param items Array of items to display (not necessarily those in the list, may be search results or a browse topic).
- * @param exportable Whether or not to show the CSV download link
  * @param viewMode "list" or "grid" for search view
  * @param viewingList contains list id if viewing in /lists/[uuid]
  * @param behavior "search," "browse," or "list" for different behavior depending on where this is used.
@@ -49,7 +48,6 @@ function ItemDescription({ description }) {
  */
 export default function ListView({
   items,
-  exportable,
   viewMode,
   viewingList,
   behavior,
@@ -178,64 +176,6 @@ export default function ListView({
     [],
   );
 
-  const downloadCSV = () => {
-    const rows = items
-      .filter((item) => {
-        const realId = item.itemDplaId || item.id;
-        return state.currentList.selectedHash[realId] !== undefined;
-      })
-      .map((item) => {
-        const realId = item.itemDplaId || item.id;
-        const thumbnailUrl =
-          item.thumbnailUrl && !item.thumbnailUrl.includes("placeholderImages")
-            ? item.thumbnailUrl
-            : "";
-        const title = item.title
-          ? `"${truncateString(item.title, 150).replace(/"/g, "”")}"`
-          : UNTITLED_TEXT;
-        const date = item?.date?.displayDate
-          ? `"${item.date.displayDate.replace(/"/g, "”")}"`
-          : "";
-        const creator = item.creator
-          ? `"${joinIfArray(item.creator, ", ").replace(/"/g, "”")}"`
-          : "";
-        const description = item.description
-          ? `"${joinTruncate(item.description).replace(/"/g, "”")}"`
-          : "";
-        const provider = item.dataProvider
-          ? `"${joinIfArray(item.dataProvider).replace(/"/g, "”")}"`
-          : "";
-        const url = item.sourceUrl;
-        return `${realId},${title},${date},${creator},${description},${provider},${thumbnailUrl},${url}`;
-      });
-    const csvData = `id,Title,Date,Creator,Description,Provider,Thumbnail,URL\r\n${rows.join("\r\n",)}`;
-    const filename = `${state?.currentList?.name || "list"}.csv`;
-    const blob = new Blob([csvData], {type: "text/csv;charset=utf-8;"});
-    if (navigator?.msSaveBlob) {
-      // IE 10+
-      navigator.msSaveBlob(blob, filename);
-    } else {
-      const link = document.createElement("a");
-      if (link.download !== undefined) {
-        // feature detection
-        // Browsers that support HTML5 download attribute
-        const url = URL.createObjectURL(blob);
-        link.setAttribute("href", url);
-        link.setAttribute("download", filename);
-        link.style.visibility = "hidden";
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-      } else {
-        const reader = new FileReader();
-        reader.onload = function () {
-          window.location.href = reader.result;
-        };
-        reader.readAsDataURL(blob);
-      }
-    }
-  };
-
   const listSelectChange = useCallback((e) => {
     const listUUID = e.target.value;
     if (listUUID === "") {
@@ -360,7 +300,7 @@ export default function ListView({
                   const listSize = Object.keys(list.selectedHash).length;
                   return (
                     <option key={list.uuid} value={list.uuid}>
-                      {list.name} ({listSize})
+                      {list.name} ({listSize}
                       {listSize !== 1 ? " items" : " item"})
                     </option>
                   );
@@ -371,11 +311,6 @@ export default function ListView({
         </div>
       )}
       <Alert showMessage={state.showMessage} />
-      {exportable && items.length > 0 && (
-        <div className={css.downloadLink}>
-          <a onClick={downloadCSV}>Download list</a>
-        </div>
-      )}
       <ul className={`${css.listView} ${viewMode === "grid" ? css.grid : ""}`}>
         {items.map((item) => {
           const realId = item.itemDplaId || item.id;

--- a/components/shared/ListView/index.js
+++ b/components/shared/ListView/index.js
@@ -318,7 +318,7 @@ export default function ListView({
       });
   };
 
-  const listCount = state.lists.length;
+  const currentItemCount = Object.keys(state.currentList?.selectedHash || {}).length;
   return (
     <div>
       {state.listsInitialized && !viewingList && (
@@ -382,7 +382,7 @@ export default function ListView({
           const checked =
             state?.currentList?.selectedHash?.[realId] !== undefined;
           const shouldDisable =
-            (!checked && listCount > MAX_LIST_ITEMS) ||
+            (!checked && currentItemCount >= MAX_LIST_ITEMS) ||
             realId === SOURCE_RESOURCE_ITEM_ID;
           const disabledMessage = `Maximum ${MAX_LIST_ITEMS} items per list.`;
           let itemLinkText = "View Full Item";
@@ -457,7 +457,7 @@ export default function ListView({
                   title={shouldDisable ? disabledMessage : ""}
                 >
                   <input
-                    className={`${css.checkboxInput} ${!checked && listCount >= MAX_LIST_ITEMS ? css.disabled : ""}`}
+                    className={`${css.checkboxInput} ${!checked && currentItemCount >= MAX_LIST_ITEMS ? css.disabled : ""}`}
                     type="checkbox"
                     title={shouldDisable ? disabledMessage : ""}
                     data-id={realId}
@@ -469,7 +469,7 @@ export default function ListView({
                     key={`checkbox-${realId}`}
                     id={`checkbox-${realId}`}
                   />
-                  {!checked && listCount >= MAX_LIST_ITEMS
+                  {!checked && currentItemCount >= MAX_LIST_ITEMS
                     ? "Can’t add more"
                     : "Add to list"}
                 </label>

--- a/constants/site.js
+++ b/constants/site.js
@@ -21,7 +21,8 @@ export const UNTITLED_TEXT = "Untitled";
 
 export const MESSAGE_DELAY = 5000;
 
-export const MAX_LIST_ITEMS = 50;
+export const MAX_LIST_ITEMS = 1000;
+export const LIST_PAGE_SIZE = 50;
 
 export const resourceTypes = {
   TEXT: "text",

--- a/lib/localForage/index.js
+++ b/lib/localForage/index.js
@@ -27,9 +27,7 @@ const removeLocalForageItem = async (key) => {
 };
 
 const setLocalForageItem = async (key, value) => {
-  return await localforage.setItem(key, value).catch(function (err) {
-    console.error("localforage.setLocalForageItem error", err);
-  });
+  return await localforage.setItem(key, value);
 };
 
 const getLocalForageItem = async (key) => {

--- a/pages/api/items/ITEMS-API.md
+++ b/pages/api/items/ITEMS-API.md
@@ -122,7 +122,7 @@ It then maps the returned `docs` array into display-ready items, extracting:
 
 | Constraint | Value | Defined In |
 |-----------|-------|-----------|
-| Max items per list (UI-enforced) | 50 | `MAX_LIST_ITEMS` in `constants/site.js` |
+| Max items per list (UI-enforced) | 1000 | `MAX_LIST_ITEMS` in `constants/site.js` |
 | ID format | 32-char hex | `DPLA_ITEM_ID_REGEX` in `constants/items.js` |
 | HTTP methods | GET only | — |
 

--- a/pages/lists/LISTS.md
+++ b/pages/lists/LISTS.md
@@ -93,7 +93,7 @@ Items can be added from three places:
 ### From Search Results (`/search`) or Browse by Topic
 - The **`ListView`** component (with `behavior="search"` or `behavior="browse"`) shows an "Add to:" dropdown and checkboxes next to items
 - Selecting a list and checking items calls `addCell(itemId)`, updating the list in localForage
-- A maximum of **50 items** per list is enforced (`MAX_LIST_ITEMS` in `constants/site.js`)
+- A maximum of **1000 items** per list is enforced (`MAX_LIST_ITEMS` in `constants/site.js`)
 
 ### From a List Page (removing)
 - With `behavior="list"`, ListView shows checkboxes to remove items

--- a/pages/lists/[listId].js
+++ b/pages/lists/[listId].js
@@ -13,9 +13,10 @@ import BreadcrumbsModule from "shared/BreadcrumbsModule";
 import ListView from "shared/ListView";
 import ListNameModal from "components/ListComponents/ListNameModal";
 import ConfirmModal from "shared/ConfirmModal";
+import Pagination from "shared/Pagination";
 import { ListLoading, ListEmpty, ListsUnavailable } from "components/ListComponents";
 
-import { addLinkInfoToResults, getDataProviderName, getItemThumbnail } from "lib";
+import { addCommasToNumber, addLinkInfoToResults, getDataProviderName, getItemThumbnail } from "lib";
 
 import { setLocalForageItem, removeLocalForageItem, STORAGE_UNAVAILABLE_ERROR } from "lib/localForage";
 
@@ -23,16 +24,18 @@ import utils from "stylesheets/utils.module.scss";
 import css from "components/ListComponents/ListComponents.module.scss";
 
 import { LISTS_TITLE } from "constants/lists";
-import { UNTITLED_TEXT } from "constants/site";
+import { UNTITLED_TEXT, LIST_PAGE_SIZE } from "constants/site";
 
 const List = () => {
   const router = useRouter();
   const listId = Array.isArray(router.query?.listId)
     ? router.query.listId[0]
     : router.query?.listId;
+  const page = Math.max(1, parseInt(router.query?.page || "1", 10) || 1);
 
   const [list, setList] = useState(null);
   const [items, setItems] = useState([]);
+  const [totalItemCount, setTotalItemCount] = useState(0);
   const [initialized, setInitialized] = useState(false);
   const [storageUnavailable, setStorageUnavailable] = useState(false);
   const isRenamingRef = useRef(false);
@@ -61,18 +64,18 @@ const List = () => {
         return;
       }
 
-      const itemIds = list?.selectedHash ? Object.keys(list?.selectedHash) : [];
+      const allItemIds = list?.selectedHash ? Object.keys(list.selectedHash) : [];
+      setTotalItemCount(allItemIds.length);
 
-      if (itemIds.length === 0) {
+      if (allItemIds.length === 0) {
         setInitialized(true);
         setList(list);
         setItems([]);
         return;
       }
 
-      const ids = itemIds.join(",");
-
-      const url = `/api/items/${ids}`;
+      const pageIds = allItemIds.slice((page - 1) * LIST_PAGE_SIZE, page * LIST_PAGE_SIZE);
+      const url = `/api/items/${pageIds.join(",")}`;
       const res = await fetch(url);
       if (!res.ok) {
         if (res.status === 404) {
@@ -114,7 +117,7 @@ const List = () => {
     };
 
     fetchList();
-  }, [listId]);
+  }, [listId, page]);
 
   const onNameChange = useCallback(
     async (value) => {
@@ -158,6 +161,8 @@ const List = () => {
     return <Error statusCode={404} />;
   }
 
+  const pageCount = Math.ceil(totalItemCount / LIST_PAGE_SIZE);
+
   return (
     <MainLayout pageTitle={list ? list.name : LISTS_TITLE}>
       <BreadcrumbsModule
@@ -189,9 +194,11 @@ const List = () => {
                 />
               </h1>
             )}
-            {list.createdAt && (
+            {(list.createdAt || initialized) && (
               <p className={css.listDate}>
-                Created {dayjs(list.createdAt, "x").fromNow()}
+                {list.createdAt && <>Created {dayjs(list.createdAt, "x").fromNow()}</>}
+                {list.createdAt && initialized && <> · </>}
+                {initialized && <>{addCommasToNumber(totalItemCount)} {totalItemCount === 1 ? "item" : "items"}</>}
               </p>
             )}
             <p>
@@ -199,13 +206,18 @@ const List = () => {
               someone else or in another browser.
             </p>
             {items && listId && (
-              <ListView
-                name={list.name}
-                exportable={true}
-                items={addLinkInfoToResults(items)}
-                behavior={"list"}
-                viewingList={listId}
-              />
+              <>
+                <ListView
+                  name={list.name}
+                  exportable={true}
+                  items={addLinkInfoToResults(items)}
+                  behavior={"list"}
+                  viewingList={listId}
+                />
+                {pageCount > 1 && (
+                  <Pagination currentPage={page} pageCount={pageCount} />
+                )}
+              </>
             )}
             {items.length === 0 && <ListEmpty />}
             {list.name && (

--- a/pages/lists/[listId].js
+++ b/pages/lists/[listId].js
@@ -177,27 +177,23 @@ const List = () => {
           });
       }
 
+      const Q = '\x22';
+      const csvField = (value) => Q + value.replace(/\x22/g, Q + Q) + Q;
       const rows = allItems.map((item) => {
         const thumbnailUrl =
-          item.thumbnailUrl && !item.thumbnailUrl.includes("placeholderImages")
+          item.thumbnailUrl && !item.thumbnailUrl.includes('placeholderImages')
             ? item.thumbnailUrl
-            : "";
-        const title = item.title
-          ? `"${truncateString(joinIfArray(item.title), 150).replace(/"/g, "“")}"`
-          : UNTITLED_TEXT;
-        const date = item?.date?.displayDate
-          ? `"${item.date.displayDate.replace(/"/g, "“")}"`
-          : "";
-        const creator = item.creator
-          ? `"${joinIfArray(item.creator, ", ").replace(/"/g, "“")}"`
-          : "";
+            : '';
+        const title = csvField(
+          item.title ? truncateString(joinIfArray(item.title), 150) : UNTITLED_TEXT
+        );
+        const date = item?.date?.displayDate ? csvField(item.date.displayDate) : csvField('');
+        const creator = item.creator ? csvField(joinIfArray(item.creator, ', ')) : csvField('');
         const description = item.description
-          ? `"${truncateString(joinIfArray(item.description)).replace(/"/g, "“")}"`
-          : "";
-        const provider = item.dataProvider
-          ? `"${joinIfArray(item.dataProvider).replace(/"/g, "“")}"`
-          : "";
-        return `${item.id},${title},${date},${creator},${description},${provider},${thumbnailUrl},${item.sourceUrl}`;
+          ? csvField(truncateString(joinIfArray(item.description)))
+          : csvField('');
+        const provider = item.dataProvider ? csvField(joinIfArray(item.dataProvider)) : csvField('');
+        return [item.id, title, date, creator, description, provider, csvField(thumbnailUrl), csvField(item.sourceUrl || '')].join(',');
       });
 
       const csvData = `id,Title,Date,Creator,Description,Provider,Thumbnail,URL\r\n${rows.join("\r\n")}`;

--- a/pages/lists/[listId].js
+++ b/pages/lists/[listId].js
@@ -10,13 +10,14 @@ dayjs.extend(relativeTime);
 import Error from "pages/_error";
 import MainLayout from "components/MainLayout";
 import BreadcrumbsModule from "shared/BreadcrumbsModule";
+import Button from "shared/Button";
 import ListView from "shared/ListView";
 import ListNameModal from "components/ListComponents/ListNameModal";
 import ConfirmModal from "shared/ConfirmModal";
 import Pagination from "shared/Pagination";
 import { ListLoading, ListEmpty, ListsUnavailable } from "components/ListComponents";
 
-import { addCommasToNumber, addLinkInfoToResults, getDataProviderName, getItemThumbnail } from "lib";
+import { addCommasToNumber, addLinkInfoToResults, getDataProviderName, getItemThumbnail, joinIfArray, truncateString } from "lib";
 
 import { setLocalForageItem, removeLocalForageItem, STORAGE_UNAVAILABLE_ERROR } from "lib/localForage";
 
@@ -38,6 +39,7 @@ const List = () => {
   const [totalItemCount, setTotalItemCount] = useState(0);
   const [initialized, setInitialized] = useState(false);
   const [isPageLoading, setIsPageLoading] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
   const [storageUnavailable, setStorageUnavailable] = useState(false);
   const isRenamingRef = useRef(false);
 
@@ -143,6 +145,71 @@ const List = () => {
     [list, listId],
   );
 
+  const handleExport = useCallback(async () => {
+    if (isExporting || !list) return;
+    setIsExporting(true);
+    try {
+      const allItemIds = Object.keys(list.selectedHash || {});
+      if (allItemIds.length === 0) return;
+
+      const allItems = [];
+      for (let i = 0; i < allItemIds.length; i += LIST_PAGE_SIZE) {
+        const batchIds = allItemIds.slice(i, i + LIST_PAGE_SIZE);
+        const res = await fetch(`/api/items/${batchIds.join(",")}`);
+        if (!res.ok) continue;
+        const json = await res.json();
+        json.docs
+          .filter((result) => result.error === undefined)
+          .forEach((result) => {
+            allItems.push({
+              ...result.sourceResource,
+              id: result.id ?? result.sourceResource["@id"],
+              sourceUrl: result.isShownAt,
+              dataProvider: getDataProviderName(result.dataProvider),
+              thumbnailUrl: getItemThumbnail(result),
+            });
+          });
+      }
+
+      const rows = allItems.map((item) => {
+        const thumbnailUrl =
+          item.thumbnailUrl && !item.thumbnailUrl.includes("placeholderImages")
+            ? item.thumbnailUrl
+            : "";
+        const title = item.title
+          ? `"${truncateString(joinIfArray(item.title), 150).replace(/"/g, "“")}"`
+          : UNTITLED_TEXT;
+        const date = item?.date?.displayDate
+          ? `"${item.date.displayDate.replace(/"/g, "“")}"`
+          : "";
+        const creator = item.creator
+          ? `"${joinIfArray(item.creator, ", ").replace(/"/g, "“")}"`
+          : "";
+        const description = item.description
+          ? `"${truncateString(joinIfArray(item.description)).replace(/"/g, "“")}"`
+          : "";
+        const provider = item.dataProvider
+          ? `"${joinIfArray(item.dataProvider).replace(/"/g, "“")}"`
+          : "";
+        return `${item.id},${title},${date},${creator},${description},${provider},${thumbnailUrl},${item.sourceUrl}`;
+      });
+
+      const csvData = `id,Title,Date,Creator,Description,Provider,Thumbnail,URL\r\n${rows.join("\r\n")}`;
+      const blob = new Blob([csvData], { type: "text/csv;charset=utf-8;" });
+      const link = document.createElement("a");
+      const url = URL.createObjectURL(blob);
+      link.setAttribute("href", url);
+      link.setAttribute("download", `DPLA User List - ${list.name || "list"}.csv`);
+      link.style.visibility = "hidden";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } finally {
+      setIsExporting(false);
+    }
+  }, [isExporting, list]);
+
   const handleConfirmDelete = useCallback(async () => {
     await removeLocalForageItem(listId);
     try {
@@ -174,7 +241,7 @@ const List = () => {
       <BreadcrumbsModule
         breadcrumbs={[
           {
-            title: "My Lists",
+            title: LISTS_TITLE,
             url: "/lists",
           },
           { title: list ? list.name : UNTITLED_TEXT },
@@ -190,14 +257,31 @@ const List = () => {
           <div>
             {list.name && (
               <h1 className={css.listDetailName}>
-                {list.name}
-                <ListNameModal
-                  name="Rename"
-                  type="rename"
-                  className={css.listRenameButton}
-                  value={list.name}
-                  onChange={onNameChange}
-                />
+                <span className={css.listNameText}>{list.name}</span>
+                <span className={css.listHeaderActions}>
+                  <ListNameModal
+                    name="Rename"
+                    type="rename"
+                    className={css.listRenameButton}
+                    value={list.name}
+                    onChange={onNameChange}
+                  />
+                  <Button
+                    type="secondary"
+                    className={css.listDownloadButton}
+                    onClick={handleExport}
+                    disabled={isExporting}
+                  >
+                    {isExporting ? "Preparing download…" : "Download list"}
+                  </Button>
+                  <ConfirmModal
+                    className={css.listDeleteConfirm}
+                    buttonText="Delete list"
+                    text="Delete list?"
+                    confirmButtonText="Delete"
+                    onConfirm={handleConfirmDelete}
+                  />
+                </span>
               </h1>
             )}
             {(list.createdAt || initialized) && (
@@ -211,11 +295,9 @@ const List = () => {
               <strong>Note:</strong> The link to this list won&apos;t work for
               someone else or in another browser.
             </p>
-            {items && listId && (
+            {items.length > 0 && listId && (
               <div style={isPageLoading ? { opacity: 0.4, pointerEvents: "none" } : undefined}>
                 <ListView
-                  name={list.name}
-                  exportable={true}
                   items={addLinkInfoToResults(items)}
                   behavior={"list"}
                   viewingList={listId}
@@ -226,15 +308,6 @@ const List = () => {
               </div>
             )}
             {items.length === 0 && <ListEmpty />}
-            {list.name && (
-              <ConfirmModal
-                className={css.listDeleteConfirm}
-                buttonText="Delete list"
-                confirmText="Delete list?"
-                confirmButtonText="Delete"
-                onConfirm={handleConfirmDelete}
-              />
-            )}
           </div>
         )}
       </div>

--- a/pages/lists/[listId].js
+++ b/pages/lists/[listId].js
@@ -37,6 +37,7 @@ const List = () => {
   const [items, setItems] = useState([]);
   const [totalItemCount, setTotalItemCount] = useState(0);
   const [initialized, setInitialized] = useState(false);
+  const [isPageLoading, setIsPageLoading] = useState(false);
   const [storageUnavailable, setStorageUnavailable] = useState(false);
   const isRenamingRef = useRef(false);
 
@@ -46,73 +47,78 @@ const List = () => {
         return;
       }
 
-      let list;
+      setIsPageLoading(true);
       try {
-        list = await localforage.getItem(listId);
-      } catch (err) {
-        console.error("fetchList error", err);
-        if (err.message === STORAGE_UNAVAILABLE_ERROR) {
-          setStorageUnavailable(true);
+        let list;
+        try {
+          list = await localforage.getItem(listId);
+        } catch (err) {
+          console.error("fetchList error", err);
+          if (err.message === STORAGE_UNAVAILABLE_ERROR) {
+            setStorageUnavailable(true);
+          }
+          setInitialized(true);
+          return;
         }
-        setInitialized(true);
-        return;
-      }
 
-      if (!list) {
-        setInitialized(true);
-        setItems([]);
-        return;
-      }
+        if (!list) {
+          setInitialized(true);
+          setItems([]);
+          return;
+        }
 
-      const allItemIds = list?.selectedHash ? Object.keys(list.selectedHash) : [];
-      setTotalItemCount(allItemIds.length);
+        const allItemIds = list?.selectedHash ? Object.keys(list.selectedHash) : [];
+        setTotalItemCount(allItemIds.length);
 
-      if (allItemIds.length === 0) {
-        setInitialized(true);
-        setList(list);
-        setItems([]);
-        return;
-      }
-
-      const pageIds = allItemIds.slice((page - 1) * LIST_PAGE_SIZE, page * LIST_PAGE_SIZE);
-      const url = `/api/items/${pageIds.join(",")}`;
-      const res = await fetch(url);
-      if (!res.ok) {
-        if (res.status === 404) {
+        if (allItemIds.length === 0) {
           setInitialized(true);
           setList(list);
           setItems([]);
           return;
         }
-        throw new Error("Couldn't load items.");
-      }
 
-      try {
-        const json = await res.json();
-        const items = json.docs
-          .filter((result) => result.error === undefined)
-          .map((result) => {
-            const thumbnailUrl = getItemThumbnail(result);
-            const dataProvider = getDataProviderName(result.dataProvider);
+        const pageIds = allItemIds.slice((page - 1) * LIST_PAGE_SIZE, page * LIST_PAGE_SIZE);
+        const url = `/api/items/${pageIds.join(",")}`;
+        const res = await fetch(url);
+        if (!res.ok) {
+          if (res.status === 404) {
+            setInitialized(true);
+            setList(list);
+            setItems([]);
+            return;
+          }
+          throw new Error("Couldn't load items.");
+        }
 
-            return {
-              ...result.sourceResource,
-              thumbnailUrl,
-              thumbnailSourceUrl: result.object,
-              id: result.id ? result.id : result.sourceResource["@id"],
-              sourceUrl: result.isShownAt,
-              provider: result.provider && result.provider.name,
-              dataProvider: dataProvider,
-              useDefaultImage: !result.object,
-            };
-          });
-        setInitialized(true);
-        setList(list);
-        setItems(items);
-      } catch {
-        setInitialized(true);
-        setList(list);
-        setItems([]);
+        try {
+          const json = await res.json();
+          const items = json.docs
+            .filter((result) => result.error === undefined)
+            .map((result) => {
+              const thumbnailUrl = getItemThumbnail(result);
+              const dataProvider = getDataProviderName(result.dataProvider);
+
+              return {
+                ...result.sourceResource,
+                thumbnailUrl,
+                thumbnailSourceUrl: result.object,
+                id: result.id ? result.id : result.sourceResource["@id"],
+                sourceUrl: result.isShownAt,
+                provider: result.provider && result.provider.name,
+                dataProvider: dataProvider,
+                useDefaultImage: !result.object,
+              };
+            });
+          setInitialized(true);
+          setList(list);
+          setItems(items);
+        } catch {
+          setInitialized(true);
+          setList(list);
+          setItems([]);
+        }
+      } finally {
+        setIsPageLoading(false);
       }
     };
 
@@ -206,7 +212,7 @@ const List = () => {
               someone else or in another browser.
             </p>
             {items && listId && (
-              <>
+              <div style={isPageLoading ? { opacity: 0.4, pointerEvents: "none" } : undefined}>
                 <ListView
                   name={list.name}
                   exportable={true}
@@ -217,7 +223,7 @@ const List = () => {
                 {pageCount > 1 && (
                   <Pagination currentPage={page} pageCount={pageCount} />
                 )}
-              </>
+              </div>
             )}
             {items.length === 0 && <ListEmpty />}
             {list.name && (

--- a/pages/lists/[listId].js
+++ b/pages/lists/[listId].js
@@ -40,6 +40,7 @@ const List = () => {
   const [initialized, setInitialized] = useState(false);
   const [isPageLoading, setIsPageLoading] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
+  const [fetchError, setFetchError] = useState(false);
   const [storageUnavailable, setStorageUnavailable] = useState(false);
   const isRenamingRef = useRef(false);
 
@@ -50,6 +51,7 @@ const List = () => {
       }
 
       setIsPageLoading(true);
+      setFetchError(false);
       try {
         let list;
         try {
@@ -89,7 +91,11 @@ const List = () => {
             setItems([]);
             return;
           }
-          throw new Error("Couldn't load items.");
+          setInitialized(true);
+          setList(list);
+          setItems([]);
+          setFetchError(true);
+          return;
         }
 
         try {
@@ -307,7 +313,10 @@ const List = () => {
                 )}
               </div>
             )}
-            {items.length === 0 && <ListEmpty />}
+            {fetchError && (
+              <p>There was a problem loading this list. Please try refreshing the page.</p>
+            )}
+            {!fetchError && items.length === 0 && <ListEmpty />}
           </div>
         )}
       </div>

--- a/pages/lists/[listId].js
+++ b/pages/lists/[listId].js
@@ -40,6 +40,7 @@ const List = () => {
   const [initialized, setInitialized] = useState(false);
   const [isPageLoading, setIsPageLoading] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
+  const [exportError, setExportError] = useState(false);
   const [fetchError, setFetchError] = useState(false);
   const [storageUnavailable, setStorageUnavailable] = useState(false);
   const isRenamingRef = useRef(false);
@@ -202,6 +203,7 @@ const List = () => {
   const handleExport = useCallback(async () => {
     if (isExporting || !list) return;
     setIsExporting(true);
+    setExportError(false);
     try {
       const allItemIds = Object.keys(list.selectedHash || {});
       if (allItemIds.length === 0) return;
@@ -209,8 +211,15 @@ const List = () => {
       const allItems = [];
       for (let i = 0; i < allItemIds.length; i += LIST_PAGE_SIZE) {
         const batchIds = allItemIds.slice(i, i + LIST_PAGE_SIZE);
-        const res = await fetch(`/api/items/${batchIds.join(",")}`);
-        if (!res.ok) continue;
+        let res;
+        try {
+          res = await fetch(`/api/items/${batchIds.join(",")}`);
+        } catch {
+          throw new Error("Network error while fetching items for export");
+        }
+        if (!res.ok) {
+          throw new Error(`Failed to fetch items (HTTP ${res.status})`);
+        }
         const json = await res.json();
         json.docs
           .filter((result) => result.error === undefined)
@@ -255,6 +264,8 @@ const List = () => {
       link.click();
       document.body.removeChild(link);
       URL.revokeObjectURL(url);
+    } catch {
+      setExportError(true);
     } finally {
       setIsExporting(false);
     }
@@ -324,6 +335,11 @@ const List = () => {
                   >
                     {isExporting ? "Preparing download…" : "Download list"}
                   </Button>
+                  {exportError && (
+                    <p role="alert" className={css.listItemsError}>
+                      We couldn&apos;t export your list. Please try again.
+                    </p>
+                  )}
                   <ConfirmModal
                     className={css.listDeleteConfirm}
                     buttonText="Delete list"

--- a/pages/lists/[listId].js
+++ b/pages/lists/[listId].js
@@ -94,6 +94,15 @@ const List = () => {
         }
 
         const pageIds = allItemIds.slice((page - 1) * LIST_PAGE_SIZE, page * LIST_PAGE_SIZE);
+
+        // Check if page is out of range
+        if (pageIds.length === 0) {
+          // Redirect to the last valid page
+          const lastPage = Math.ceil(allItemIds.length / LIST_PAGE_SIZE);
+          Router.replace({ pathname: `/lists/${listId}`, query: { page: lastPage } });
+          return;
+        }
+
         const ids = pageIds.join(",");
 
         let res;

--- a/pages/lists/import.js
+++ b/pages/lists/import.js
@@ -59,7 +59,7 @@ export default function ImportList() {
       const lines = text.split(/\r?\n/);
       const seen = new Set();
       const ids = [];
-      for (let i = 1; i < lines.length; i++) {
+      for (let i = 0; i < lines.length; i++) {
         const id = lines[i].split(",")[0].trim().toLowerCase();
         if (DPLA_ITEM_ID_REGEX.test(id) && !seen.has(id)) {
           seen.add(id);

--- a/pages/lists/import.js
+++ b/pages/lists/import.js
@@ -79,13 +79,18 @@ export default function ImportList() {
       const uuid = createUUID();
       const createdAt = Date.now();
       const selectedHash = Object.fromEntries(ids.map((id) => [id, id]));
-      await setLocalForageItem(uuid, {
-        uuid,
-        name,
-        selectedHash,
-        count: ids.length,
-        createdAt,
-      });
+      try {
+        await setLocalForageItem(uuid, {
+          uuid,
+          name,
+          selectedHash,
+          count: ids.length,
+          createdAt,
+        });
+      } catch {
+        setError("Could not save the list. Your browser storage may be full or unavailable.");
+        return;
+      }
       await Router.push({ pathname: `/lists/${uuid}` });
     } finally {
       setIsImporting(false);

--- a/pages/lists/import.js
+++ b/pages/lists/import.js
@@ -1,0 +1,158 @@
+import React, { useCallback, useRef, useState } from "react";
+import Router from "next/router";
+
+import MainLayout from "components/MainLayout";
+import BreadcrumbsModule from "shared/BreadcrumbsModule";
+import Button from "shared/Button";
+
+import { createUUID } from "lib";
+import { setLocalForageItem } from "lib/localForage";
+
+import { LISTS_TITLE } from "constants/lists";
+import { DPLA_ITEM_ID_REGEX } from "constants/items";
+import { MAX_LIST_ITEMS } from "constants/site";
+
+import utils from "stylesheets/utils.module.scss";
+import css from "components/ListComponents/ListComponents.module.scss";
+
+const PAGE_TITLE = "Import a list";
+const NAME_CHAR_LIMIT = 64;
+
+export default function ImportList() {
+  const fileInputRef = useRef(null);
+  const [selectedFile, setSelectedFile] = useState(null);
+  const [listName, setListName] = useState("");
+  const [error, setError] = useState("");
+  const [isImporting, setIsImporting] = useState(false);
+
+  const handleFileChange = useCallback((e) => {
+    const file = e.target.files?.[0];
+    if (fileInputRef.current) fileInputRef.current.value = "";
+    if (!file) return;
+    setError("");
+    setSelectedFile(file);
+    setListName(
+      file.name.replace(/\.csv$/i, "").replace(/^DPLA User List - /i, "")
+    );
+  }, []);
+
+  const handleImport = useCallback(async () => {
+    if (isImporting || !selectedFile) return;
+    setError("");
+
+    const MAX_FILE_BYTES = 5 * 1024 * 1024; // 5 MB
+    if (selectedFile.size > MAX_FILE_BYTES) {
+      setError("File is too large. Please make sure you are importing a valid DPLA list CSV.");
+      return;
+    }
+
+    setIsImporting(true);
+    try {
+      let text;
+      try {
+        text = await selectedFile.text();
+      } catch {
+        setError("Could not read the file. Please try again.");
+        return;
+      }
+
+      const lines = text.split(/\r?\n/);
+      const seen = new Set();
+      const ids = [];
+      for (let i = 1; i < lines.length; i++) {
+        const id = lines[i].split(",")[0].trim().toLowerCase();
+        if (DPLA_ITEM_ID_REGEX.test(id) && !seen.has(id)) {
+          seen.add(id);
+          ids.push(id);
+          if (ids.length >= MAX_LIST_ITEMS) break;
+        }
+      }
+
+      if (ids.length === 0) {
+        setError(
+          "No valid DPLA item IDs were found in this file. Make sure you are importing a CSV that was previously downloaded from a DPLA list."
+        );
+        return;
+      }
+
+      const name = listName.trim() || "Imported list";
+      const uuid = createUUID();
+      const createdAt = Date.now();
+      const selectedHash = Object.fromEntries(ids.map((id) => [id, id]));
+      await setLocalForageItem(uuid, {
+        uuid,
+        name,
+        selectedHash,
+        count: ids.length,
+        createdAt,
+      });
+      await Router.push({ pathname: `/lists/${uuid}` });
+    } finally {
+      setIsImporting(false);
+    }
+  }, [isImporting, selectedFile, listName]);
+
+  return (
+    <MainLayout pageTitle={PAGE_TITLE}>
+      <BreadcrumbsModule
+        breadcrumbs={[{ title: LISTS_TITLE, url: "/lists" }, { title: PAGE_TITLE }]}
+      />
+      <div id="main" role="main" className={`${utils.container} ${css.listDetailWrapper}`}>
+        <h1 className={css.contentTitle}>{PAGE_TITLE}</h1>
+        <p>
+          Import a CSV file to restore or share a list. The imported list will
+          be saved in this browser alongside your other lists.
+        </p>
+        <p>You can import previously exported DPLA lists, or provide your own CSV where the first column contains DPLA item IDs (the header row, if present, is skipped automatically).</p>
+        <div className={css.importPageActions}>
+          <Button
+            type={selectedFile ? "secondary" : "primary"}
+            onClick={() => fileInputRef.current?.click()}
+            disabled={isImporting}
+            title={selectedFile?.name}
+          >
+            {selectedFile
+              ? selectedFile.name.length > 30
+                ? selectedFile.name.slice(0, 28) + "…"
+                : selectedFile.name
+              : "Choose CSV file"}
+          </Button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".csv"
+            className={css.importInput}
+            onChange={handleFileChange}
+          />
+        </div>
+        {selectedFile && (
+          <div className={css.importNameField}>
+            <label htmlFor="import-list-name" className={css.importNameLabel}>
+              List name
+            </label>
+            <input
+              id="import-list-name"
+              type="text"
+              value={listName}
+              onChange={(e) => setListName(e.target.value)}
+              maxLength={NAME_CHAR_LIMIT}
+              placeholder="Imported list"
+              className={css.importNameInput}
+              disabled={isImporting}
+            />
+            <div className={css.importPageActions}>
+              <Button
+                type="primary"
+                onClick={handleImport}
+                disabled={isImporting}
+              >
+                {isImporting ? "Importing…" : "Import list"}
+              </Button>
+            </div>
+          </div>
+        )}
+        {error && <p className={css.importError}>{error}</p>}
+      </div>
+    </MainLayout>
+  );
+}


### PR DESCRIPTION
DPLA's website allows users to create lists, which are stored locally in the user's browser. Users can also download their lists as CSVs. This PR introduces a new import feature, as well as some improvements and fixes such as pagination.

## Import feature
With this PR, users will be able to import lists they have exported from DPLA or created independently. The import just needs to be a CSV file with DPLA item IDs in the first column. During import, users can name the incoming list, and is treated like any other user-created list after import.

This is especially useful because lists are currently stored in the user's browser storage, which can be lost if they clear browser data, switch computers, or use a different browser. Importing gives users a way to restore list backups and potentially share lists with others.

Because lists are stored client-side, there are minimal security concerns with the import (i.e. we don't process the CSV serverside).

### Screenshots
"My Lists" page, showing an updated description and a new link to go to the import page:
<img width="800" src="https://github.com/user-attachments/assets/90729708-4b26-47a8-9b7d-380fa66765bf" />

The import page:
<img width="800" src="https://github.com/user-attachments/assets/c473de74-b2e4-4d4b-b4bc-1f9771dc0dfe" />

The import page after selecting a CSV file, with the option to change the incoming list name:
<img width="800" src="https://github.com/user-attachments/assets/43fbecfb-6d36-4ae9-bd7e-01fe2754eeeb" />

## Interface updates
Some changes were made to the lists UI, particularly on an individual list page. The delete button is now at the top of the page instead of the bottom, and the "Download list" link has been turned into a button as well for visibility and consistency. The header is now also a bit more responsive for mobile support.
<img width="800" src="https://github.com/user-attachments/assets/67733070-0d96-48dd-ba8c-960726ff71a9" />

## Pagination
As noted in https://github.com/dpla/dpla-frontend/issues/1536, lists have no limit to the number of items (due to a bug) and large lists would cause errors when trying to view. This PR introduces pagination to lists (50 shown per page), and sets an enforced limit of 1,000 items (with pagination, the limit is rather arbitrary and can be even higher if we want it to be). The list limit is defined in constant `MAX_LIST_ITEMS`, and the list items per page is set in constant `LIST_PAGE_SIZE`.

The screenshot above shows an example of a list with 72 items.

## Other minor improvements
* A downloaded list is now named `DPLA User List - NAME.csv` instead of just `NAME.csv`, to make it more clear that it is an exported user list from DPLA.
* The list download logic has been moved from `ListView/index.js` to `[listId].js`, since it's logic that's applied per-list.

# CodeRabbit Summary
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds CSV import for user lists, paginates list views at 50 items per page, and raises the per-list client-side cap from 50 to MAX_LIST_ITEMS = 1000.

Key changes
- New import page (pages/lists/import.js)
  - Import .csv files where the first column contains DPLA item IDs (header row skipped).
  - Auto-prefill list name from filename (strips .csv and optional "DPLA User List - " prefix); user may rename before import.
  - User supplies a list name; imported lists are saved locally via localForage/localStorage.
  - Validates file size (max 5 MB), extracts unique IDs (lowercased), enforces DPLA_ITEM_ID_REGEX, de-duplicates, stops at MAX_LIST_ITEMS (1000), and errors if no valid IDs.
  - New page component: export default function ImportList().

- Paginated list detail page (pages/lists/[listId].js)
  - Page-aware loading using LIST_PAGE_SIZE = 50 (route reads page param).
  - Tracks totalItemCount, isPageLoading, fetchError, and shows Pagination when pageCount > 1.
  - Loads only the slice of selected IDs for the current page, fetching /api/items/<comma-separated-ids>.
  - CSV export/download moved from ListView to this page; export fetches all selected items in LIST_PAGE_SIZE-sized batches, filters out errored results, excludes placeholder thumbnails, truncates long text fields, escapes/quotes CSV fields, and triggers a client-side Blob download named "DPLA User List - {NAME}.csv". Export shows “Preparing download…” and disables download while running.
  - Inline header actions added (rename, download, delete); delete moved into the list header. Breadcrumbs adjusted to use LISTS_TITLE.
  - Renders ListView only when items are present; visually disables interaction while page loads.

- UI/logic and styling updates
  - CheckableLists updated to use MAX_LIST_ITEMS for checkbox disabling (disable when list.count >= MAX_LIST_ITEMS and not currently checked); also respects state.updatingLists.
  - ListView no longer provides in-component CSV download/link; export logic removed and ListView’s exportable prop removed. ListView checkbox disabling logic changed to base on currentItemCount from state.currentList.selectedHash.
  - Empty-state copy and helper text updated to reference MAX_LIST_ITEMS (formatted).
  - My Lists landing page adds an Import action and CTA adjustments ("Create new list", "Import list from CSV").
  - "Download list" converted from link to button; header responsiveness and import form styles improved. Several SCSS selector changes/additions for list actions and import UI.
  - ConfirmModal now accepts an optional confirmButtonText prop to customize the primary confirm button label.

- Constants
  - constants/site.js: MAX_LIST_ITEMS changed 50 → 1000; LIST_PAGE_SIZE added = 50.

Files of note
- pages/lists/import.js — import UI, CSV parsing, validation, persistence
- pages/lists/[listId].js — pagination-aware loading, CSV export/download, header actions, page/error state
- components/ListComponents/* — checkbox disabling logic, empty-state copy, import UI styling
- components/shared/ListView/index.js — removed in-component CSV download/link; logic adjusted to use currentItemCount
- components/shared/ConfirmModal/index.js — new confirmButtonText prop
- constants/site.js — MAX_LIST_ITEMS and LIST_PAGE_SIZE

Architectural & operational impact (explicit)
- Frontend-only changes. No new or modified backend endpoints (continues to call existing /api/items/).
- No database migrations.
- No environment variables or AWS Secrets Manager keys added, removed, or renamed.
- No shared infrastructure (CodePipeline/CodeBuild/ECS task definitions/IAM) changes.
- No manual pipeline trigger or ECS redeploy required beyond the normal frontend deployment process.

Security & data implications
- Import/export operate entirely client-side. File size is limited (5 MB) and imported IDs are capped at MAX_LIST_ITEMS (1000) to bound client work.
- Export fetches item data from existing backend endpoints; export logic filters out errored responses and placeholder thumbnails before including rows.
- No new credential handling, backend ingestion, or public API shape changes introduced. Existing local-only list storage warning remains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->