### PR TITLE
Add transcription editing UI under the IIIF viewer

### DIFF
--- a/components/ItemComponents/Content/IIIFViewer/TranscriptionPanel.js
+++ b/components/ItemComponents/Content/IIIFViewer/TranscriptionPanel.js
@@ -1,0 +1,284 @@
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+} from "react";
+
+import { addCommasToNumber } from "lib";
+import {
+  TRANSCRIPT_STATUSES,
+  TRANSCRIPT_STATUS_LABELS,
+  DEFAULT_TRANSCRIPT_STATUS,
+  MAX_TRANSCRIPT_TEXT_BYTES,
+} from "constants/transcribe";
+
+import css from "./TranscriptionPanel.module.css";
+
+// Per-page transcription editor rendered under the IIIF viewer on the Transcribe local.
+// It follows the viewer's current canvas: one <textarea> + status picker + Save, keyed to
+// the canvas the user is looking at. On open it hydrates every saved unit for the item
+// (GET /api/transcript/{itemId}); Save upserts one canvas (PUT). Drafts are held per
+// canvas in memory so flipping pages never loses unsaved edits.
+//
+// This is a staging-only alpha: there is intentionally no auth on reads or writes yet
+// (the site itself is header-gated). See docs/transcribe/transcription-storage.md.
+
+// Mirror the server's UTF-8 byte check (Buffer.byteLength) in the browser so the byte
+// counter and the Save guard match what the API enforces. TextEncoder is available in
+// every supported browser and in the Node runtime used for SSR.
+const encoder = new TextEncoder();
+function utf8ByteLength(str) {
+  return encoder.encode(str).length;
+}
+
+// The limit label never changes, so format it once at module scope.
+const MAX_BYTES_LABEL = addCommasToNumber(MAX_TRANSCRIPT_TEXT_BYTES);
+
+function formatUpdatedAt(iso) {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleString();
+}
+
+const EMPTY_DRAFT = { text: "", status: DEFAULT_TRANSCRIPT_STATUS };
+
+export default function TranscriptionPanel({ itemId, canvas }) {
+  const canvasId = canvas?.id ?? null;
+
+  // What the server has stored, keyed by canvasId: { text, status, updatedAt }.
+  const [saved, setSaved] = useState({});
+  // Working drafts, keyed by canvasId: { text, status } — preserved across page nav.
+  const [drafts, setDrafts] = useState({});
+  const [loadState, setLoadState] = useState("loading"); // loading | ready | error
+  const [saveState, setSaveState] = useState("idle"); // idle | saving | error
+  const [saveError, setSaveError] = useState(null);
+
+  const savingRef = useRef(false);
+  const loadTokenRef = useRef(0);
+
+  // Hydrate all saved units whenever the item changes. A load token guards against a
+  // stale in-flight response overwriting state after the itemId has moved on.
+  useEffect(() => {
+    if (!itemId) return;
+    const token = ++loadTokenRef.current;
+    setLoadState("loading");
+    (async () => {
+      try {
+        const res = await fetch(
+          `/api/transcript/${encodeURIComponent(itemId)}`,
+        );
+        if (!res.ok) throw new Error(`load failed: ${res.status}`);
+        const data = await res.json();
+        if (token !== loadTokenRef.current) return;
+        const savedMap = {};
+        const draftMap = {};
+        for (const unit of data.units || []) {
+          if (!unit.canvasId) continue;
+          const text = unit.text ?? "";
+          const status = unit.status ?? DEFAULT_TRANSCRIPT_STATUS;
+          savedMap[unit.canvasId] = {
+            text,
+            status,
+            updatedAt: unit.updatedAt ?? null,
+          };
+          draftMap[unit.canvasId] = { text, status };
+        }
+        setSaved(savedMap);
+        setDrafts(draftMap);
+        setLoadState("ready");
+      } catch (err) {
+        if (token !== loadTokenRef.current) return;
+        console.warn(
+          "Transcription: could not load transcripts.",
+          err?.message ?? err,
+        );
+        setLoadState("error");
+      }
+    })();
+  }, [itemId]);
+
+  // Clear the transient save indicator when the user navigates to another page.
+  useEffect(() => {
+    setSaveState("idle");
+    setSaveError(null);
+  }, [canvasId]);
+
+  const draft = (canvasId && drafts[canvasId]) || EMPTY_DRAFT;
+  const savedForCanvas = (canvasId && saved[canvasId]) || null;
+  const { text, status } = draft;
+
+  const byteLength = useMemo(() => utf8ByteLength(text), [text]);
+  const overLimit = byteLength > MAX_TRANSCRIPT_TEXT_BYTES;
+  const dirty = savedForCanvas
+    ? text !== savedForCanvas.text || status !== savedForCanvas.status
+    : text.trim() !== "" || status !== DEFAULT_TRANSCRIPT_STATUS;
+
+  const updateDraft = useCallback(
+    (patch) => {
+      if (!canvasId) return;
+      setDrafts((prev) => ({
+        ...prev,
+        [canvasId]: { ...EMPTY_DRAFT, ...prev[canvasId], ...patch },
+      }));
+      // A fresh edit invalidates the "Saved ✓" indicator.
+      setSaveState("idle");
+      setSaveError(null);
+    },
+    [canvasId],
+  );
+
+  const handleSave = useCallback(async () => {
+    if (!canvasId || savingRef.current || overLimit) return;
+    savingRef.current = true;
+    setSaveState("saving");
+    setSaveError(null);
+    try {
+      const res = await fetch(
+        `/api/transcript/${encodeURIComponent(itemId)}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ canvasId, text, status }),
+        },
+      );
+      if (!res.ok) {
+        let message = `save failed: ${res.status}`;
+        try {
+          const body = await res.json();
+          if (body?.error) message = body.error;
+        } catch {
+          /* non-JSON error body — keep the status-code message */
+        }
+        throw new Error(message);
+      }
+      const result = await res.json();
+      setSaved((prev) => ({
+        ...prev,
+        [canvasId]: { text, status, updatedAt: result?.updatedAt ?? null },
+      }));
+      // Saved and no longer dirty → the render shows "Saved ✓" from that fact alone,
+      // so there is no distinct "saved" state value to track.
+      setSaveState("idle");
+    } catch (err) {
+      console.warn("Transcription: save failed.", err?.message ?? err);
+      setSaveError(err?.message || "Save failed.");
+      setSaveState("error");
+    } finally {
+      savingRef.current = false;
+    }
+  }, [canvasId, itemId, text, status, overLimit]);
+
+  // A page with no canvas @id in the manifest can't be addressed by the store.
+  if (!canvasId) {
+    return (
+      <section className={css.panel} aria-label="Transcription">
+        <p className={css.note}>
+          This page can’t be transcribed — the manifest doesn’t give it a canvas
+          identifier.
+        </p>
+      </section>
+    );
+  }
+
+  const loading = loadState === "loading";
+  const saving = saveState === "saving";
+
+  let saveMessage = null;
+  let saveMessageClass = css.saveStatus;
+  if (saveState === "error") {
+    saveMessage = saveError || "Save failed.";
+    saveMessageClass = `${css.saveStatus} ${css.saveStatusError}`;
+  } else if (dirty) {
+    saveMessage = "Unsaved changes";
+  } else if (savedForCanvas) {
+    saveMessage = "Saved ✓";
+    saveMessageClass = `${css.saveStatus} ${css.saveStatusSaved}`;
+  }
+
+  const updatedAt = savedForCanvas?.updatedAt
+    ? formatUpdatedAt(savedForCanvas.updatedAt)
+    : null;
+
+  return (
+    <section className={css.panel} aria-label="Transcription">
+      <div className={css.header}>
+        <h3 className={css.heading}>Transcribe this page</h3>
+        {canvas?.label && <span className={css.pageRef}>{canvas.label}</span>}
+      </div>
+
+      <p className={css.help}>
+        Type what you can read on the page shown above, choose a status, and save.
+        Transcriptions are public and unversioned while the site is in alpha.
+      </p>
+
+      {loadState === "error" && (
+        <p className={`${css.note} ${css.noteError}`} role="alert">
+          Existing transcriptions couldn’t be loaded. You can still type and save
+          below, but earlier work may not be shown.
+        </p>
+      )}
+
+      <label className={css.fieldLabel} htmlFor="transcript-text">
+        Transcription
+      </label>
+      <textarea
+        id="transcript-text"
+        className={css.textarea}
+        value={text}
+        onChange={(event) => updateDraft({ text: event.target.value })}
+        placeholder="Type what you see on this page…"
+        rows={10}
+        spellCheck
+        disabled={loading}
+      />
+
+      <div className={css.controls}>
+        <div className={css.statusField}>
+          <label className={css.fieldLabel} htmlFor="transcript-status">
+            Status
+          </label>
+          <select
+            id="transcript-status"
+            className={css.select}
+            value={status}
+            onChange={(event) => updateDraft({ status: event.target.value })}
+            disabled={loading}
+          >
+            {TRANSCRIPT_STATUSES.map((value) => (
+              <option key={value} value={value}>
+                {TRANSCRIPT_STATUS_LABELS[value] ?? value}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <button
+          type="button"
+          className={css.saveButton}
+          onClick={handleSave}
+          disabled={saving || overLimit || loading || !dirty}
+        >
+          {saving ? "Saving…" : "Save"}
+        </button>
+
+        {saveMessage && (
+          <span className={saveMessageClass} role="status" aria-live="polite">
+            {saveMessage}
+          </span>
+        )}
+      </div>
+
+      <div className={css.meta}>
+        <span className={overLimit ? css.countOver : css.count}>
+          {addCommasToNumber(byteLength)} / {MAX_BYTES_LABEL} bytes
+          {overLimit && " — too long to save"}
+        </span>
+        {updatedAt && (
+          <span className={css.updatedAt}>Last saved {updatedAt}</span>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/components/ItemComponents/Content/IIIFViewer/TranscriptionPanel.module.css
+++ b/components/ItemComponents/Content/IIIFViewer/TranscriptionPanel.module.css
@@ -1,0 +1,160 @@
+.panel {
+  margin-top: 1rem;
+  padding: 1rem;
+  border: 1px solid var(--darkBorderColor, #d4d4d4);
+  border-radius: 2px;
+  background: var(--warmerBackgroundColor, #fafafa);
+}
+
+.header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.heading {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--headingColor, #333);
+}
+
+.pageRef {
+  font-size: 0.85rem;
+  color: var(--headingColor, #555);
+  opacity: 0.8;
+}
+
+.help {
+  margin: 0.35rem 0 0.75rem;
+  font-size: 0.85rem;
+  color: var(--headingColor, #555);
+}
+
+.fieldLabel {
+  display: block;
+  margin-bottom: 0.25rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--headingColor, #333);
+}
+
+.textarea {
+  width: 100%;
+  min-height: 12rem;
+  padding: 0.6rem;
+  border: 1px solid var(--darkBorderColor, #ccc);
+  border-radius: 2px;
+  background: #fff;
+  color: var(--headingColor, #222);
+  font-family: inherit;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  resize: vertical;
+  box-sizing: border-box;
+}
+
+.textarea:focus {
+  outline: 2px solid var(--linkColor, #2b67ac);
+  outline-offset: 1px;
+}
+
+.textarea:disabled {
+  background: #f2f2f2;
+  color: #888;
+}
+
+.controls {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-top: 0.75rem;
+}
+
+.statusField {
+  display: flex;
+  flex-direction: column;
+}
+
+.select {
+  min-width: 12rem;
+  height: 2.25rem;
+  padding: 0 0.5rem;
+  border: 1px solid var(--darkBorderColor, #ccc);
+  border-radius: 2px;
+  background: #fff;
+  color: var(--headingColor, #222);
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.saveButton {
+  height: 2.25rem;
+  padding: 0 1.25rem;
+  border: 1px solid var(--linkColor, #2b67ac);
+  border-radius: 2px;
+  background: var(--linkColor, #2b67ac);
+  color: #fff;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.saveButton:hover:not(:disabled) {
+  filter: brightness(0.94);
+}
+
+.saveButton:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.saveStatus {
+  font-size: 0.85rem;
+  color: var(--headingColor, #555);
+}
+
+.saveStatusSaved {
+  color: #1a7f37;
+  font-weight: 600;
+}
+
+.saveStatusError {
+  color: #b3261e;
+  font-weight: 600;
+}
+
+.meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
+  font-size: 0.8rem;
+  color: var(--headingColor, #666);
+}
+
+.count {
+  color: var(--headingColor, #666);
+}
+
+.countOver {
+  color: #b3261e;
+  font-weight: 600;
+}
+
+.updatedAt {
+  color: var(--headingColor, #666);
+}
+
+.note {
+  margin: 0.5rem 0 0;
+  font-size: 0.85rem;
+  color: var(--headingColor, #555);
+}
+
+.noteError {
+  color: #b3261e;
+}

--- a/components/ItemComponents/Content/IIIFViewer/index.js
+++ b/components/ItemComponents/Content/IIIFViewer/index.js
@@ -1,5 +1,7 @@
 import React from "react";
 
+import TranscriptionPanel from "./TranscriptionPanel";
+
 import css from "./IIIFViewer.module.css";
 
 // Full-image page viewer for items that carry a IIIF manifest. Fetches the parsed
@@ -159,6 +161,13 @@ export default class IIIFViewer extends React.Component {
           <p className={css.pageStatus}>
             Page {currentPage + 1} of {canvases.length}
           </p>
+        )}
+
+        {status === "ready" && canvases[currentPage] && (
+          <TranscriptionPanel
+            itemId={this.props.itemId}
+            canvas={canvases[currentPage]}
+          />
         )}
       </div>
     );

--- a/constants/transcribe.js
+++ b/constants/transcribe.js
@@ -11,6 +11,17 @@ export const TRANSCRIPT_STATUSES = [
   "illegible",
 ];
 
+// Human-readable labels for the status picker. Keyed by the enum values above.
+export const TRANSCRIPT_STATUS_LABELS = {
+  in_progress: "In progress",
+  complete: "Complete",
+  nothing_to_transcribe: "Nothing to transcribe",
+  illegible: "Illegible / can't read",
+};
+
+// The status a freshly-opened (not-yet-saved) page defaults to in the picker.
+export const DEFAULT_TRANSCRIPT_STATUS = "in_progress";
+
 // Max transcript size, measured in UTF-8 *bytes* (not characters) since that is what
 // DynamoDB's 400 KB per-item limit counts. Kept below 400 KB to leave headroom for the
 // item's other attributes (keys, status, timestamps, canvas_id).


### PR DESCRIPTION
## What this adds

The transcription **editing UI** for the Transcribe local, wired to the save/load
API from #1570. It renders inside `IIIFViewer` (which `MainMetadata` already gates
to `NEXT_PUBLIC_LOCAL_ID === "transcribe"` + `item.iiifManifest`), so it appears
only on Transcribe and follows the viewer's current canvas automatically.

Per page (canvas):

- A **`<textarea>`**, a **status `<select>`** — In progress / Complete / Nothing to
  transcribe / Illegible — and a **Save** button, keyed to the canvas on screen.
- On open, it hydrates **every** saved unit for the item (`GET /api/transcript/{itemId}`).
  **Save** upserts one canvas (`PUT`). Drafts are held **per canvas in memory**, so
  flipping pages in the viewer never loses unsaved edits.
- A UTF-8 **byte counter** mirrors the server's limit. **Save** is disabled while
  loading, while saving, when over the limit, or when there are no unsaved changes;
  an in-flight ref guard prevents concurrent saves. Save/error/"Saved ✓"/"Unsaved
  changes" states are surfaced inline.

Client-safe `TRANSCRIPT_STATUS_LABELS` + `DEFAULT_TRANSCRIPT_STATUS` live in
`constants/transcribe.js` next to the existing enum.

## Security / scope

No auth on reads or writes yet — **intentional** for this header-gated staging
alpha (the site sits behind the baggins ALB `DPLA_INTERNAL_ACCESS` gate). A per-IP /
token limiter is required before any public exposure. See
`docs/transcribe/transcription-storage.md`.

## Backend status

The #1570 backend is **merged, deployed, and smoke-tested** on staging:
`transcribe-transcripts` DynamoDB table + task-role IAM policy + `TRANSCRIBE_TABLE_NAME`
env are live on `local-transcribe:2`. A curl round-trip against
`transcribe-internal.dp.la/api/transcript/{itemId}` (GET → PUT → GET) confirmed a
write persists and reads back. So this PR only needs the image rebuilt to ship the UI.

## Test plan

- [ ] On a Transcribe item that has a IIIF manifest, the **"Transcribe this page"**
      panel appears under the page viewer.
- [ ] Type text, choose a status, **Save** → indicator shows **"Saved ✓"**; reload the
      page → the text and status are still there.
- [ ] Change the text after saving → indicator shows **"Unsaved changes"**; Save
      re-enables.
- [ ] Multi-page item: navigating pages swaps the textarea to that canvas's transcript;
      unsaved edits typed on one page are still there after flipping away and back.
- [ ] A page/item with no saved transcript shows an empty textarea with status
      defaulting to **In progress**.
- [ ] (Server-verified, needs staging access) `GET`/`PUT` round-trip via
      `transcribe-internal.dp.la` — already confirmed by curl.

## Deferred (tracked here, not on the issue tracker)

- Auth / attribution on writes; per-IP or token **rate limiting** before public exposure.
- An explicit "experimental — data may be wiped" notice in the UI.
- Sub-canvas regions and timed-media (A/V) segment units (the storage schema already
  supports them; the UI is whole-canvas only for v1).
- Autosave / drafts persistence beyond the in-memory per-session drafts.
- Version history, moderation, and export back to providers.

Depends on #1570 (merged).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds a transcription editing panel beneath the IIIF viewer for Transcribe items with IIIF manifests.
- Supports per-canvas text drafts, status selection, UTF-8 byte counts, size validation, saving, and inline loading, saved, unsaved, and error states.
- Loads saved transcripts through the existing API and saves each canvas with `PUT`.
- Retains unsaved drafts while users navigate between canvases.
- Adds shared status labels and the default `"in_progress"` status.

## Deployment and configuration

- No manual pipeline trigger or ECS redeployment is specified.
- No environment variables or AWS Secrets Manager keys change.
- No database migration is included.
- No shared infrastructure configuration changes.
- No new API endpoint or public response shape is added.
- Authentication and rate limiting remain deferred in the staging-only, header-gated environment.
- The frontend depends on the backend deployment from `#1570`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->