### PR TITLE
Add item-level transcription status rollup (per-status counters)

### DIFF
--- a/docs/transcribe/transcription-storage.md
+++ b/docs/transcribe/transcription-storage.md
@@ -79,6 +79,36 @@ units later is **just more rows** — the v1 `canvas#…` records never need re-
 **Status enum:** `in_progress | complete | nothing_to_transcribe | illegible`.
 `not_started` is **implicit** — the absence of a record for that unit.
 
+### Item rollup row (per-status counters)
+
+Alongside an item's unit rows sits **one rollup row** — same PK, reserved
+`unit_key = #item` (it sorts before the `canvas#…` unit keys and can't collide with a
+hashed one). It carries a **counter per status**, so an item's **status set** (the
+distinct statuses it has ≥1 unit in) is a single read — the basis for an item-level
+status facet, since search returns items, not units.
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `record_type` | S | `item_rollup` (distinguishes it from unit rows) |
+| `n_{status}` | N | count of the item's units currently in `{status}` (e.g. `n_complete`) |
+| `updated_at` | S | ISO-8601 UTC of the last write |
+| `schema_version` | N | `1` |
+
+**Maintained on every unit write, not recomputed.** The `PUT` upserts the unit row with
+`ReturnValues=ALL_OLD` to learn the status it replaced, then applies just that delta to
+the rollup with atomic `ADD` (`+new`, `−old`) — so concurrent writes to *different* units
+of the same item compose correctly, and re-saving the same status is a no-op. The unit
+rows are the source of truth; the rollup is a derived aggregate that
+`scripts/backfill-transcript-rollups.mjs` can rebuild from them at any time (it also does
+the one-time backfill).
+
+**Rollup rows exist only for *touched* items.** `not_started` / "untranscribed" is still
+the absence of any row for the item — its **count** is `iiif-corpus total (from ES) −
+touched items (from DynamoDB)`, and a work-queue can hand out untranscribed items by
+sampling the corpus; neither needs a per-item placeholder. (Materializing an
+`untranscribed` default per corpus item is possible but is a near-whole-corpus copy —
+deferred.)
+
 ## API contract
 
 Two same-origin Next API routes on the Transcribe app (behind the alpha header gate).
@@ -93,6 +123,7 @@ later:
 ```json
 {
   "itemId": "0123…",
+  "itemStatus": ["complete", "in_progress"],
   "units": [
     { "unitKey": "canvas#3b1f…", "unitType": "canvas",
       "canvasId": "https://…/canvas/1", "text": "…", "status": "complete",    "updatedAt": "2026-…" },
@@ -101,16 +132,17 @@ later:
   ]
 }
 ```
-(Future timed/region units appear in the same list with `startMs`/`endMs` or `region`
-fields — additive only.)
+`itemStatus` is the item's status set (from the rollup row, which is filtered out of
+`units`). Future timed/region units appear in the same list with `startMs`/`endMs` or
+`region` fields — additive only.
 
 ### `PUT /api/transcript/{itemId}` — save one unit
 v1 body: `{ "canvasId": "https://…/canvas/2", "text": "…", "status": "in_progress" }`
 → server derives `unit_key = canvas#{sha256 of canvasId}`, stores the raw id in
-`canvas_id`, sets `unit_type = canvas`, upserts one item, and returns
-`{ "unitKey": "…", "canvasId": "…", "status": "…", "updatedAt": "…" }`. Later the
-body gains optional `unitType` / `startMs` / `endMs` / `page` fields to address finer
-units — additive, non-breaking.
+`canvas_id`, sets `unit_type = canvas`, upserts one unit, updates the item rollup, and
+returns `{ "unitKey": "…", "canvasId": "…", "status": "…", "updatedAt": "…",
+"itemStatus": ["…"] }`. Later the body gains optional `unitType` / `startMs` / `endMs` /
+`page` fields to address finer units — additive, non-breaking.
 
 ## How future media types map on (no migration, no breaking change)
 
