### PR TITLE
fix(probeImage): replace AbortController+setTimeout with AbortSignal.timeout

### DIFF
--- a/lib/probeImage.js
+++ b/lib/probeImage.js
@@ -51,15 +51,12 @@ async function detectErrorType(url, fallbackType) {
     return fallbackType;
   }
 
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), STATUS_PROBE_TIMEOUT_MS);
-
   try {
     const response = await fetch(url, {
       method: "HEAD",
       cache: "no-store",
       mode: "cors",
-      signal: controller.signal,
+      signal: AbortSignal.timeout(STATUS_PROBE_TIMEOUT_MS),
     });
     if (Number.isInteger(response?.status) && response.status >= 400) {
       return String(response.status);
@@ -72,8 +69,6 @@ async function detectErrorType(url, fallbackType) {
     }
   } catch {
     // Ignore; fallbackType is returned below.
-  } finally {
-    clearTimeout(timeout);
   }
 
   return fallbackType;
@@ -118,7 +113,7 @@ const probeImage = (url, onError, provider, sourceUrl) => {
       const pageUrl = typeof window !== "undefined" ? window.location?.href || "" : "";
       void detectErrorType(url, "decode").then((errorType) => {
         reportThumbnailError(url, provider, sourceUrl, pageUrl, errorType);
-      });
+      }).catch(() => {});
       onError();
     }
     cleanup();
@@ -129,7 +124,7 @@ const probeImage = (url, onError, provider, sourceUrl) => {
       void detectErrorType(url, "load").then((errorType) => {
         if (!errorType) return;
         reportThumbnailError(url, provider, sourceUrl, pageUrl, errorType);
-      });
+      }).catch(() => {});
       onError();
     }
     cleanup();


### PR DESCRIPTION
## Summary

- **Root cause**: Chrome's `onunhandledrejection` handler was firing for the `AbortError` before the `try/catch` in `detectErrorType` could handle it — a known timing quirk when `controller.abort()` is called from a macrotask (`setTimeout`). Sentry was capturing this as DPLA-FRONTEND-1N9 (251 events from a single scraper IP, all from `/search`).
- **Fix**: Replace the `AbortController` + `setTimeout` + `clearTimeout` pattern in `detectErrorType` with `AbortSignal.timeout()`, which is designed for exactly this use case and eliminates the floating setTimeout callback that triggered the race.
- **Belt-and-suspenders**: Added `.catch(() => {})` to both `void detectErrorType(...).then(...)` call sites, since those chains had no rejection handler.

`AbortSignal.timeout()` is supported in Chrome 103+, Firefox 100+, Safari 16+ (mid-2022).

## Test plan

- [ ] All 25 existing `lib/*.test.mjs` tests pass (verified locally)
- [ ] Confirm DPLA-FRONTEND-1N9 stops receiving new events after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a race condition in the `probeImage` function's error handling. Chrome's `onunhandledrejection` event handler was firing for an `AbortError` before the `try/catch` block in `detectErrorType` could handle it, due to a timing issue when `controller.abort()` is called from a macrotask (`setTimeout`). This resulted in unhandled rejection events captured by Sentry (DPLA-FRONTEND-1N9: 251 events from a single scraper IP on the `/search` endpoint).

## Changes

**lib/probeImage.js:**
- Replaced the `AbortController` + `setTimeout` + `clearTimeout` pattern with the native `AbortSignal.timeout(STATUS_PROBE_TIMEOUT_MS)` API in the `detectErrorType` function's fetch call
- Added `.catch(() => {})` handlers to both `detectErrorType(...).then(...)` call sites (in `img.onload` and `img.onerror` handlers) to prevent unhandled promise rejections

The `AbortSignal.timeout()` API is purpose-built for timeout scenarios and eliminates the floating setTimeout callback that triggered the race condition. Browser support is sufficient (Chrome 103+, Firefox 100+, Safari 16+, all from mid-2022 or earlier).

## Testing

All 25 existing tests in `lib/*.test.mjs` pass locally. Resolution of the Sentry issue is expected after deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->