### PR TITLE
Add Our Partners links to pro and user site header navs

### DIFF
--- a/components/MainLayout/components/shared/NavigationPro.js
+++ b/components/MainLayout/components/shared/NavigationPro.js
@@ -24,6 +24,9 @@ function NavigationPro({ isHome, className, css }) {
           <Link href="/about-dpla-pro">About</Link>
         </li>
         <li>
+          <Link href="/hubs/our-partners">Our Partners</Link>
+        </li>
+        <li>
           <Link href="/events">Events</Link>
         </li>
       </ul>

--- a/components/MainLayout/components/shared/NavigationUser.js
+++ b/components/MainLayout/components/shared/NavigationUser.js
@@ -33,17 +33,17 @@ function NavigationUser({ isHome, className, css }) {
             Primary Source Sets
           </Link>
         </li>
-        <li>
-          <Link href="/lists" data-cy="my-lists">
-            My Lists
-          </Link>
-        </li>
       </ul>
       <span className={css.divider} />
       <ul className={`${css.links} ${css.secondaryLinks}`}>
         <li>
           <Link href="/about" data-cy="about-dpla">
             About DPLA
+          </Link>
+        </li>
+        <li>
+          <Link href="/about/our-partners" data-cy="our-partners">
+            Our Partners
           </Link>
         </li>
         <li>


### PR DESCRIPTION
## Summary
- Adds an "Our Partners" link to the pro.dp.la header navigation, between About and Events, pointing to the existing [/hubs/our-partners](https://pro.dp.la/hubs/our-partners) page.
- Adds an "Our Partners" link to the dp.la header navigation, between About DPLA and News, pointing to the new [/about/our-partners](https://dp.la/about/our-partners) page.
- Removes the "My Lists" link from the dp.la header to keep it from getting too long. The /lists feature is unchanged and remains reachable via the footer (and local-site headers are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added “Our Partners” to the pro.dp.la header. It links to `/hubs/our-partners`.
- Added “Our Partners” to the dp.la header. It links to `/about/our-partners`.
- Removed the “My Lists” header link. The `/lists` feature remains available in the footer.
- Local-site headers remain unchanged.

## Operational impact

- No manual pipeline trigger or ECS redeployment is required beyond the normal application deployment.
- No environment variables or AWS Secrets Manager keys changed.
- No database migration included.
- No shared infrastructure configuration changed.
- No public API response shape or endpoint changed.
- No security implications identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->