@@ -119,8 +151,10 @@ units — additive, non-breaking.
   time order — exactly what WebVTT/caption export needs. Just new rows + attributes.
 - **PDF sub-pages / regions:** N unit-records per asset (`pdf#…#page#…`,
   `canvas#…#region#…`), region geometry (`xywh`) as an attribute. One asset, many units.
-- **Per-unit vs asset-level status:** each unit carries its own `status`; an
-  asset-level "done" rollup can be computed or stored under a reserved unit_key later.
+- **Per-unit vs asset-level status:** each unit carries its own `status`; the
+  **item-level** rollup row (above) aggregates them into per-status counters under the
+  reserved `#item` key. A finer asset-level rollup (per PDF, per A/V file) can slot in
+  the same way later.
 
 ## Write-path guards (v1)
 
@@ -138,7 +172,8 @@ A per-IP / token limiter is required **before any public exposure**.
 
 1. DynamoDB table `transcribe-transcripts` (keys above, on-demand).
 2. An IAM policy on the ECS task role (`ecs-tasks-execution-role`) granting
-   `dynamodb:GetItem`, `PutItem`, and `Query` scoped to that table's ARN.
+   `dynamodb:GetItem`, `PutItem`, `UpdateItem`, and `Query` scoped to that table's ARN
+   (`UpdateItem` maintains the rollup counters).
 3. Task-def env: `TRANSCRIBE_TABLE_NAME=transcribe-transcripts`.
 
 ## Deferred / follow-up (tracked on the PR, not the issue tracker)

--- a/docs/transcribe/transcription-storage.md
+++ b/docs/transcribe/transcription-storage.md
@@ -176,6 +176,14 @@ A per-IP / token limiter is required **before any public exposure**.
    (`UpdateItem` maintains the rollup counters).
 3. Task-def env: `TRANSCRIBE_TABLE_NAME=transcribe-transcripts`.
 
+The **backfill script** (`scripts/backfill-transcript-rollups.mjs`) runs separately — as
+an operator, locally, via the AWS CLI's default profile, **not** the task role — and needs
+`dynamodb:Scan` + `PutItem` on the table. The task role deliberately does **not** get
+`Scan`: the app only Query/Get/Put/Update, so keeping `Scan` out preserves least
+privilege. Run the backfill with transcript writes **quiesced** (it recomputes from a
+point-in-time scan and overwrites rollups unconditionally); it is idempotent, so simply
+re-run it if a write landed mid-run.
+
 ## Deferred / follow-up (tracked on the PR, not the issue tracker)
 
 Sub-canvas + timed-media units (schema is ready; logic deferred); rate limiting +

--- a/lib/transcriptRollup.js
+++ b/lib/transcriptRollup.js
@@ -1,0 +1,37 @@
+// Pure helpers for the item-level status rollup. No I/O and no build-time path
+// aliases, so this stays unit-testable under `node --test`. The I/O that reads/writes
+// the rollup row lives in ./transcriptStore. See docs/transcribe/transcription-storage.md.
+
+// Reserved sort key for an item's rollup row — one per item, sitting alongside that
+// item's unit rows under the same partition key. "#" sorts before the "canvas#"/"av#"/
+// "pdf#" unit prefixes and can't be produced by a hashed unit key, so it never collides.
+export const ITEM_ROLLUP_SORT_KEY = "#item";
+
+// `record_type` value marking a rollup row (vs a transcribable unit row).
+export const ITEM_ROLLUP_RECORD_TYPE = "item_rollup";
+
+// The rollup attribute that counts how many of an item's units are currently in a
+// given status, e.g. "n_complete". Per-status counters let a single unit write adjust
+// the rollup by an atomic delta, without re-reading all of the item's units.
+export function statusCountAttr(status) {
+  return `n_${status}`;
+}
+
+// The item's status set: the distinct statuses it currently has at least one unit in.
+// `counters` is a { status: count } object; its key order is preserved, so pass it in
+// the canonical enum order for a stable result.
+export function deriveStatusSet(counters) {
+  return Object.entries(counters)
+    .filter(([, count]) => count > 0)
+    .map(([status]) => status);
+}
+
+// The counter deltas a single unit write causes, as { status: delta }. Moving a unit
+// from one status to another decrements the old and increments the new; a brand-new
+// unit only increments; re-saving the same status changes no counters (an empty delta).
+export function rollupDelta(previousStatus, newStatus) {
+  if (previousStatus === newStatus) return {};
+  const delta = { [newStatus]: 1 };
+  if (previousStatus) delta[previousStatus] = -1;
+  return delta;
+}

