### PR TITLE
Fix blank initial render of PSS/exhibition image viewer under OpenSeadragon 6

### DIFF
--- a/components/shared/mediaViewers/ZoomableImageViewer.js
+++ b/components/shared/mediaViewers/ZoomableImageViewer.js
@@ -25,6 +25,10 @@ export default class ZoomableImageViewer extends React.Component {
         const url = this.props.pathToFile;
         this.viewer = new OpenSeaDragon({
           element: this.containerRef.current,
+          // OSD 6's default WebGL drawer renders blank (until an interaction
+          // forces a redraw) for cross-origin images served without CORS
+          // headers, as these are — see IIIFViewer for the full rationale.
+          drawer: "canvas",
           tileSources: {type: "image", url},
           prefixUrl: "/static/images/openseadragon/",
         });


### PR DESCRIPTION
## Problem

Primary Source Set source pages (e.g. [this one](https://dp.la/primary-source-sets/treaty-of-versailles-and-the-end-of-world-war-i/sources/1897)) render a blank image viewer on load, with a console error:

```
Error creating texture in WebGL. undefined
```

The image only appears after the user pans/zooms (an interaction forces a redraw through OSD's canvas fallback).

## Cause

Since the upgrade to OpenSeadragon 6, the default drawer is WebGL. WebGL textures require CORS-clean images, but PSS (and exhibition) images are served cross-origin from CloudFront (`d2jf00asb0fe6y.cloudfront.net`) with no `Access-Control-Allow-Origin` header. The texture upload throws `SecurityError: ... The image element contains cross-origin data` (verified against the live page), leaving the first frame blank.

This is the same bug already fixed in `IIIFViewer` (`drawer: "canvas"`), but `ZoomableImageViewer` — used by PSS source pages and exhibitions — was missed.

## Fix

Add `drawer: "canvas"` to the OpenSeadragon options in `ZoomableImageViewer`. The canvas 2D drawer displays cross-origin images regardless of CORS, and performance is a non-issue for a single static image.

A repo-wide scan (and a scan of black-womens-suffrage) found no other OpenSeadragon call sites or first-party canvas/WebGL image drawing affected by this pattern — these two viewers were the only instances.

## Testing

- Pre-commit test suite: 45/45 pass
- Verified the failure mechanism against production with a live WebGL texture-upload test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Configure `ZoomableImageViewer` to use OpenSeadragon’s Canvas drawer.
- Prevent blank initial renders for cross-origin CloudFront images after the OpenSeadragon 6 upgrade.
- Pre-commit tests pass: 45/45.

## Operational impact

- No manual pipeline trigger or ECS redeployment is identified.
- No environment variables or AWS Secrets Manager keys change.
- No database migration is included.
- No shared infrastructure configuration changes.
- No public API response shape or endpoint changes.
- No security changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->