### PR TITLE
Update Dockerfile after eslint config move

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ COPY *.js ./
 COPY package.json ./
 COPY yarn.lock ./
 COPY jsconfig.json ./
-COPY .eslintrc.json ./
+COPY eslint.config.mjs ./
 RUN yarn install --ignore-scripts --immutable --prod
 RUN --mount=type=secret,id=sentry_auth \
     SENTRY_AUTH_TOKEN=$(cat /run/secrets/sentry_auth 2>/dev/null || true) \
@@ -60,7 +60,7 @@ COPY *.js ./
 COPY package.json ./
 COPY yarn.lock ./
 COPY jsconfig.json ./
-COPY .eslintrc.json ./
+COPY eslint.config.mjs ./
 COPY --chown=node:node --from=builder /opt/dpla-frontend/.next /opt/dpla-frontend/.next
 COPY --from=builder /opt/dpla-frontend/node_modules /opt/dpla-frontend/node_modules
 USER node


### PR DESCRIPTION
The project's eslint configuration has been moved, from `.eslintrc.json` to `eslint.config.mjs`. This PR updates our Dockerfile to account for this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates the Dockerfile to copy `eslint.config.mjs` instead of `.eslintrc.json` in both build stages, keeping ESLint configuration available after the project’s config file move.

This change takes effect after rebuilding the image and redeploying the container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->