### PR TITLE
Fix blank IIIF viewer: use OSD canvas drawer for cross-origin images

### DIFF
--- a/components/ItemComponents/Content/IIIFViewer/index.js
+++ b/components/ItemComponents/Content/IIIFViewer/index.js
@@ -78,6 +78,13 @@ export default class IIIFViewer extends React.Component {
     this.viewer = new OpenSeaDragon({
       element: this.containerRef.current,
       prefixUrl: "/static/images/openseadragon/",
+      // Use the canvas drawer, not OSD 6's default WebGL drawer. WebGL textures
+      // require CORS-clean images, but provider images are cross-origin, so the
+      // default fails ("Error creating texture in WebGL") and renders blank until
+      // an interaction forces a redraw. The canvas drawer renders cross-origin
+      // images regardless of CORS, so it works across all providers — not just
+      // CORS-compliant ones — and perf is a non-issue for a single web-sized page.
+      drawer: "canvas",
       tileSources: canvases.map((c) => ({ type: "image", url: c.imageUrl })),
       sequenceMode: true,
       showSequenceControl: false, // we render our own page bar


### PR DESCRIPTION
## What

Fixes the IIIF viewer rendering **blank until you interact**, with `Error creating texture in WebGL` in the console.

**Root cause:** OpenSeaDragon 6 defaults to the **WebGL drawer**, and WebGL textures must be created from **CORS-clean** images. Provider images are cross-origin, and OSD doesn't request them CORS-clean by default, so the initial GPU texture creation fails and nothing draws until a zoom forces a fallback redraw.

**Fix:** set `drawer: "canvas"`. The canvas 2D drawer renders cross-origin images regardless of CORS (no WebGL texture step), so it works across **all** providers — not only CORS-compliant ones — with negligible perf cost for a single web-sized (1600px) page image.

*(Alternative considered: `crossOriginPolicy: "Anonymous"` keeps WebGL but **breaks** any provider that doesn't send CORS, so canvas is the robust choice for DPLA's varied corpus.)*

Manifest fetch/parse/redirect handling from #1571 is unchanged and already verified returning the correct image; this is purely the render path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Configure OpenSeaDragon to use the canvas drawer.
- Fix blank initial IIIF viewer rendering and the `Error creating texture in WebGL` error for cross-origin provider images.
- Manifest fetching, parsing, and redirect handling remain unchanged.

## Impact

- No manual pipeline trigger or ECS redeployment is required.
- No environment variables or AWS Secrets Manager keys changed.
- No database migration included.
- No shared infrastructure configuration changed.
- No public API response shape or endpoint changed.
- No security implications introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->