--- a/lib/transcriptRollup.test.mjs
+++ b/lib/transcriptRollup.test.mjs
@@ -1,0 +1,49 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  ITEM_ROLLUP_SORT_KEY,
+  statusCountAttr,
+  deriveStatusSet,
+  rollupDelta,
+} from "./transcriptRollup.js";
+
+test("ITEM_ROLLUP_SORT_KEY is stable and cannot collide with a unit key", () => {
+  assert.equal(ITEM_ROLLUP_SORT_KEY, "#item");
+  assert.ok(!ITEM_ROLLUP_SORT_KEY.startsWith("canvas#"));
+});
+
+test("statusCountAttr namespaces the per-status counter attribute", () => {
+  assert.equal(statusCountAttr("complete"), "n_complete");
+  assert.equal(statusCountAttr("in_progress"), "n_in_progress");
+  assert.equal(statusCountAttr("nothing_to_transcribe"), "n_nothing_to_transcribe");
+});
+
+test("deriveStatusSet keeps only positive counts, preserving order", () => {
+  assert.deepEqual(
+    deriveStatusSet({
+      in_progress: 2,
+      complete: 0,
+      nothing_to_transcribe: 1,
+      illegible: 0,
+    }),
+    ["in_progress", "nothing_to_transcribe"],
+  );
+  assert.deepEqual(deriveStatusSet({ in_progress: 0, complete: 0 }), []);
+  assert.deepEqual(deriveStatusSet({}), []);
+});
+
+test("rollupDelta increments the new status", () => {
+  assert.deepEqual(rollupDelta(null, "in_progress"), { in_progress: 1 });
+});
+
+test("rollupDelta moves a unit: +new, -old", () => {
+  assert.deepEqual(rollupDelta("in_progress", "complete"), {
+    complete: 1,
+    in_progress: -1,
+  });
+});
+
+test("rollupDelta is a no-op when the status is unchanged", () => {
+  assert.deepEqual(rollupDelta("complete", "complete"), {});
+});

