### PR TITLE
fix(sentry): suppress iOS translation engine stack overflows

### DIFF
--- a/components/shared/mediaViewers/ZoomableImageViewer.js
+++ b/components/shared/mediaViewers/ZoomableImageViewer.js
@@ -49,7 +49,7 @@ export default class ZoomableImageViewer extends React.Component {
 
   render() {
     return (
-      <div ref={this.containerRef} className={css.zoomableImageViewer}>
+      <div ref={this.containerRef} className={css.zoomableImageViewer} translate="no">
         <Noscript>
           <div className={css.noscriptContainer}>
             <img

--- a/instrumentation-client.js
+++ b/instrumentation-client.js
@@ -26,6 +26,17 @@ Sentry.init({
       return null;
     }
 
+    // iOS translation engines (Google App, Chrome Mobile iOS on WKWebView) inject
+    // scripts that recursively traverse the DOM and can overflow the call stack on
+    // complex pages. The crash is in the injected script, not our code — all frames
+    // resolve to "undefined" (no file path). This is not fixable from our end.
+    if (msg.startsWith("Maximum call stack size exceeded")) {
+      const frames = event?.exception?.values?.[0]?.stacktrace?.frames ?? [];
+      if (frames.length > 0 && frames.every((f) => !f.filename || f.filename === "undefined")) {
+        return null;
+      }
+    }
+
     return event;
   },
 });


### PR DESCRIPTION
## Summary

Investigation of Sentry issue **DPLA-FRONTEND-TW** (`RangeError: Maximum call stack size exceeded`, 620 events, 45 users).

**Root cause:** iOS translation engines (Google App and Chrome Mobile iOS on WKWebView) inject scripts that recursively traverse the DOM to wrap text nodes in `<font>` elements. On complex pages, this overflows the JS call stack *within the injected script itself* — not in React or our code. The crash shows as a single-frame exception with `filename: "undefined"` (external injected script with no source map). This is not the same bug as the desktop Google Translate / React reconciliation crash fixed in #1520.

Key evidence:
- 100% iOS devices (Google App iOS 26, Chrome Mobile iOS 149)
- Single-frame stacktrace: `undefined:LINE:COL` in both pre-patch (May 12) and post-patch (June 17) events — the iOS issue predates #1520 entirely
- User breadcrumbs show continued browsing after the crash — translation fails silently, page stays functional
- Crashes occur on pages with no OpenSeadragon viewer (`/`, `/search`, `/browse-by-topic`), so the DOM traversal overflow is not specific to any one component

**Changes:**

1. **`instrumentation-client.js`** — adds a `beforeSend` filter that suppresses `RangeError: Maximum call stack size exceeded` events where every stack frame has `filename: "undefined"` or empty. The frame check ensures a genuine infinite-recursion bug in our own code (which would produce recognisable app filenames) is not suppressed.

2. **`ZoomableImageViewer.js`** — adds `translate="no"` to the viewer container as a partial DOM-depth mitigation. This tells the translation engine to skip the OpenSeadragon canvas subtree, reducing traversal depth on viewer pages. The container holds no user-visible translatable text (it's OpenSeadragon canvases + a noscript fallback with `alt=""`), so there's no UX cost.

## Test plan

- [ ] All 25 existing tests pass (verified locally)
- [ ] After deploy, confirm DPLA-FRONTEND-TW stops receiving new events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

Addresses a Sentry issue (`RangeError: Maximum call stack size exceeded`) affecting 620 events across 45 iOS users. The crashes originate from iOS translation engines (Google App iOS and Chrome Mobile iOS on WKWebView) that inject scripts to traverse and wrap DOM text nodes. On complex pages, this traversal overflows the JavaScript call stack within the injected script itself, producing single-frame exceptions with undefined filenames. This issue is distinct from the desktop Google Translate crash fixed in `#1520`.

## Changes

**instrumentation-client.js** — Adds a `beforeSend` filter in the Sentry client that suppresses `RangeError: Maximum call stack size exceeded` events where all stack frames have undefined or empty filenames. This approach avoids suppressing genuine infinite-recursion bugs in application code, which would produce recognizable app filenames. Other existing suppression behavior for known iOS SVG/canvas and navigation issues remains unchanged.

**ZoomableImageViewer.js** — Adds `translate="no"` attribute to the OpenSeadragon viewer container to prevent translation engines from traversing the canvas subtree. This reduces DOM traversal depth on viewer pages without UX impact, as the container contains only canvases and noscript fallback content.

## Deployment Notes

No manual pipeline trigger, ECS redeployment, environment variables, database migrations, infrastructure configuration changes, API modifications, or security implications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->