### PR TITLE
Return 404 instead of 500 for unresolved /local/markdown routes

### DIFF
--- a/pages/local/markdown.js
+++ b/pages/local/markdown.js
@@ -101,6 +101,13 @@ export async function getServerSideProps(context) {
   const asPath = subsection ? `/${section}/${subsection}` : `/${section}`;
   const routes = local["routes"];
   const pageData = routes[asPath];
+  // `/local/markdown` is only meant to be reached via the section rewrites in
+  // next.config.js. A direct hit (e.g. an internal health check) arrives with
+  // no `section`, so asPath won't match a route and pageData is undefined —
+  // return a 404 instead of throwing a 500 on pageData.path below.
+  if (!pageData) {
+    return { notFound: true };
+  }
   const markdownPath = join(
     process.cwd(),
     "public",


### PR DESCRIPTION
## Problem

`pages/local/markdown.js` is an **internal rewrite target**. On local sites, `next.config.js` rewrites real routes like `/${section}` → `/local/markdown?section=${section}`. Its `getServerSideProps` then looks the section up in the local's routes map and reads `pageData.path`:

```js
const asPath = subsection ? `/${section}/${subsection}` : `/${section}`;
const pageData = routes[asPath];
const markdownPath = join(..., pageData.path);   // ← 500 when pageData is undefined
```

When the page is hit **directly** with no `section` (an internal ALB health check, or a crawler), `asPath` is `/undefined`, which isn't a route key, so `pageData` is `undefined` and the read throws **`TypeError: Cannot read properties of undefined (reading 'path')`** — an uncaught 500.

Sentry: **DPLA-FRONTEND-1PS**, recurring 2026-07-30 → 08-10 on `aviation-internal.dp.la/local/markdown` (0 users — it's server-side, non-interactive traffic).

## Fix

Guard the lookup — when the section doesn't resolve to a known route, return a 404 instead of crashing:

```js
const pageData = routes[asPath];
if (!pageData) {
  return { notFound: true };
}
```

This defends at the exact point of failure against **any** unresolved section, regardless of how the request arrives (internal ALB, crawler, or a rewrite gap). It's a genuine "this page doesn't exist" case, so HTTP 404 is the correct status.

## Related (optional follow-up, not included here)

The `local` siteEnv rewrites in `next.config.js` are **missing** the `fourOhFour("/local/markdown")` guard that the `pro` (line 180) and `user` (line 205) envs both have. Adding it there would block the literal path at the rewrite layer for parity/defense-in-depth — but it's optional polish: it only covers the one literal path, whereas this `getServerSideProps` guard is the load-bearing fix that can't be routed around. Left out to keep this change minimal and focused; happy to add it if preferred.

## Testing

- `npm test` passes (25/25 + favicon checks).
- Ran the `simplify` review (reuse / simplification / efficiency / altitude); no findings — inline `return { notFound: true }` is the established idiom in this repo (e.g. `pages/news/index.js:159`), and altitude confirmed the getServerSideProps guard is the correct depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Return HTTP 404 for unknown local markdown routes.
- Prevent an uncaught `TypeError` and HTTP 500 response when route lookup fails.
- Apply the fix to direct requests, crawlers, health checks, and rewrite gaps.
- Tests pass: 25 test suites and favicon checks.

## Operational impact

- No manual pipeline trigger or ECS redeployment is specified.
- No environment variables or AWS Secrets Manager keys change.
- No database migration is included.
- No shared infrastructure configuration changes.
- The response changes from HTTP 500 to HTTP 404 for unresolved routes. No endpoint is added or removed.
- No security changes are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->