--- a/lib/transcriptStore.js
+++ b/lib/transcriptStore.js
@@ -76,10 +76,19 @@ export async function putCanvasTranscript({ itemId, canvasId, text, status }) {
   const unitKey = canvasUnitKey(canvasId);
   const updatedAt = new Date().toISOString();
 
-  // Upsert the unit row. ALL_OLD returns the row this write replaced (if any), so we
-  // learn the exact status transition and can adjust the rollup by just that delta.
-  // The unit rows are the source of truth; the rollup is a derived aggregate that a
-  // recompute (scripts/backfill-transcript-rollups.mjs) can always rebuild from them.
+  // Consistency model — the unit PutItem and the rollup UpdateItem are two separate,
+  // NON-transactional writes, deliberately (TransactWriteItems can't return ALL_OLD, so a
+  // transaction would force an extra GetItem on every save just to learn the prior
+  // status). This is sound for a derived, non-authoritative aggregate:
+  //   • Concurrency is safe: DynamoDB serializes single-item PutItems and ALL_OLD returns
+  //     the exact value each write replaced, so concurrent same-unit deltas telescope
+  //     (−old/+new pairs cancel) and the rollup's atomic ADD composes writes across an
+  //     item's different units — the counters stay correct without a lock.
+  //   • The only gap is a *dropped* rollup update: if this PutItem lands but the following
+  //     UpdateItem fails (crash/throttle), the rollup drifts. That is acceptable because
+  //     the unit rows are the source of truth and the rollup is a derived aggregate that
+  //     scripts/backfill-transcript-rollups.mjs recomputes/repairs from them at any time.
+  // ALL_OLD gives us the status this write replaced, so we adjust the rollup by that delta.
   const putOut = await dynamoRequest("PutItem", {
     TableName: tableName(),
     Item: {

--- a/lib/transcriptStore.js
+++ b/lib/transcriptStore.js
@@ -1,11 +1,21 @@
 // DynamoDB data-access for transcription units. Each row is one transcribable unit:
 // PK = dpla_item_id, SK = unit_key (v1: canvas#{sha256 of canvasId}); the raw canvas @id
-// is kept in the canvas_id attribute. Non-key attributes are schemaless, so timed/region
-// units slot in later without migration. Uses the dependency-free SigV4 client in
-// ./dynamodbClient. See docs/transcribe/transcription-storage.md.
+// is kept in the canvas_id attribute. Alongside an item's unit rows sits one **rollup
+// row** (SK = ITEM_ROLLUP_SORT_KEY) holding per-status counters, so the item's overall
+// status set is a single read and can drive an item-level status facet later. Non-key
+// attributes are schemaless, so timed/region units slot in without migration. Uses the
+// dependency-free SigV4 client in ./dynamodbClient. See docs/transcribe/transcription-storage.md.
 
 import { dynamoRequest } from "./dynamodbClient";
 import { canvasUnitKey } from "./transcriptUnitKey";
+import {
+  ITEM_ROLLUP_SORT_KEY,
+  ITEM_ROLLUP_RECORD_TYPE,
+  statusCountAttr,
+  deriveStatusSet,
+  rollupDelta,
+} from "./transcriptRollup";
+import { TRANSCRIPT_STATUSES } from "constants/transcribe";
 
 const SCHEMA_VERSION = 1;
 
@@ -15,11 +25,24 @@ function tableName() {
   return name;
 }
 
-// All transcription units for an item, as a list (see the GET contract). Follows
-// DynamoDB pagination (LastEvaluatedKey) so a large result set isn't truncated at the
-// 1 MB per-Query limit.
+// Read { status: count } for every known status (0 when absent), in enum order so
+// deriveStatusSet yields a stable ordering.
+function countersFromRollup(rollupRow) {
+  const counters = {};
+  for (const status of TRANSCRIPT_STATUSES) {
+    const raw = rollupRow?.[statusCountAttr(status)]?.N;
+    counters[status] = raw ? Number(raw) : 0;
+  }
+  return counters;
+}
+
+// All transcription units for an item (list — see the GET contract) plus the item's
+// rollup status set. Follows DynamoDB pagination (LastEvaluatedKey) so a large result
+// set isn't truncated at the 1 MB per-Query limit. The rollup row is filtered out of
+// `units` — it is not a transcribable unit.
 export async function getTranscriptsForItem(itemId) {
   const units = [];
+  let rollupRow = null;
   let exclusiveStartKey;
   do {
     const out = await dynamoRequest("Query", {
@@ -29,6 +52,10 @@ export async function getTranscriptsForItem(itemId) {
       ...(exclusiveStartKey ? { ExclusiveStartKey: exclusiveStartKey } : {}),
     });
     for (const item of out.Items || []) {
+      if (item.unit_key?.S === ITEM_ROLLUP_SORT_KEY) {
+        rollupRow = item;
+        continue;
+      }
       units.push({
         unitKey: item.unit_key?.S,
         unitType: item.unit_type?.S,
@@ -40,14 +67,20 @@ export async function getTranscriptsForItem(itemId) {
     }
     exclusiveStartKey = out.LastEvaluatedKey;
   } while (exclusiveStartKey);
-  return units;
+  return { units, itemStatus: deriveStatusSet(countersFromRollup(rollupRow)) };
 }
 
-// Upsert one canvas unit's transcript + status. Returns the stored key/status/time.
+// Upsert one canvas unit's transcript + status, and keep the item rollup counters in
+// step. Returns the stored key/status/time plus the item's new status set.
 export async function putCanvasTranscript({ itemId, canvasId, text, status }) {
   const unitKey = canvasUnitKey(canvasId);
   const updatedAt = new Date().toISOString();
-  await dynamoRequest("PutItem", {
+
+  // Upsert the unit row. ALL_OLD returns the row this write replaced (if any), so we
+  // learn the exact status transition and can adjust the rollup by just that delta.
+  // The unit rows are the source of truth; the rollup is a derived aggregate that a
+  // recompute (scripts/backfill-transcript-rollups.mjs) can always rebuild from them.
+  const putOut = await dynamoRequest("PutItem", {
     TableName: tableName(),
     Item: {
       dpla_item_id: { S: itemId },
@@ -59,6 +92,54 @@ export async function putCanvasTranscript({ itemId, canvasId, text, status }) {
       updated_at: { S: updatedAt },
       schema_version: { N: String(SCHEMA_VERSION) },
     },
+    ReturnValues: "ALL_OLD",
   });
-  return { unitKey, canvasId, status, updatedAt };
+  const previousStatus = putOut.Attributes?.status?.S ?? null;
+
+  const rollup = await applyRollupDelta({
+    itemId,
+    previousStatus,
+    newStatus: status,
+    updatedAt,
+  });
+  return { unitKey, canvasId, status, updatedAt, itemStatus: deriveStatusSet(rollup) };
+}
+
+// Apply a unit's status delta to the item rollup row with atomic ADD (so concurrent
+// writes to other units of the same item compose correctly), upserting the row on the
+// item's first unit. Returns the new counters.
+async function applyRollupDelta({ itemId, previousStatus, newStatus, updatedAt }) {
+  const delta = rollupDelta(previousStatus, newStatus);
+
+  const names = { "#u": "updated_at", "#rt": "record_type", "#sv": "schema_version" };
+  const values = {
+    ":u": { S: updatedAt },
+    ":rt": { S: ITEM_ROLLUP_RECORD_TYPE },
+    ":sv": { N: String(SCHEMA_VERSION) },
+  };
+  const addParts = [];
+  Object.entries(delta).forEach(([status, amount], i) => {
+    const nameKey = `#c${i}`;
+    const valueKey = `:d${i}`;
+    names[nameKey] = statusCountAttr(status);
+    values[valueKey] = { N: String(amount) };
+    addParts.push(`${nameKey} ${valueKey}`);
+  });
+
+  const updateExpression =
+    (addParts.length ? `ADD ${addParts.join(", ")} ` : "") +
+    "SET #u = :u, #rt = :rt, #sv = :sv";
+
+  const out = await dynamoRequest("UpdateItem", {
+    TableName: tableName(),
+    Key: {
+      dpla_item_id: { S: itemId },
+      unit_key: { S: ITEM_ROLLUP_SORT_KEY },
+    },
+    UpdateExpression: updateExpression,
+    ExpressionAttributeNames: names,
+    ExpressionAttributeValues: values,
+    ReturnValues: "ALL_NEW",
+  });
+  return countersFromRollup(out.Attributes);
 }

--- a/pages/api/transcript/[itemId].js
+++ b/pages/api/transcript/[itemId].js
@@ -25,9 +25,9 @@ export default async function handler(req, res) {
 
   if (req.method === "GET") {
     try {
-      const units = await getTranscriptsForItem(itemId);
+      const { units, itemStatus } = await getTranscriptsForItem(itemId);
       res.setHeader("Cache-Control", "no-store");
-      res.status(200).json({ itemId, units });
+      res.status(200).json({ itemId, units, itemStatus });
     } catch (err) {
       console.error("Error loading transcripts.", { message: getErrorMessage(err) });
       res.status(502).json({ error: "Could not load transcripts." });

--- a/scripts/backfill-transcript-rollups.mjs
+++ b/scripts/backfill-transcript-rollups.mjs
@@ -1,0 +1,82 @@
+// Backfill / repair the item-level rollup rows in the transcribe-transcripts table.
+//
+// Recomputes each item's per-status counters from its authoritative unit rows and
+// overwrites its rollup row (SK = "#item"). Idempotent — safe to re-run — because it
+// derives everything from the unit rows, so it doubles as a repair tool if an
+// incremental rollup update was ever lost mid-write.
+//
+// Uses the AWS CLI (default profile credentials), not the app's SigV4 client, so it can
+// run locally. Read-only against unit rows; only writes "#item" rollup rows.
+//
+//   node scripts/backfill-transcript-rollups.mjs
+//
+// See docs/transcribe/transcription-storage.md.
+
+import { execFileSync } from "node:child_process";
+
+import {
+  ITEM_ROLLUP_SORT_KEY,
+  ITEM_ROLLUP_RECORD_TYPE,
+  statusCountAttr,
+} from "../lib/transcriptRollup.js";
+
+const TABLE = process.env.TRANSCRIBE_TABLE_NAME || "transcribe-transcripts";
+const REGION = process.env.AWS_REGION || "us-east-1";
+const SCHEMA_VERSION = "1";
+
+// Run an aws CLI command with args passed as an array (no shell — nothing to escape).
+function aws(args) {
+  const out = execFileSync(
+    "aws",
+    [...args, "--region", REGION, "--output", "json"],
+    { encoding: "utf8", maxBuffer: 128 * 1024 * 1024 },
+  );
+  return out.trim() ? JSON.parse(out) : {};
+}
+
+// 1. Scan every row (paginated).
+const rows = [];
+let startKey = null;
+do {
+  const args = ["dynamodb", "scan", "--table-name", TABLE];
+  if (startKey) args.push("--exclusive-start-key", JSON.stringify(startKey));
+  const page = aws(args);
+  rows.push(...(page.Items || []));
+  startKey = page.LastEvaluatedKey || null;
+} while (startKey);
+
+// 2. Group unit rows by item and count statuses (skip existing rollup rows).
+const byItem = new Map();
+for (const row of rows) {
+  if (row.unit_key?.S === ITEM_ROLLUP_SORT_KEY) continue;
+  const itemId = row.dpla_item_id?.S;
+  const status = row.status?.S;
+  const updatedAt = row.updated_at?.S ?? "";
+  if (!itemId || !status) continue;
+  if (!byItem.has(itemId)) byItem.set(itemId, { counts: {}, latest: "" });
+  const rec = byItem.get(itemId);
+  rec.counts[status] = (rec.counts[status] || 0) + 1;
+  if (updatedAt > rec.latest) rec.latest = updatedAt;
+}
+
+// 3. Overwrite each item's rollup row from the recomputed counts.
+let written = 0;
+for (const [itemId, { counts, latest }] of byItem) {
+  const item = {
+    dpla_item_id: { S: itemId },
+    unit_key: { S: ITEM_ROLLUP_SORT_KEY },
+    record_type: { S: ITEM_ROLLUP_RECORD_TYPE },
+    schema_version: { N: SCHEMA_VERSION },
+    updated_at: { S: latest || new Date().toISOString() },
+  };
+  for (const [status, count] of Object.entries(counts)) {
+    item[statusCountAttr(status)] = { N: String(count) };
+  }
+  aws(["dynamodb", "put-item", "--table-name", TABLE, "--item", JSON.stringify(item)]);
+  written += 1;
+  console.log(`  ${itemId}  ${JSON.stringify(counts)}`);
+}
+
+console.log(
+  `Backfilled ${written} item rollup row(s) from ${rows.length} scanned row(s) in ${TABLE}.`,
+);

--- a/scripts/backfill-transcript-rollups.mjs
+++ b/scripts/backfill-transcript-rollups.mjs
@@ -5,8 +5,16 @@
 // derives everything from the unit rows, so it doubles as a repair tool if an
 // incremental rollup update was ever lost mid-write.
 //
-// Uses the AWS CLI (default profile credentials), not the app's SigV4 client, so it can
-// run locally. Read-only against unit rows; only writes "#item" rollup rows.
+// Principal & permissions: run as an operator, locally, via the AWS CLI's default
+// profile — NOT the ECS task role. It needs dynamodb:Scan + PutItem on the table; the
+// task role deliberately does not get Scan (the app only Query/Get/Put/Update), so the
+// backfill's broad read stays out of the runtime least-privilege policy.
+//
+// Run with writes quiesced: it recomputes from a point-in-time scan and overwrites each
+// rollup unconditionally, so a transcript write landing mid-run could be overwritten
+// with a slightly stale count. It is idempotent, so the remedy is simply to re-run it
+// once writes are idle — no fencing / change-replay needed for this coordinated
+// maintenance task on a low-traffic alpha table.
 //
 //   node scripts/backfill-transcript-rollups.mjs
 //
@@ -29,37 +37,39 @@ function aws(args) {
   const out = execFileSync(
     "aws",
     [...args, "--region", REGION, "--output", "json"],
-    { encoding: "utf8", maxBuffer: 128 * 1024 * 1024 },
+    { encoding: "utf8", maxBuffer: 16 * 1024 * 1024 },
   );
   return out.trim() ? JSON.parse(out) : {};
 }
 
-// 1. Scan every row (paginated).
-const rows = [];
+// Scan the table one page at a time and group unit rows by item as we go, so we never
+// hold more than a single ~1 MB page in memory. `--no-paginate` is required: without it
+// the AWS CLI auto-paginates and returns the entire table in one response (which can
+// blow the maxBuffer and makes the LastEvaluatedKey loop dead code). Rollup rows are
+// skipped — only transcribable unit rows feed the counts.
+const byItem = new Map();
+let scanned = 0;
 let startKey = null;
 do {
-  const args = ["dynamodb", "scan", "--table-name", TABLE];
+  const args = ["dynamodb", "scan", "--table-name", TABLE, "--no-paginate"];
   if (startKey) args.push("--exclusive-start-key", JSON.stringify(startKey));
   const page = aws(args);
-  rows.push(...(page.Items || []));
+  for (const row of page.Items || []) {
+    scanned += 1;
+    if (row.unit_key?.S === ITEM_ROLLUP_SORT_KEY) continue;
+    const itemId = row.dpla_item_id?.S;
+    const status = row.status?.S;
+    const updatedAt = row.updated_at?.S ?? "";
+    if (!itemId || !status) continue;
+    if (!byItem.has(itemId)) byItem.set(itemId, { counts: {}, latest: "" });
+    const rec = byItem.get(itemId);
+    rec.counts[status] = (rec.counts[status] || 0) + 1;
+    if (updatedAt > rec.latest) rec.latest = updatedAt;
+  }
   startKey = page.LastEvaluatedKey || null;
 } while (startKey);
 
-// 2. Group unit rows by item and count statuses (skip existing rollup rows).
-const byItem = new Map();
-for (const row of rows) {
-  if (row.unit_key?.S === ITEM_ROLLUP_SORT_KEY) continue;
-  const itemId = row.dpla_item_id?.S;
-  const status = row.status?.S;
-  const updatedAt = row.updated_at?.S ?? "";
-  if (!itemId || !status) continue;
-  if (!byItem.has(itemId)) byItem.set(itemId, { counts: {}, latest: "" });
-  const rec = byItem.get(itemId);
-  rec.counts[status] = (rec.counts[status] || 0) + 1;
-  if (updatedAt > rec.latest) rec.latest = updatedAt;
-}
-
-// 3. Overwrite each item's rollup row from the recomputed counts.
+// Overwrite each item's rollup row from the recomputed counts.
 let written = 0;
 for (const [itemId, { counts, latest }] of byItem) {
   const item = {
@@ -78,5 +88,5 @@ for (const [itemId, { counts, latest }] of byItem) {
 }
 
 console.log(
-  `Backfilled ${written} item rollup row(s) from ${rows.length} scanned row(s) in ${TABLE}.`,
+  `Backfilled ${written} item rollup row(s) from ${scanned} scanned row(s) in ${TABLE}.`,
 );


### PR DESCRIPTION
## What this adds

An **item-level status rollup** for transcriptions. Each item gets one rollup row —
same PK, reserved `unit_key = #item` — holding a **counter per status**
(`n_complete`, `n_in_progress`, `n_nothing_to_transcribe`, `n_illegible`). An item's
overall **status set** (the distinct statuses it has ≥1 unit in) is therefore a single
read. This is the groundwork for an item-level status facet: search returns *items*, but
transcription status lives per-canvas, so we need the rollup to answer "what's this
item's status" without re-scanning its units.

### How it's maintained (per-status counters, on every write)

`putCanvasTranscript` upserts the unit row with `ReturnValues=ALL_OLD` to learn the
status it replaced, then applies **just that delta** to the rollup with an atomic
`UpdateItem ADD` (`+new`, `−old`):

- Concurrent writes to **different** canvases of the same item compose correctly (atomic `ADD`).
- Because DynamoDB serializes single-item writes and `ALL_OLD` returns the exact value each
  write replaced, even concurrent **same-canvas** writes telescope to correct counters.
- Re-saving the same status is a counter no-op.

**Invariant:** the unit rows are the source of truth; the rollup is a *derived aggregate*.
`scripts/backfill-transcript-rollups.mjs` recomputes it from the unit rows, so it doubles
as both the one-time backfill and a repair tool if an incremental update is ever lost
(the write path is two non-transactional calls — `TransactWriteItems` can't return
`ALL_OLD`, so this is the correct trade-off for a non-authoritative status facet).

### API

`getTranscriptsForItem` filters the rollup row out of `units` and returns
`{ units, itemStatus }`. The `GET` and `PUT` responses now include `itemStatus` (the
status set) — additive, non-breaking.

## Files

- `lib/transcriptRollup.js` — pure, `node --test`-able helpers (`ITEM_ROLLUP_SORT_KEY`,
  `ITEM_ROLLUP_RECORD_TYPE`, `statusCountAttr`, `deriveStatusSet`, `rollupDelta`) + tests.
- `lib/transcriptStore.js` — rollup maintenance on write; rollup-aware read.
- `pages/api/transcript/[itemId].js` — `itemStatus` in the GET response.
- `scripts/backfill-transcript-rollups.mjs` — backfill / repair (imports the shared
  constants so it can never drift from the runtime schema).
- `docs/transcribe/transcription-storage.md` — rollup row, `itemStatus`, IAM update.

## Deploy prerequisites (order matters)

1. Merge.
2. Add **`dynamodb:UpdateItem`** to the ECS task-role policy (the rollup write needs it;
   the current policy has only Get/Put/Query).
3. Rebuild + deploy the transcribe image.
4. Run `node scripts/backfill-transcript-rollups.mjs` **once** to populate rollups for the
   existing items (current data → `nothing_to_transcribe×1`, `complete×1`, `in_progress×2`).

## Test plan

- [ ] After deploy + backfill, `GET /api/transcript/{itemId}` returns `itemStatus` for a
      touched item (e.g. the 2-page item → `["in_progress"]`).
- [ ] Save a canvas as `in_progress`, then re-save the same canvas as `complete`; the
      item's rollup shows `n_in_progress` decremented and `n_complete` incremented, and
      `itemStatus` reflects the change.
- [ ] Save two different canvases of one item with different statuses; `itemStatus`
      contains both.
- [ ] Re-running the backfill is idempotent (counters unchanged).

## Notes on scope

Verified locally: unit tests (10), CSP, migration syntax, cross-dir import resolution.
CI runs the user/pro/local builds. Deliberately **not** included (deferred): the GSI /
browse-query layer for the facet, and any "untranscribed" handling (that's `corpus − touched`
by arithmetic, not a stored default — see the data-model doc).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Add item-level transcript status rollups in a reserved `#item` DynamoDB row.
- Add `itemStatus` to GET and PUT transcript responses.
- Add rollup helpers, tests, and a backfill script for repair.
- Update the ECS task role with `dynamodb:UpdateItem`.
- Require operator credentials with `Scan` and `PutItem` permissions for the backfill.
- Deploy or redeploy ECS services for the code and IAM changes to take effect.
- This is not a database schema migration. Rerun the backfill to rebuild derived rollup data.
- Run the backfill with writes quiesced. Rerun it if writes occur during execution.
- No environment variables or AWS Secrets Manager keys change.
- No manual pipeline trigger is specified.
- No authentication changes or new external data inputs are included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->