### PR TITLE
Scope Transcribe local to the iiif tag (was aviation placeholder)

### DIFF
--- a/constants/local.js
+++ b/constants/local.js
@@ -282,8 +282,10 @@ const LOCALS = {
     hasBrowseByPartner: true,
     hasBrowseAll: true,
     hasSidebar: false,
+    // Scope to items with a transcribable IIIF manifest. The `iiif` tag is added at
+    // index time by sparkindexer (ingestion3#763), so it populates on the next reindex.
     tags: [
-      "aviation"
+      "iiif"
     ],
     routes: {
       "/about" : {


### PR DESCRIPTION
## What

Switch the Transcribe local's corpus scoping from the placeholder `aviation` tag to the
`iiif` tag, so Transcribe is scoped to items that actually have a transcribable IIIF
manifest — the intended corpus.

```diff
-    tags: [ "aviation" ],
+    tags: [ "iiif" ],
```

## Dependency + deploy timing (important)

The `iiif` tag is added at **index time** by sparkindexer (`ElasticSearchWriter.addMediaTags`,
ingestion3#763 — merged to sparkindexer `main` via PR #66). It is **not** in the current
Elasticsearch index; it populates on the **next reindex**.

So: **deploy this only after the reindex lands.** If deployed before, `&tags=iiif` matches
nothing and the Transcribe corpus is empty until the reindex. (The frontend renders
`local.tags` as `&tags=iiif`, same mechanism aviation uses.)

## Verified

`constants/local.js` loads and `LOCALS.transcribe.tags === ["iiif"]`.

## ⚠️ Heads-up on the sparkindexer side (separate repo, not this PR)

While verifying the tag implementation I think I found a latent bug in
`ElasticSearchWriter.addMediaTags` worth a look before the reindex — flagged separately;
it does not affect Transcribe's own corpus but could affect other tag-scoped locals
(e.g. aviation). Details in the review conversation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Changes the Transcribe corpus tag from `aviation` to `iiif`.
- Limits results to items with transcribable IIIF manifests.
- The tag will populate during the next Elasticsearch reindex.

## Deployment

- Complete the Elasticsearch reindex before deployment.
- Deploy the change after the reindex.
- An ECS redeployment is required for the configuration change to take effect.
- The corpus remains empty until the `iiif` tag is available.

## Impact

- No environment variables or AWS Secrets Manager keys changed.
- No database migration included.
- No shared infrastructure configuration changed.
- No public API response shape or endpoint changed.
- No security implications identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->