### PR TITLE
Fix FeedbackForm crash from JSON.stringify on the Next.js router

### DIFF
--- a/components/FeedbackForm/index.js
+++ b/components/FeedbackForm/index.js
@@ -12,7 +12,6 @@ class FeedbackForm extends React.Component {
     timestamp: Date.now(),
     isSending: false,
     isSent: false,
-    url: JSON.stringify(this.props.router),
     modalActive: false,
     type: "comment",
     step: 1,
@@ -25,7 +24,6 @@ class FeedbackForm extends React.Component {
       timestamp: prevState.timestamp,
       isSending: false,
       isSent: false,
-      url: prevState.url,
       modalActive: false,
       type: "comment",
       step: 1,
@@ -40,7 +38,6 @@ class FeedbackForm extends React.Component {
       timestamp: Date.now(),
       isSending: false,
       isSent: false,
-      url: prevState.url,
       modalActive: true,
       type: "comment",
       step: 1,
@@ -54,7 +51,6 @@ class FeedbackForm extends React.Component {
       timestamp: prevState.timestamp,
       isSending: prevState.isSending,
       isSent: prevState.isSent,
-      url: prevState.url,
       modalActive: prevState.modalActive,
       type: e.target.value,
       step: prevState.step,
@@ -68,7 +64,6 @@ class FeedbackForm extends React.Component {
       timestamp: prevState.timestamp,
       isSending: prevState.isSending,
       isSent: prevState.isSent,
-      url: prevState.url,
       modalActive: prevState.modalActive,
       type: prevState.type,
       step: prevState.step,
@@ -82,7 +77,6 @@ class FeedbackForm extends React.Component {
       timestamp: prevState.timestamp,
       isSending: prevState.isSending,
       isSent: prevState.isSent,
-      url: prevState.url,
       modalActive: prevState.modalActive,
       type: prevState.type,
       step: prevState.step,
@@ -96,7 +90,6 @@ class FeedbackForm extends React.Component {
       timestamp: prevState.timestamp,
       isSending: prevState.isSending,
       isSent: prevState.isSent,
-      url: prevState.url,
       modalActive: prevState.modalActive,
       type: prevState.type,
       step: prevState.step,
@@ -121,7 +114,6 @@ class FeedbackForm extends React.Component {
       timestamp: prevState.timestamp,
       isSending: true,
       isSent: false,
-      url: prevState.url,
       modalActive: prevState.modalActive,
       type: prevState.type,
       step: prevState.step,
@@ -129,7 +121,7 @@ class FeedbackForm extends React.Component {
       message: prevState.message,
     }));
 
-    const url = this.state.url;
+    const url = this.props.router?.asPath ?? "";
     const message = this.state.message;
     const type = this.state.type;
     const email = this.state.email;
@@ -155,7 +147,6 @@ class FeedbackForm extends React.Component {
         timestamp: prevState.timestamp,
         isSending: false,
         isSent: true,
-        url: prevState.url,
         modalActive: prevState.modalActive,
         type: prevState.type,
         step: 2,
@@ -175,7 +166,7 @@ class FeedbackForm extends React.Component {
   render() {
     const charLimit = 400;
     const step = this.state.step;
-    const url = this.state.url;
+    const url = this.props.router?.asPath ?? "";
     const modalActive = this.state.modalActive;
     const isSending = this.state.isSending;
     const type = this.state.type;


### PR DESCRIPTION
## Problem

`FeedbackForm`'s state initializer captured the current page for the feedback form's `frompage` field by serializing the entire Next.js router object:

```js
url: JSON.stringify(this.props.router),
```

The router object can hold circular references (DOM nodes carrying React fibers), so on affected pages this throws **`TypeError: Converting circular structure to JSON`** during render. `FeedbackForm` is mounted in the persistent footer (`FooterUser` / `FooterPro`), so the unhandled throw propagates through React's commit phase, trips Next.js's error boundary, and **white-screens the whole page**.

Sentry: **DPLA-FRONTEND-1PC** (observed on `/primary-source-sets/cherokee-removal-and-the-trail-of-tears`; the circular chain in the event is `HTMLAnchorElement → __reactFiber$… → stateNode`).

## Fix

Read `router.asPath` instead of stringifying the router:

```js
const url = this.props.router?.asPath ?? "";
```

- It's the value `frompage` actually wants — the current path including query.
- It's a plain string that can never be circular, so the crash can't recur.
- It's SSR-safe via `withRouter`.

This also fixes a **second, quieter bug**: the old code stored `url` in `state` at construction time. Since the footer component only ever constructs once, `frompage` was frozen to the initial landing page and reported a **stale URL after any client-side navigation**. Reading `asPath` at submit/render time (it's refreshed on every route change via `withRouter`) makes `frompage` reflect the page the user is actually on, and lets us drop the redundant `url` state field.

## Testing

- `npm test` passes (25/25 + favicon checks).
- Ran the `simplify` review (reuse / simplification / efficiency / altitude); the altitude finding — capture at submit time rather than construction — is folded into this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Prevents `FeedbackForm` crashes caused by circular references in `JSON.stringify(router)`.
- Uses `router.asPath` to provide the current path and query string.
- Removes redundant `url` state and prevents stale `frompage` values after client-side navigation.
- Tests reportedly pass: 25/25, including favicon checks.

## Operational Impact

- Does not require a manual pipeline trigger or ECS redeployment beyond the standard application deployment process.
- Does not add, remove, or rename environment variables or AWS Secrets Manager keys.
- Does not include a database migration.
- Does not change shared infrastructure configuration.
- Does not change public-facing API response shapes or endpoints.
- Has no security implications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->