### PR TITLE
Add IIIF page viewer for Transcribe local items

### DIFF
--- a/components/ItemComponents/Content/IIIFViewer/IIIFViewer.module.css
+++ b/components/ItemComponents/Content/IIIFViewer/IIIFViewer.module.css
@@ -1,0 +1,96 @@
+.iiifViewer {
+  width: 100%;
+}
+
+.stage {
+  position: relative;
+  width: 100%;
+  height: 480px;
+  background: #1b1b1b;
+  border: 1px solid var(--darkBorderColor, #d4d4d4);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.osdContainer {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  text-align: center;
+  color: #fff;
+  font-size: 0.95rem;
+}
+
+.pageBarWrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-top: 0.5rem;
+}
+
+.pageBar {
+  display: flex;
+  gap: 0.25rem;
+  overflow-x: auto;
+  padding: 0.25rem;
+  scrollbar-width: thin;
+}
+
+.pageButton {
+  flex: 0 0 auto;
+  min-width: 2rem;
+  height: 2rem;
+  padding: 0 0.4rem;
+  border: 1px solid var(--darkBorderColor, #ccc);
+  border-radius: 2px;
+  background: var(--warmerBackgroundColor, #fff);
+  color: var(--linkColor, #2b67ac);
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.pageButton:hover {
+  border-color: var(--linkColor, #2b67ac);
+}
+
+.pageButtonActive,
+.pageButtonActive:hover {
+  background: var(--linkColor, #2b67ac);
+  border-color: var(--linkColor, #2b67ac);
+  color: #fff;
+  font-weight: 600;
+}
+
+.pageArrow {
+  flex: 0 0 auto;
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid var(--darkBorderColor, #ccc);
+  border-radius: 2px;
+  background: var(--warmerBackgroundColor, #fff);
+  color: var(--linkColor, #2b67ac);
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.pageArrow:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.pageStatus {
+  margin: 0.35rem 0 0;
+  font-size: 0.85rem;
+  color: var(--headingColor, #333);
+}

--- a/components/ItemComponents/Content/IIIFViewer/index.js
+++ b/components/ItemComponents/Content/IIIFViewer/index.js
@@ -1,0 +1,138 @@
+import React from "react";
+
+import css from "./IIIFViewer.module.css";
+
+// Full-image page viewer for items that carry a IIIF manifest. Fetches the parsed
+// canvas list from /api/iiif-manifest/<itemId> (same origin — see that route), then
+// drives OpenSeaDragon in sequenceMode so each page's image loads only when viewed.
+// A clickable page-number bar navigates between canvases.
+//
+// OpenSeaDragon touches window/document, so — like ZoomableImageViewer — it is
+// require()'d inside a lifecycle method that only runs in the browser, never at import.
+export default class IIIFViewer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { status: "loading", canvases: [], currentPage: 0 };
+    this.containerRef = React.createRef();
+    this.viewer = null;
+    this._mounted = false;
+  }
+
+  componentDidMount() {
+    this._mounted = true;
+    this.loadManifest();
+  }
+
+  componentWillUnmount() {
+    this._mounted = false;
+    if (this.viewer) {
+      this.viewer.destroy();
+      this.viewer = null;
+    }
+  }
+
+  async loadManifest() {
+    try {
+      const res = await fetch(
+        `/api/iiif-manifest/${encodeURIComponent(this.props.itemId)}`,
+      );
+      if (!res.ok) throw new Error(`manifest request failed: ${res.status}`);
+      const data = await res.json();
+      if (!this._mounted) return;
+      const canvases = Array.isArray(data.canvases) ? data.canvases : [];
+      if (canvases.length === 0) {
+        this.setState({ status: "empty" });
+        return;
+      }
+      this.setState({ status: "ready", canvases }, () => this.initViewer(canvases));
+    } catch (err) {
+      console.warn("IIIF viewer: could not load manifest.", err?.message ?? err);
+      if (this._mounted) this.setState({ status: "error" });
+    }
+  }
+
+  initViewer(canvases) {
+    if (this.viewer || !this.containerRef.current) return;
+    const OpenSeaDragon = require("openseadragon");
+    this.viewer = new OpenSeaDragon({
+      element: this.containerRef.current,
+      prefixUrl: "/static/images/openseadragon/",
+      tileSources: canvases.map((c) => ({ type: "image", url: c.imageUrl })),
+      sequenceMode: true,
+      showSequenceControl: false, // we render our own page bar
+      showNavigator: false,
+      showNavigationControl: true,
+    });
+    this.viewer.addHandler("page", (event) => {
+      if (this._mounted) this.setState({ currentPage: event.page });
+    });
+  }
+
+  goToPage(index) {
+    if (this.viewer) this.viewer.goToPage(index);
+  }
+
+  render() {
+    const { status, canvases, currentPage } = this.state;
+    const hasPages = status === "ready" && canvases.length > 1;
+    return (
+      <div className={css.iiifViewer}>
+        <div className={css.stage}>
+          {/* OpenSeaDragon owns this node; keep React children out of it. */}
+          <div ref={this.containerRef} className={css.osdContainer} translate="no" />
+          {status !== "ready" && (
+            <div className={css.overlay} role="status">
+              {status === "loading" && "Loading page viewer…"}
+              {status === "empty" && "No page images are available for this item."}
+              {status === "error" && "The page viewer could not be loaded."}
+            </div>
+          )}
+        </div>
+
+        {hasPages && (
+          <div className={css.pageBarWrapper}>
+            <button
+              type="button"
+              className={css.pageArrow}
+              aria-label="Previous page"
+              disabled={currentPage <= 0}
+              onClick={() => this.goToPage(currentPage - 1)}
+            >
+              &lsaquo;
+            </button>
+            <nav className={css.pageBar} aria-label="Pages">
+              {canvases.map((canvas, index) => (
+                <button
+                  key={canvas.id || index}
+                  type="button"
+                  className={`${css.pageButton} ${
+                    index === currentPage ? css.pageButtonActive : ""
+                  }`}
+                  aria-label={`Go to page ${index + 1}`}
+                  aria-current={index === currentPage ? "true" : undefined}
+                  onClick={() => this.goToPage(index)}
+                >
+                  {index + 1}
+                </button>
+              ))}
+            </nav>
+            <button
+              type="button"
+              className={css.pageArrow}
+              aria-label="Next page"
+              disabled={currentPage >= canvases.length - 1}
+              onClick={() => this.goToPage(currentPage + 1)}
+            >
+              &rsaquo;
+            </button>
+          </div>
+        )}
+        {status === "ready" && (
+          <p className={css.pageStatus}>
+            Page {currentPage + 1} of {canvases.length}
+          </p>
+        )}
+      </div>
+    );
+  }
+}

--- a/components/ItemComponents/Content/IIIFViewer/index.js
+++ b/components/ItemComponents/Content/IIIFViewer/index.js
@@ -16,6 +16,7 @@ export default class IIIFViewer extends React.Component {
     this.containerRef = React.createRef();
     this.viewer = null;
     this._mounted = false;
+    this._loadToken = 0;
   }
 
   componentDidMount() {
@@ -31,23 +32,43 @@ export default class IIIFViewer extends React.Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    // The item page reuses this component across client-side navigation, so a new
+    // itemId must tear down the old viewer and load the new manifest.
+    if (prevProps.itemId !== this.props.itemId) {
+      if (this.viewer) {
+        this.viewer.destroy();
+        this.viewer = null;
+      }
+      this.setState({ status: "loading", canvases: [], currentPage: 0 });
+      this.loadManifest();
+    }
+  }
+
   async loadManifest() {
+    // Guard against a stale in-flight response replacing state after the itemId
+    // has changed (or the component unmounted).
+    const token = ++this._loadToken;
     try {
       const res = await fetch(
         `/api/iiif-manifest/${encodeURIComponent(this.props.itemId)}`,
       );
       if (!res.ok) throw new Error(`manifest request failed: ${res.status}`);
       const data = await res.json();
-      if (!this._mounted) return;
+      if (!this._mounted || token !== this._loadToken) return;
       const canvases = Array.isArray(data.canvases) ? data.canvases : [];
       if (canvases.length === 0) {
         this.setState({ status: "empty" });
         return;
       }
-      this.setState({ status: "ready", canvases }, () => this.initViewer(canvases));
+      this.setState({ status: "ready", canvases }, () => {
+        if (token === this._loadToken) this.initViewer(canvases);
+      });
     } catch (err) {
       console.warn("IIIF viewer: could not load manifest.", err?.message ?? err);
-      if (this._mounted) this.setState({ status: "error" });
+      if (this._mounted && token === this._loadToken) {
+        this.setState({ status: "error" });
+      }
     }
   }
 

--- a/components/ItemComponents/Content/MainMetadata.js
+++ b/components/ItemComponents/Content/MainMetadata.js
@@ -1,6 +1,7 @@
 import React from "react";
 
 import ItemImage from "./ItemImage";
+import IIIFViewer from "./IIIFViewer";
 import ItemTermValuePair from "./ItemTermValuePair";
 
 import { joinIfArray, readMyRights } from "lib";
@@ -58,6 +59,10 @@ class MainMetadata extends React.Component {
   render() {
     const { isOpen } = this.state;
     const { item } = this.props;
+    // On the Transcribe local, items that carry a IIIF manifest get the full
+    // page viewer in place of the thumbnail; everywhere else is unchanged.
+    const showIiifViewer =
+      process.env.NEXT_PUBLIC_LOCAL_ID === "transcribe" && !!item.iiifManifest;
     const maxDescriptionLength = 600; //characters
     const descriptionIsLong = item.description
       ? joinIfArray(item.description).length > maxDescriptionLength
@@ -81,15 +86,19 @@ class MainMetadata extends React.Component {
           <div className={css.termValuePair}>
             <dt className={`${css.term} ${css.imageLabel}`}>Image</dt>
             <dd className={css.value}>
-              <ItemImage
-                title=""
-                type={item.type}
-                url={item.thumbnailUrl}
-                provider={item.partner}
-                thumbnailSourceUrl={item.thumbnailSourceUrl}
-                defaultImageClass={css.defaultItemImage}
-                useDefaultImage={item.useDefaultImage}
-              />
+              {showIiifViewer ? (
+                <IIIFViewer itemId={item.id} />
+              ) : (
+                <ItemImage
+                  title=""
+                  type={item.type}
+                  url={item.thumbnailUrl}
+                  provider={item.partner}
+                  thumbnailSourceUrl={item.thumbnailSourceUrl}
+                  defaultImageClass={css.defaultItemImage}
+                  useDefaultImage={item.useDefaultImage}
+                />
+              )}
               {item.sourceUrl && (
                 <a
                   rel="noopener"

--- a/lib/parseIiifManifest.js
+++ b/lib/parseIiifManifest.js
@@ -1,0 +1,85 @@
+// Parse a IIIF Presentation manifest (API v2 or v3) into a flat, ordered list of
+// canvases, each with a single web-displayable image URL. Pure function — no I/O,
+// so it can be unit-tested and run server-side in the /api/iiif-manifest route.
+//
+// v2 canvases live at manifest.sequences[0].canvases[]; v3 canvases at manifest.items[].
+// When a canvas exposes a IIIF Image API service we derive a bounded-size image URL
+// from it; otherwise we fall back to the static image the manifest references.
+
+const DEFAULT_IMAGE_WIDTH = 1600;
+
+// Resolve a human label from the several shapes IIIF allows:
+//   v2: "Page 1" | [{ "@value": "Page 1" }] ; v3: { en: ["Page 1"], none: ["1"] }
+function firstLabel(label) {
+  if (!label) return null;
+  if (typeof label === "string") return label;
+  if (Array.isArray(label)) {
+    const first = label[0];
+    return typeof first === "string" ? first : (first?.["@value"] ?? null);
+  }
+  if (typeof label === "object") {
+    const values = Object.values(label);
+    const first = Array.isArray(values[0]) ? values[0][0] : values[0];
+    return first != null ? String(first) : null;
+  }
+  return null;
+}
+
+// A IIIF Image API service can be a single object or an array; its id is `id` (v3)
+// or `@id` (v2).
+function imageServiceId(service) {
+  if (!service) return null;
+  const svc = Array.isArray(service) ? service[0] : service;
+  return svc?.id || svc?.["@id"] || null;
+}
+
+// IIIF Image API request: {id}/{region}/{size}/{rotation}/{quality}.{format}.
+// A width-only size ("1600,") is valid in both Image API v2 and v3.
+function sizedImageUrl(serviceId, width) {
+  return `${serviceId.replace(/\/$/, "")}/full/${width},/0/default.jpg`;
+}
+
+function canvasFromV2(canvas, width) {
+  const resource = canvas?.images?.[0]?.resource;
+  const serviceId = imageServiceId(resource?.service);
+  const imageUrl = serviceId
+    ? sizedImageUrl(serviceId, width)
+    : resource?.["@id"] || null;
+  if (!imageUrl) return null;
+  return { id: canvas["@id"] || null, label: firstLabel(canvas.label), imageUrl };
+}
+
+function canvasFromV3(canvas, width) {
+  const annotation = canvas?.items?.[0]?.items?.[0];
+  const body = Array.isArray(annotation?.body)
+    ? annotation.body[0]
+    : annotation?.body;
+  const serviceId = imageServiceId(body?.service);
+  const imageUrl = serviceId ? sizedImageUrl(serviceId, width) : body?.id || null;
+  if (!imageUrl) return null;
+  return { id: canvas.id || null, label: firstLabel(canvas.label), imageUrl };
+}
+
+export function parseIiifManifest(manifest, { width = DEFAULT_IMAGE_WIDTH } = {}) {
+  if (!manifest || typeof manifest !== "object") {
+    return { count: 0, canvases: [] };
+  }
+
+  // Structural version detection: v3 puts canvases in top-level `items`;
+  // v2 nests them under `sequences[0].canvases`.
+  const raw = Array.isArray(manifest.items)
+    ? manifest.items.map((c) => canvasFromV3(c, width))
+    : (manifest.sequences?.[0]?.canvases || []).map((c) => canvasFromV2(c, width));
+
+  const canvases = raw
+    .filter(Boolean)
+    .map((canvas, index) => ({
+      ...canvas,
+      // Give every page a stable, 1-based label for the page-number UI.
+      label: canvas.label || `Page ${index + 1}`,
+    }));
+
+  return { count: canvases.length, canvases };
+}
+
+export { DEFAULT_IMAGE_WIDTH };

--- a/lib/parseIiifManifest.js
+++ b/lib/parseIiifManifest.js
@@ -76,8 +76,9 @@ function canvasFromV3(canvas, width) {
   const annotations = (Array.isArray(canvas?.items) ? canvas.items : []).flatMap(
     (page) => (Array.isArray(page?.items) ? page.items : []),
   );
-  const candidates = annotations.map((anno) =>
-    Array.isArray(anno?.body) ? anno.body[0] : anno?.body,
+  // An annotation can carry multiple bodies; scan them all in order.
+  const candidates = annotations.flatMap((anno) =>
+    Array.isArray(anno?.body) ? anno.body : [anno?.body],
   );
   const imageUrl = firstResolvableImage(candidates, width);
   if (!imageUrl) return null;

--- a/lib/parseIiifManifest.js
+++ b/lib/parseIiifManifest.js
@@ -4,7 +4,9 @@
 //
 // v2 canvases live at manifest.sequences[0].canvases[]; v3 canvases at manifest.items[].
 // When a canvas exposes a IIIF Image API service we derive a bounded-size image URL
-// from it; otherwise we fall back to the static image the manifest references.
+// from it; otherwise we fall back to the static image the manifest references. A canvas
+// can carry more than one image candidate, so we scan them in order and keep the first
+// that resolves, dropping the canvas only when none do.
 
 const DEFAULT_IMAGE_WIDTH = 1600;
 
@@ -26,11 +28,12 @@ function firstLabel(label) {
 }
 
 // A IIIF Image API service can be a single object or an array; its id is `id` (v3)
-// or `@id` (v2).
+// or `@id` (v2). Only a string id is usable — a non-string would throw downstream.
 function imageServiceId(service) {
   if (!service) return null;
   const svc = Array.isArray(service) ? service[0] : service;
-  return svc?.id || svc?.["@id"] || null;
+  const id = svc?.id || svc?.["@id"];
+  return typeof id === "string" ? id : null;
 }
 
 // IIIF Image API request: {id}/{region}/{size}/{rotation}/{quality}.{format}.
@@ -39,23 +42,44 @@ function sizedImageUrl(serviceId, width) {
   return `${serviceId.replace(/\/$/, "")}/full/${width},/0/default.jpg`;
 }
 
+// One image candidate (a v2 `resource` or a v3 annotation `body`) -> image URL.
+// Prefer a bounded-size derivative from its Image API service; fall back to the
+// static image id the manifest names directly.
+function imageUrlFromResource(resource, width) {
+  if (!resource || typeof resource !== "object") return null;
+  const serviceId = imageServiceId(resource.service);
+  if (serviceId) return sizedImageUrl(serviceId, width);
+  const direct = resource["@id"] || resource.id;
+  return typeof direct === "string" ? direct : null;
+}
+
+// Return the first resolvable image URL from an ordered list of candidates.
+function firstResolvableImage(candidates, width) {
+  for (const candidate of candidates) {
+    const imageUrl = imageUrlFromResource(candidate, width);
+    if (imageUrl) return imageUrl;
+  }
+  return null;
+}
+
 function canvasFromV2(canvas, width) {
-  const resource = canvas?.images?.[0]?.resource;
-  const serviceId = imageServiceId(resource?.service);
-  const imageUrl = serviceId
-    ? sizedImageUrl(serviceId, width)
-    : resource?.["@id"] || null;
+  const candidates = (Array.isArray(canvas?.images) ? canvas.images : []).map(
+    (image) => image?.resource,
+  );
+  const imageUrl = firstResolvableImage(candidates, width);
   if (!imageUrl) return null;
   return { id: canvas["@id"] || null, label: firstLabel(canvas.label), imageUrl };
 }
 
 function canvasFromV3(canvas, width) {
-  const annotation = canvas?.items?.[0]?.items?.[0];
-  const body = Array.isArray(annotation?.body)
-    ? annotation.body[0]
-    : annotation?.body;
-  const serviceId = imageServiceId(body?.service);
-  const imageUrl = serviceId ? sizedImageUrl(serviceId, width) : body?.id || null;
+  // canvas.items are AnnotationPages; each page.items are Annotations with a body.
+  const annotations = (Array.isArray(canvas?.items) ? canvas.items : []).flatMap(
+    (page) => (Array.isArray(page?.items) ? page.items : []),
+  );
+  const candidates = annotations.map((anno) =>
+    Array.isArray(anno?.body) ? anno.body[0] : anno?.body,
+  );
+  const imageUrl = firstResolvableImage(candidates, width);
   if (!imageUrl) return null;
   return { id: canvas.id || null, label: firstLabel(canvas.label), imageUrl };
 }

--- a/lib/parseIiifManifest.test.mjs
+++ b/lib/parseIiifManifest.test.mjs
@@ -203,3 +203,27 @@ test("v3: uses a later annotation when the first is unusable", () => {
   const { canvases } = parseIiifManifest(manifest);
   assert.equal(canvases[0].imageUrl, "https://example.org/second.jpg");
 });
+
+test("v3: scans every body of an annotation, not just the first", () => {
+  const manifest = {
+    items: [
+      {
+        id: "c1",
+        items: [
+          {
+            items: [
+              {
+                body: [
+                  { type: "TextualBody" }, // no image -> unusable
+                  { id: "https://example.org/from-second-body.jpg" },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  const { canvases } = parseIiifManifest(manifest);
+  assert.equal(canvases[0].imageUrl, "https://example.org/from-second-body.jpg");
+});

--- a/lib/parseIiifManifest.test.mjs
+++ b/lib/parseIiifManifest.test.mjs
@@ -138,3 +138,68 @@ test("skips canvases with no resolvable image", () => {
   assert.equal(count, 1);
   assert.equal(canvases[0].imageUrl, "https://example.org/ok.jpg");
 });
+
+test("ignores a non-string service id and falls back to the direct image", () => {
+  const manifest = {
+    items: [
+      {
+        id: "c1",
+        items: [
+          {
+            items: [
+              {
+                body: {
+                  id: "https://example.org/ok.jpg",
+                  service: [{ id: 123 }], // non-string id must not throw
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  const { canvases } = parseIiifManifest(manifest);
+  assert.equal(canvases[0].imageUrl, "https://example.org/ok.jpg");
+});
+
+test("v2: uses a later image candidate when the first is unusable", () => {
+  const manifest = {
+    sequences: [
+      {
+        canvases: [
+          {
+            "@id": "c1",
+            images: [
+              { resource: {} }, // no @id, no service -> unusable
+              { resource: { "@id": "https://example.org/second.jpg" } },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  const { count, canvases } = parseIiifManifest(manifest);
+  assert.equal(count, 1);
+  assert.equal(canvases[0].imageUrl, "https://example.org/second.jpg");
+});
+
+test("v3: uses a later annotation when the first is unusable", () => {
+  const manifest = {
+    items: [
+      {
+        id: "c1",
+        items: [
+          {
+            items: [
+              { body: { type: "TextualBody" } }, // no id/service -> unusable
+              { body: { id: "https://example.org/second.jpg" } },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  const { canvases } = parseIiifManifest(manifest);
+  assert.equal(canvases[0].imageUrl, "https://example.org/second.jpg");
+});

--- a/lib/parseIiifManifest.test.mjs
+++ b/lib/parseIiifManifest.test.mjs
@@ -1,0 +1,140 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { parseIiifManifest } from "./parseIiifManifest.js";
+
+test("returns empty result for null/invalid input", () => {
+  assert.deepEqual(parseIiifManifest(null), { count: 0, canvases: [] });
+  assert.deepEqual(parseIiifManifest(undefined), { count: 0, canvases: [] });
+  assert.deepEqual(parseIiifManifest("not an object"), { count: 0, canvases: [] });
+  assert.deepEqual(parseIiifManifest({}), { count: 0, canvases: [] });
+});
+
+test("v2: derives a bounded IIIF Image API url from the canvas image service", () => {
+  const manifest = {
+    "@context": "http://iiif.io/api/presentation/2/context.json",
+    sequences: [
+      {
+        canvases: [
+          {
+            "@id": "https://example.org/canvas/1",
+            label: "Front",
+            images: [
+              {
+                resource: {
+                  "@id": "https://example.org/iiif/img1/full/full/0/default.jpg",
+                  service: { "@id": "https://example.org/iiif/img1" },
+                },
+              },
+            ],
+          },
+          {
+            "@id": "https://example.org/canvas/2",
+            images: [
+              {
+                resource: {
+                  "@id": "https://example.org/iiif/img2/full/full/0/default.jpg",
+                  // trailing slash on the service id must not double up
+                  service: { "@id": "https://example.org/iiif/img2/" },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  const { count, canvases } = parseIiifManifest(manifest, { width: 1000 });
+  assert.equal(count, 2);
+  assert.equal(canvases[0].label, "Front");
+  assert.equal(
+    canvases[0].imageUrl,
+    "https://example.org/iiif/img1/full/1000,/0/default.jpg",
+  );
+  // no label -> stable 1-based fallback; trailing slash collapsed
+  assert.equal(canvases[1].label, "Page 2");
+  assert.equal(
+    canvases[1].imageUrl,
+    "https://example.org/iiif/img2/full/1000,/0/default.jpg",
+  );
+});
+
+test("v2: falls back to the static resource @id when there is no image service", () => {
+  const manifest = {
+    sequences: [
+      {
+        canvases: [
+          {
+            "@id": "c1",
+            label: [{ "@value": "Plate I" }],
+            images: [{ resource: { "@id": "https://example.org/static/1.jpg" } }],
+          },
+        ],
+      },
+    ],
+  };
+  const { count, canvases } = parseIiifManifest(manifest);
+  assert.equal(count, 1);
+  assert.equal(canvases[0].label, "Plate I");
+  assert.equal(canvases[0].imageUrl, "https://example.org/static/1.jpg");
+});
+
+test("v3: derives image url from service and reads language-map labels", () => {
+  const manifest = {
+    "@context": "http://iiif.io/api/presentation/3/context.json",
+    items: [
+      {
+        id: "https://example.org/canvas/1",
+        label: { en: ["Recto"], none: ["1"] },
+        items: [
+          {
+            items: [
+              {
+                body: {
+                  id: "https://example.org/iiif/p1/full/max/0/default.jpg",
+                  service: [{ id: "https://example.org/iiif/p1" }],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  const { count, canvases } = parseIiifManifest(manifest, { width: 1600 });
+  assert.equal(count, 1);
+  assert.equal(canvases[0].label, "Recto");
+  assert.equal(
+    canvases[0].imageUrl,
+    "https://example.org/iiif/p1/full/1600,/0/default.jpg",
+  );
+});
+
+test("v3: falls back to body.id and handles an array body", () => {
+  const manifest = {
+    items: [
+      {
+        id: "c1",
+        items: [{ items: [{ body: [{ id: "https://example.org/plain.jpg" }] }] }],
+      },
+    ],
+  };
+  const { canvases } = parseIiifManifest(manifest);
+  assert.equal(canvases[0].imageUrl, "https://example.org/plain.jpg");
+  assert.equal(canvases[0].label, "Page 1");
+});
+
+test("skips canvases with no resolvable image", () => {
+  const manifest = {
+    items: [
+      { id: "c1", items: [{ items: [{ body: {} }] }] }, // no id/service -> dropped
+      {
+        id: "c2",
+        items: [{ items: [{ body: { id: "https://example.org/ok.jpg" } }] }],
+      },
+    ],
+  };
+  const { count, canvases } = parseIiifManifest(manifest);
+  assert.equal(count, 1);
+  assert.equal(canvases[0].imageUrl, "https://example.org/ok.jpg");
+});

--- a/pages/api/iiif-manifest/[itemId].js
+++ b/pages/api/iiif-manifest/[itemId].js
@@ -12,12 +12,51 @@
 import { parseIiifManifest } from "lib/parseIiifManifest";
 import { DPLA_ITEM_ID_REGEX } from "constants/items";
 
-const MANIFEST_FETCH_TIMEOUT_MS = 10000;
+const FETCH_TIMEOUT_MS = 10000;
 
 function getErrorMessage(err) {
   if (err instanceof Error) return err.message;
   if (typeof err === "string") return err;
   return "Unknown error";
+}
+
+// First-layer SSRF guard: block manifest URLs whose host is an internal DPLA
+// endpoint or a private / loopback / link-local IP literal. This checks the literal
+// host only; hostnames that *resolve* into private space (DNS rebinding) and
+// redirect hops are a documented follow-up hardening item.
+function isBlockedManifestHost(hostname) {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (host === "localhost" || host.endsWith(".localhost") || host === "::1") {
+    return true;
+  }
+  if (
+    host === "api-internal.dp.la" ||
+    host.endsWith("-internal.dp.la") ||
+    host.endsWith(".internal.dp.la")
+  ) {
+    return true;
+  }
+  const ipv4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (ipv4) {
+    const a = Number(ipv4[1]);
+    const b = Number(ipv4[2]);
+    if (a === 0 || a === 10 || a === 127) return true; // this-host, private, loopback
+    if (a === 169 && b === 254) return true; // link-local + cloud metadata
+    if (a === 192 && b === 168) return true; // private
+    if (a === 172 && b >= 16 && b <= 31) return true; // private
+    if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT
+  }
+  return false;
+}
+
+async function fetchWithTimeout(input, init) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 export default async function handler(req, res) {
@@ -47,7 +86,7 @@ export default async function handler(req, res) {
     const itemUrl = new URL(apiUrl);
     itemUrl.pathname = itemUrl.pathname.replace(/\/$/, "") + `/items/${itemId}`;
     itemUrl.searchParams.set("api_key", apiKey);
-    const itemRes = await fetch(itemUrl);
+    const itemRes = await fetchWithTimeout(itemUrl);
     if (!itemRes.ok) {
       itemRes.body?.cancel?.().catch(() => {});
       res.status(itemRes.status === 404 ? 404 : 502).json({
@@ -70,7 +109,7 @@ export default async function handler(req, res) {
     return;
   }
 
-  // Basic hygiene on the (index-supplied) manifest URL: web schemes only.
+  // Validate the (index-supplied) manifest URL: web schemes only, non-internal host.
   let parsedUrl;
   try {
     parsedUrl = new URL(manifestUrl);
@@ -82,14 +121,16 @@ export default async function handler(req, res) {
     res.status(502).json({ error: "Unsupported manifest URL scheme." });
     return;
   }
+  if (isBlockedManifestHost(parsedUrl.hostname)) {
+    console.error("Blocked IIIF manifest host.", { host: parsedUrl.hostname });
+    res.status(502).json({ error: "Manifest host not allowed." });
+    return;
+  }
 
   // 2. Fetch the manifest server-side with a timeout.
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), MANIFEST_FETCH_TIMEOUT_MS);
   let manifest;
   try {
-    const manifestRes = await fetch(parsedUrl, {
-      signal: controller.signal,
+    const manifestRes = await fetchWithTimeout(parsedUrl, {
       headers: { Accept: "application/json, application/ld+json" },
     });
     if (!manifestRes.ok) {
@@ -106,12 +147,18 @@ export default async function handler(req, res) {
     });
     res.status(aborted ? 504 : 502).json({ error: "Could not load IIIF manifest." });
     return;
-  } finally {
-    clearTimeout(timeout);
   }
 
-  // 3. Parse to a small canvas list and return.
-  const result = parseIiifManifest(manifest);
+  // 3. Parse to a small canvas list. Guard so one malformed manifest can't 500 the route.
+  let result;
+  try {
+    result = parseIiifManifest(manifest);
+  } catch (err) {
+    console.error("Error parsing IIIF manifest.", { message: getErrorMessage(err) });
+    res.status(502).json({ error: "Could not parse IIIF manifest." });
+    return;
+  }
+
   res.setHeader("Cache-Control", "public, max-age=3600");
   res.status(200).json(result);
 }

--- a/pages/api/iiif-manifest/[itemId].js
+++ b/pages/api/iiif-manifest/[itemId].js
@@ -13,6 +13,11 @@ import { parseIiifManifest } from "lib/parseIiifManifest";
 import { DPLA_ITEM_ID_REGEX } from "constants/items";
 
 const FETCH_TIMEOUT_MS = 10000;
+// Cap how many bytes we buffer from an upstream response. `.json()` reads the whole
+// body into memory, so a large or slow-chunked response could exhaust memory/CPU; this
+// bounds the size (the timeout only bounds duration). Generous for IIIF manifests,
+// which are JSON documents, not media.
+const MAX_UPSTREAM_BODY_BYTES = 5 * 1024 * 1024;
 
 function getErrorMessage(err) {
   if (err instanceof Error) return err.message;
@@ -57,6 +62,34 @@ function isBlockedManifestHost(hostname) {
   return false;
 }
 
+// Read a JSON response body while enforcing a maximum byte size, so a large or
+// slow-chunked upstream can't buffer unbounded data into memory. Streams and counts
+// bytes rather than trusting a (possibly absent or wrong) Content-Length; the fetch
+// AbortSignal still bounds total time.
+async function readJsonWithLimit(response, maxBytes) {
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    response.body?.cancel?.().catch(() => {});
+    throw new Error(`Upstream body exceeds ${maxBytes} bytes`);
+  }
+  const reader = response.body?.getReader?.();
+  if (!reader) return response.json(); // no readable stream; let fetch parse
+  const chunks = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) throw new Error(`Upstream body exceeds ${maxBytes} bytes`);
+      chunks.push(value);
+    }
+    return JSON.parse(Buffer.concat(chunks).toString("utf-8"));
+  } finally {
+    reader.cancel?.().catch(() => {});
+  }
+}
+
 // Fetch JSON under a single deadline covering BOTH the response headers and the body
 // read: fetch() resolves once headers arrive, so decoding the body outside the timeout
 // would leave a stalled body with no deadline. Throws UpstreamHttpError on non-OK, or
@@ -70,7 +103,7 @@ async function fetchJsonWithTimeout(input, init) {
       response.body?.cancel?.().catch(() => {});
       throw new UpstreamHttpError(response.status);
     }
-    return await response.json();
+    return await readJsonWithLimit(response, MAX_UPSTREAM_BODY_BYTES);
   } finally {
     clearTimeout(timeout);
   }

--- a/pages/api/iiif-manifest/[itemId].js
+++ b/pages/api/iiif-manifest/[itemId].js
@@ -20,6 +20,14 @@ function getErrorMessage(err) {
   return "Unknown error";
 }
 
+class UpstreamHttpError extends Error {
+  constructor(status) {
+    super(`Upstream responded ${status}`);
+    this.name = "UpstreamHttpError";
+    this.status = status;
+  }
+}
+
 // First-layer SSRF guard: block manifest URLs whose host is an internal DPLA
 // endpoint or a private / loopback / link-local IP literal. This checks the literal
 // host only; hostnames that *resolve* into private space (DNS rebinding) and
@@ -49,11 +57,20 @@ function isBlockedManifestHost(hostname) {
   return false;
 }
 
-async function fetchWithTimeout(input, init) {
+// Fetch JSON under a single deadline covering BOTH the response headers and the body
+// read: fetch() resolves once headers arrive, so decoding the body outside the timeout
+// would leave a stalled body with no deadline. Throws UpstreamHttpError on non-OK, or
+// the fetch AbortError on timeout.
+async function fetchJsonWithTimeout(input, init) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   try {
-    return await fetch(input, { ...init, signal: controller.signal });
+    const response = await fetch(input, { ...init, signal: controller.signal });
+    if (!response.ok) {
+      response.body?.cancel?.().catch(() => {});
+      throw new UpstreamHttpError(response.status);
+    }
+    return await response.json();
   } finally {
     clearTimeout(timeout);
   }
@@ -86,21 +103,19 @@ export default async function handler(req, res) {
     const itemUrl = new URL(apiUrl);
     itemUrl.pathname = itemUrl.pathname.replace(/\/$/, "") + `/items/${itemId}`;
     itemUrl.searchParams.set("api_key", apiKey);
-    const itemRes = await fetchWithTimeout(itemUrl);
-    if (!itemRes.ok) {
-      itemRes.body?.cancel?.().catch(() => {});
-      res.status(itemRes.status === 404 ? 404 : 502).json({
-        error: itemRes.status === 404 ? "Not found." : "Upstream service error.",
-      });
-      return;
-    }
-    const data = await itemRes.json();
+    const data = await fetchJsonWithTimeout(itemUrl);
     manifestUrl = data?.docs?.[0]?.iiifManifest;
   } catch (err) {
+    if (err instanceof UpstreamHttpError && err.status === 404) {
+      res.status(404).json({ error: "Not found." });
+      return;
+    }
+    const aborted = err?.name === "AbortError";
     console.error("Error resolving item for IIIF manifest.", {
       message: getErrorMessage(err),
+      aborted,
     });
-    res.status(502).json({ error: "Upstream service error." });
+    res.status(aborted ? 504 : 502).json({ error: "Upstream service error." });
     return;
   }
 
@@ -127,18 +142,12 @@ export default async function handler(req, res) {
     return;
   }
 
-  // 2. Fetch the manifest server-side with a timeout.
+  // 2. Fetch the manifest server-side (timeout covers headers + body decode).
   let manifest;
   try {
-    const manifestRes = await fetchWithTimeout(parsedUrl, {
+    manifest = await fetchJsonWithTimeout(parsedUrl, {
       headers: { Accept: "application/json, application/ld+json" },
     });
-    if (!manifestRes.ok) {
-      manifestRes.body?.cancel?.().catch(() => {});
-      res.status(502).json({ error: "Could not load IIIF manifest." });
-      return;
-    }
-    manifest = await manifestRes.json();
   } catch (err) {
     const aborted = err?.name === "AbortError";
     console.error("Error fetching IIIF manifest.", {

--- a/pages/api/iiif-manifest/[itemId].js
+++ b/pages/api/iiif-manifest/[itemId].js
@@ -1,0 +1,117 @@
+// Server-side IIIF manifest resolver for the Transcribe viewer.
+//
+// The client calls /api/iiif-manifest/<itemId> (its own origin), and this route:
+//   1. looks the DPLA item up in the API to find its trusted `iiifManifest` URL,
+//   2. fetches that manifest server-side, and
+//   3. returns a small, parsed list of canvases (page count + one image URL each).
+//
+// Keying on itemId — rather than a client-supplied URL — means the fetched URL is
+// always one DPLA's own index vouches for, so this is not an open proxy. The client
+// fetching same-origin also sidesteps CORS and the app's CSP `connect-src` policy.
+
+import { parseIiifManifest } from "lib/parseIiifManifest";
+import { DPLA_ITEM_ID_REGEX } from "constants/items";
+
+const MANIFEST_FETCH_TIMEOUT_MS = 10000;
+
+function getErrorMessage(err) {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  return "Unknown error";
+}
+
+export default async function handler(req, res) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    res.status(405).json({ error: "Method not allowed" });
+    return;
+  }
+
+  const { itemId } = req.query;
+  if (typeof itemId !== "string" || !DPLA_ITEM_ID_REGEX.test(itemId)) {
+    res.status(404).json({ error: "Not found." });
+    return;
+  }
+
+  const apiUrl = process.env.API_URL;
+  const apiKey = process.env.API_KEY;
+  if (!apiUrl || !apiKey) {
+    console.error("API configuration missing: API_URL or API_KEY not set");
+    res.status(500).json({ error: "Server configuration error." });
+    return;
+  }
+
+  // 1. Resolve the item's manifest URL from the DPLA record.
+  let manifestUrl;
+  try {
+    const itemUrl = new URL(apiUrl);
+    itemUrl.pathname = itemUrl.pathname.replace(/\/$/, "") + `/items/${itemId}`;
+    itemUrl.searchParams.set("api_key", apiKey);
+    const itemRes = await fetch(itemUrl);
+    if (!itemRes.ok) {
+      itemRes.body?.cancel?.().catch(() => {});
+      res.status(itemRes.status === 404 ? 404 : 502).json({
+        error: itemRes.status === 404 ? "Not found." : "Upstream service error.",
+      });
+      return;
+    }
+    const data = await itemRes.json();
+    manifestUrl = data?.docs?.[0]?.iiifManifest;
+  } catch (err) {
+    console.error("Error resolving item for IIIF manifest.", {
+      message: getErrorMessage(err),
+    });
+    res.status(502).json({ error: "Upstream service error." });
+    return;
+  }
+
+  if (!manifestUrl || typeof manifestUrl !== "string") {
+    res.status(404).json({ error: "This item has no IIIF manifest." });
+    return;
+  }
+
+  // Basic hygiene on the (index-supplied) manifest URL: web schemes only.
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(manifestUrl);
+  } catch {
+    res.status(502).json({ error: "Malformed manifest URL." });
+    return;
+  }
+  if (parsedUrl.protocol !== "https:" && parsedUrl.protocol !== "http:") {
+    res.status(502).json({ error: "Unsupported manifest URL scheme." });
+    return;
+  }
+
+  // 2. Fetch the manifest server-side with a timeout.
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), MANIFEST_FETCH_TIMEOUT_MS);
+  let manifest;
+  try {
+    const manifestRes = await fetch(parsedUrl, {
+      signal: controller.signal,
+      headers: { Accept: "application/json, application/ld+json" },
+    });
+    if (!manifestRes.ok) {
+      manifestRes.body?.cancel?.().catch(() => {});
+      res.status(502).json({ error: "Could not load IIIF manifest." });
+      return;
+    }
+    manifest = await manifestRes.json();
+  } catch (err) {
+    const aborted = err?.name === "AbortError";
+    console.error("Error fetching IIIF manifest.", {
+      message: getErrorMessage(err),
+      aborted,
+    });
+    res.status(aborted ? 504 : 502).json({ error: "Could not load IIIF manifest." });
+    return;
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  // 3. Parse to a small canvas list and return.
+  const result = parseIiifManifest(manifest);
+  res.setHeader("Cache-Control", "public, max-age=3600");
+  res.status(200).json(result);
+}

--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -221,6 +221,7 @@ export async function getServerSideProps(context) {
       doc: strippedDoc,
       originalRecord,
       filecoin: doc.filecoin,
+      iiifManifest: doc.iiifManifest,
     },
     randomItemId,
     isQA,


### PR DESCRIPTION
## What

Adds the **IIIF page viewer** for the Transcribe local. When an item record carries an `iiifManifest`, the item page renders a full-image OpenSeaDragon viewer with clickable page navigation **instead of** the thumbnail pane. Read-only display — the transcription box and its storage backend are separate later slices.

## Scope / gating

- **Transcribe-only:** the viewer triggers on `NEXT_PUBLIC_LOCAL_ID === "transcribe"` **and** `iiifManifest` present. These are shared item components, so **dp.la and every other local are unchanged** — the behavior change is contained to the transcribe deployment.
- Corpus scoping is untouched (still the `aviation` tag); this PR only changes item-page media rendering.

## How it works

1. `pages/item/[itemId].js` — surface `iiifManifest` into the item props (the gate).
2. `pages/api/iiif-manifest/[itemId].js` — server route that resolves the item's **trusted** manifest URL from the DPLA record, fetches the manifest server-side, and returns a parsed canvas list. Keyed by **itemId, not a client-supplied URL**, so it is not an open proxy; the same-origin client fetch also sidesteps CORS and the CSP `connect-src` policy — **no CSP change needed**.
3. `lib/parseIiifManifest.js` — pure IIIF Presentation **v2 + v3** parser → `{count, canvases:[{label, imageUrl}]}`, unit-tested (`lib/parseIiifManifest.test.mjs`, 6 cases).
4. `components/ItemComponents/Content/IIIFViewer` — OpenSeaDragon in `sequenceMode` (each page's image loads only when viewed) with a clickable page-number bar, prev/next, page status, and loading/empty/error states. OSD is `require()`'d client-side only (same SSR-safe pattern as `ZoomableImageViewer`).

## Deliberate v1 tradeoff

Each canvas is shown as a **web-sized IIIF image** (`…/full/1600,/0/default.jpg`) — full pan/zoom, but not progressive deep-zoom tiling. True `info.json` tiling (better for reading dense text at full resolution) needs a scoped `connect-src` relaxation on the transcribe build and is a **follow-up**, kept out of this PR to keep it focused. `mediaMaster` items are also deferred (they need a derivative proxy).

## Testing

- `node --test lib/parseIiifManifest.test.mjs` → 6/6 pass (also runs in the husky pre-commit hook).
- `eslint` could not be run in the worktree locally — a `@rushstack/eslint-patch` module-resolution artifact of the worktree's `node_modules`, not a code issue; relying on the CI `eslint .` + `build (local/user/pro)` checks.
- Manual: on transcribe-internal, open an item with a `iiifManifest` → viewer + page navigation; open one without → unchanged thumbnail pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds a read-only IIIF page viewer for eligible Transcribe local items with an `iiifManifest`.

- Adds a server-side `GET /api/iiif-manifest/[itemId]` endpoint.
- Supports IIIF Presentation v2 and v3 manifests.
- Loads OpenSeadragon only in the browser.
- Provides page navigation, status, loading, and error states.
- Uses web-sized IIIF images with a default width of 1600 pixels.
- Keeps other local item behavior unchanged.
- Adds parser unit tests for manifest parsing.
- Does not change transcription UI, storage backends, corpus scoping, or `mediaMaster` support.

## API and security

- Adds a public-facing API endpoint that returns parsed canvas data.
- Validates item IDs and trusted manifest URLs.
- Blocks unsupported schemes and private hosts.
- Restricts requests to `GET`.
- Limits item-record and manifest response bodies to 5 MB.
- Fetches external manifest data on the server with request timeouts that include response-body decoding.
- Distinguishes upstream 404 errors from other upstream failures.
- Handles malformed manifests, missing manifests, oversized responses, and timeouts.
- No authentication, credential, or authorization changes are included.

## Deployment and infrastructure

- No manual pipeline trigger or ECS redeployment is explicitly required.
- No environment variables or AWS Secrets Manager keys are added, removed, or renamed.
- No database migration is included.
- No shared infrastructure configuration changes are included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Deferred / follow-up

Recorded here intentionally (experimental feature — not filed on the issue tracker):

- **Full outbound target policy for manifest fetches** — partially addressed here (internal-host/private-IP denylist + https-only scheme check + request timeout + response body-size cap). The stronger policy is deferred: a positive host allowlist, connect-time IP validation (to defeat DNS rebinding), and redirect-hop validation. Sufficient for the header-gated alpha; harden before any public exposure.
- **True IIIF `info.json` deep-zoom tiling** — v1 shows a bounded web-sized image per canvas. Progressive tiled deep-zoom (better for reading dense text at full resolution) needs a scoped CSP `connect-src` relaxation on the transcribe build.
- **`mediaMaster` (non-IIIF) items** — display full-frame media for items exposing a media master instead of a IIIF manifest, via a thumbnail-api-style derivative/resize proxy.
