### PR TITLE
fix: correct content-page heading scale for h4/h5/h6

### DIFF
--- a/stylesheets/content-pages.module.css
+++ b/stylesheets/content-pages.module.css
@@ -98,14 +98,22 @@
   & h4,
   & h5,
   & h6 {
+    font-weight: normal;
     line-height: 1.15;
     margin-bottom: 1rem;
     margin-top: 1rem;
   }
 
+  & h2,
+  & h3,
+  & h4,
+  & h5,
+  & h6 {
+    font-family: var(--sansFont), sans-serif;
+  }
+
   & h1 {
     font-family: var(--serifFont), serif;
-    font-weight: normal;
     font-size: 2rem;
     margin-bottom: 1rem;
     margin-top: 0;
@@ -121,30 +129,25 @@
   }
 
   & h2 {
-    font-family: var(--sansFont), sans-serif;
     font-size: 1.75rem;
-    font-weight: normal;
     margin-top: 2.5rem;
   }
 
   & h3 {
     font-size: 1.25rem;
-    font-weight: normal;
-    font-family: var(--sansFont), sans-serif;
   }
 
   & h4 {
-    font-size: 1.5rem;
+    font-size: 1.125rem;
   }
 
   & h5 {
-    font-size: 1.125rem;
+    font-size: 1rem;
     text-transform: uppercase;
-    font-weight: normal;
   }
 
   & h6 {
-    font-size: 1.25rem;
+    font-size: 1rem;
   }
 
   & p {


### PR DESCRIPTION
## Problem

In `stylesheets/content-pages.module.css`, the `.content` heading scale is non-monotonic and inconsistently declared:

| | size | weight | family |
|---|---|---|---|
| h1 | 3rem | 400 | serif *(intentional)* |
| h2 | 1.75rem | 400 | sans |
| h3 | 1.25rem | 400 | sans |
| **h4** | **1.5rem** | **700** | **serif** |
| h5 | 1.125rem | 400 | serif |
| **h6** | **1.25rem** | **700** | **serif** |

Three separate defects, all on the levels that declare the fewest properties:

1. **Size out of order.** `h4` (1.5rem) and `h6` (1.25rem) are both `>=` `h3` (1.25rem), so a sub-subheading renders as large as or larger than the heading above it.
2. **Weight.** `h4` and `h6` never declare `font-weight`, so they fall back to the UA default `bold` while h2/h3/h5 are `normal`.
3. **Family.** Only h1/h2/h3 declare `font-family`, so h4/h5/h6 inherit the serif stack from the `.content` container instead of the sans stack used by h2/h3.

Origin is cbaaf344 (2018-03-05), which set these three sizes and added `font-weight: normal` to h5 but not to its two neighbours, and never checked the sizes against h3.

This surfaced on `pro.dp.la/events/workshops`, where event date lines marked up as `h4` rendered larger and bolder than the `h3` event titles above them.

## Approach

Repeating the shared declarations on every level is what allowed h4/h6 to be missed, so rather than patch each level individually this hoists them:

- `font-weight: normal` moves into the existing `h1`–`h6` group — a no-op for h1/h2/h3/h5, which already declared it, and supplies it for h4/h6
- `font-family: var(--sansFont), sans-serif` moves into a new `h2`–`h6` group
- each level now declares only its own `font-size` (plus h5's `text-transform`)

Resulting scale descends monotonically: **3 / 1.75 / 1.25 / 1.125 / 1 / 1rem**. h5 and h6 tie at 1rem, differentiated by h5's uppercase.

## Verification

Computed values measured in-browser on `pro.dp.la` with the patch injected over the deployed stylesheet:

| | deployed | this PR |
|---|---|---|
| h1 | 32px w400 serif | 32px w400 serif — unchanged |
| h2 | 28px w400 sans | 28px w400 sans — unchanged |
| h3 | 20px w400 sans | 20px w400 sans — unchanged |
| **h4** | 24px w700 serif | **18px w400 sans** |
| h5 | 18px w400 serif | 16px w400 sans |
| **h6** | 20px w700 serif | 16px w400 sans |

h1/h2/h3 are byte-identical before and after, confirming the hoist introduces no regression. (h1 reads 32px because the probe viewport was under the 52em breakpoint; it is unchanged either way.)

Also confirmed: `--sansFont` is a global `:root` var in `stylesheets/typography.css`; `reset.css` sets only margin/padding on headings (so the bold really is the UA default); and no other stylesheet declares `h4`/`h5`/`h6` sizes. `prettier --check` clean, `npm test` 45/45.

## Blast radius

Small. Across the whole CMS (95 pages, 1,134 posts):

- **h5: 0 blocks, h6: 0 blocks** — those two changes are purely preventative
- **h4: 31 blocks across 14 items** — 2 pages (`dpla-wikimedia`, `harmful-language-statement`) and 12 posts. These currently render larger than the heading above them, so this is a correction rather than a regression.

## Possible follow-up (not in this PR)

`h1` carries a nested `& b { font-weight: normal }` to neutralise inline bold. The same guard does not exist for h2–h6, so an editor wrapping heading text in `<strong>` in the CMS silently overrides the theme's `normal` weight — which is exactly what was making some event titles on the workshops page render bold while identical-level siblings did not. Generalising that guard to all heading levels would prevent it at the CSS layer, but it changes intent (it would make inline bold in headings impossible), so I left it for a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Corrects content-page heading sizes for `h4`, `h5`, and `h6`.
- Applies normal weight to all headings.
- Applies the sans-serif font stack to `h2`–`h6`.
- Sets heading sizes to `3 / 1.75 / 1.25 / 1.125 / 1 / 1rem`.
- Preserves uppercase text for `h5`.
- Leaves `h1`–`h3` unchanged.
- `prettier --check` passes.
- All 45 tests pass.

## Scope

- No manual pipeline trigger or ECS redeployment is required.
- No environment variables or AWS Secrets Manager keys changed.
- No database migration included.
- No shared infrastructure configuration changed.
- No public-facing API response shape or endpoint changed.
- No security implications identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->