### PR TITLE
fix: scope request body parsing so transcript PUTs aren't capped at 100kb

### DIFF
--- a/constants/transcribe.js
+++ b/constants/transcribe.js
@@ -27,3 +27,12 @@ export const DEFAULT_TRANSCRIPT_STATUS = "in_progress";
 // item's other attributes (keys, status, timestamps, canvas_id).
 export const MAX_TRANSCRIPT_TEXT_BYTES = 380_000;
 export const MAX_CANVAS_ID_CHARS = 2048;
+
+// Wire-size ceiling for a transcript PUT body (the route's bodyParser sizeLimit). Twice
+// the text cap, because that is the worst case for ordinary text once JSON-escaped — a
+// newline, quote or backslash each cost two bytes on the wire — plus room for the
+// canvasId and status fields. Derived rather than hardcoded so that raising the text cap
+// can't leave the parser as the binding constraint: the text cap must stay enforced by
+// the route's own byte check, which returns a clear JSON 413, not by the parser, whose
+// 413 carries no explanation.
+export const MAX_TRANSCRIPT_REQUEST_BYTES = MAX_TRANSCRIPT_TEXT_BYTES * 2;

--- a/constants/transcribe.js
+++ b/constants/transcribe.js
@@ -29,10 +29,13 @@ export const MAX_TRANSCRIPT_TEXT_BYTES = 380_000;
 export const MAX_CANVAS_ID_CHARS = 2048;
 
 // Wire-size ceiling for a transcript PUT body (the route's bodyParser sizeLimit). Twice
-// the text cap, because that is the worst case for ordinary text once JSON-escaped — a
-// newline, quote or backslash each cost two bytes on the wire — plus room for the
-// canvasId and status fields. Derived rather than hardcoded so that raising the text cap
-// can't leave the parser as the binding constraint: the text cap must stay enforced by
-// the route's own byte check, which returns a clear JSON 413, not by the parser, whose
-// 413 carries no explanation.
-export const MAX_TRANSCRIPT_REQUEST_BYTES = MAX_TRANSCRIPT_TEXT_BYTES * 2;
+// the text cap is the worst case for ordinary text once JSON-escaped — a newline, quote
+// or backslash each cost two bytes on the wire — and the extra 8kb covers the rest of the
+// envelope: the keys, the quoting, a max-length canvasId and the status. Derived rather
+// than hardcoded so that raising the text cap can't leave the parser as the binding
+// constraint: the text cap must stay enforced by the route's own byte check, which
+// returns a clear JSON 413, not by the parser, whose 413 carries no explanation.
+//
+// Next statically analyses `export const config`, so the route cannot import this and
+// repeats the number as a literal. lib/transcriptRequestLimit.test.mjs keeps them in sync.
+export const MAX_TRANSCRIPT_REQUEST_BYTES = MAX_TRANSCRIPT_TEXT_BYTES * 2 + 8_192;

--- a/docs/transcribe/transcription-storage.md
+++ b/docs/transcribe/transcription-storage.md
@@ -165,6 +165,20 @@ Enforced server-side in the `PUT` handler:
 - `text` ≤ 380 000 **UTF-8 bytes** (`Buffer.byteLength`, not char count — headroom under DynamoDB's 400 KB item limit); else 413.
 - Text stored **verbatim** and rendered as text in the UI → no HTML/JS injection surface.
 
+Outside the handler, the request body itself is capped at `MAX_TRANSCRIPT_REQUEST_BYTES`
+via the route's `config.api.bodyParser.sizeLimit`. That constant is **derived** as
+`MAX_TRANSCRIPT_TEXT_BYTES * 2` — twice the text cap is the worst case for ordinary text
+once JSON-escaped — so raising the text cap can't silently leave the parser as the
+binding constraint. The headroom matters: an over-long transcript must be rejected by the
+`text` guard above, which returns a clear JSON 413, not by the body parser, whose 413
+carries no explanation.
+
+This only works because `server.js` mounts **no app-level body parser**. An app-level
+parser consumes the request stream before the Next.js catchall runs, so its limit (100 KB
+by default) would silently become the ceiling for this route — and Next would then skip
+its own parsing entirely, since `req.body` is already set. See the comment above
+`expressApp.get("/healthcheck", ...)` in `server.js` before adding one.
+
 **Rate limiting is deferred** — the alpha is header-gated, so abuse exposure is low.
 A per-IP / token limiter is required **before any public exposure**.
 

--- a/docs/transcribe/transcription-storage.md
+++ b/docs/transcribe/transcription-storage.md
@@ -167,9 +167,13 @@ Enforced server-side in the `PUT` handler:
 
 Outside the handler, the request body itself is capped at `MAX_TRANSCRIPT_REQUEST_BYTES`
 via the route's `config.api.bodyParser.sizeLimit`. That constant is **derived** as
-`MAX_TRANSCRIPT_TEXT_BYTES * 2` — twice the text cap is the worst case for ordinary text
-once JSON-escaped — so raising the text cap can't silently leave the parser as the
-binding constraint. The headroom matters: an over-long transcript must be rejected by the
+`MAX_TRANSCRIPT_TEXT_BYTES * 2 + 8_192` — twice the text cap is the worst case for
+ordinary text once JSON-escaped (a newline, quote or backslash each cost two bytes on the
+wire), and the extra 8 KB covers the envelope: keys, quoting, a max-length `canvasId` and
+the status. Deriving it means raising the text cap can't silently leave the parser as the
+binding constraint. Next statically analyses `export const config`, so the route repeats
+the number as a literal; `lib/transcriptRequestLimit.test.mjs` asserts the two match and
+covers the newline-heavy worst case. The headroom matters: an over-long transcript must be rejected by the
 `text` guard above, which returns a clear JSON 413, not by the body parser, whose 413
 carries no explanation.
 

--- a/docs/transcribe/transcription-storage.md
+++ b/docs/transcribe/transcription-storage.md
@@ -162,7 +162,7 @@ Enforced server-side in the `PUT` handler:
 - `itemId` matches the DPLA id regex; else 404.
 - `canvasId` non-empty string ≤ 2048 chars; else 400.
 - `status` ∈ the enum; else 400.
-- `text` ≤ 380 000 **UTF-8 bytes** (`Buffer.byteLength`, not char count — headroom under DynamoDB's 400 KB item limit); else 413.
+- `text` ≤ 380 000 **UTF-8 bytes** (`Buffer.byteLength`, not char count — headroom under DynamoDB's 400 KB item limit); else 413. Subject to the wire-size ceiling below, which binds first for text that JSON-escapes to more than about twice its size.
 - Text stored **verbatim** and rendered as text in the UI → no HTML/JS injection surface.
 
 Outside the handler, the request body itself is capped at `MAX_TRANSCRIPT_REQUEST_BYTES`
@@ -173,9 +173,21 @@ wire), and the extra 8 KB covers the envelope: keys, quoting, a max-length `canv
 the status. Deriving it means raising the text cap can't silently leave the parser as the
 binding constraint. Next statically analyses `export const config`, so the route repeats
 the number as a literal; `lib/transcriptRequestLimit.test.mjs` asserts the two match and
-covers the newline-heavy worst case. The headroom matters: an over-long transcript must be rejected by the
-`text` guard above, which returns a clear JSON 413, not by the body parser, whose 413
-carries no explanation.
+covers the newline-heavy worst case. The headroom matters: an over-long transcript must be
+rejected by the `text` guard above, which returns a clear JSON 413, not by the body
+parser, whose 413 carries no explanation.
+
+**Known boundary.** The 2× multiplier covers ordinary text, where the only characters that
+escape are newlines, quotes and backslashes, at two bytes each. It does **not** cover text
+made largely of control characters, which JSON-escape to `\u00XX` at six bytes each: 380 000
+NUL bytes serialise to 2 280 081 wire bytes, well over the ceiling, so such a request is
+rejected by the parser with a generic 413 rather than by the `text` guard. This is
+deliberate. Covering it would require a ~2.3 MB ceiling, roughly tripling peak per-request
+memory on a route that has no rate limiting or admission control (see **Rate limiting is
+deferred** below), to accommodate input that is not plausible transcription text. Nothing is
+lost or corrupted in that case — the request is refused either way; only the error message
+is less specific. If the handler ever starts rejecting control characters outright, this
+boundary disappears and the contract above becomes exact.
 
 This only works because `server.js` mounts **no app-level body parser**. An app-level
 parser consumes the request stream before the Next.js catchall runs, so its limit (100 KB

--- a/lib/transcriptRequestLimit.test.mjs
+++ b/lib/transcriptRequestLimit.test.mjs
@@ -54,3 +54,19 @@ test("a transcript just over the text cap still reaches the handler", () => {
   });
   assert.ok(Buffer.byteLength(body, "utf8") <= MAX_TRANSCRIPT_REQUEST_BYTES);
 });
+
+// Documents a known, deliberate boundary rather than a bug. Control characters JSON-escape
+// to \u00XX (six bytes each), so text made largely of them exceeds the wire ceiling and is
+// refused by the parser with a generic 413 instead of the handler's specific one. Covering
+// it would need a ~2.3MB ceiling — roughly triple the peak per-request memory on a route
+// with no rate limiting — for input that is not plausible transcription text. If this test
+// ever fails, the multiplier changed: re-read the "Known boundary" note in
+// docs/transcribe/transcription-storage.md and make sure the change was intended.
+test("control-character text exceeds the wire limit (known, documented boundary)", () => {
+  const body = JSON.stringify({
+    canvasId: "https://example.org/iiif/canvas/1",
+    text: "\0".repeat(MAX_TRANSCRIPT_TEXT_BYTES),
+    status: "in_progress",
+  });
+  assert.ok(Buffer.byteLength(body, "utf8") > MAX_TRANSCRIPT_REQUEST_BYTES);
+});

--- a/lib/transcriptRequestLimit.test.mjs
+++ b/lib/transcriptRequestLimit.test.mjs
@@ -1,0 +1,56 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  MAX_TRANSCRIPT_TEXT_BYTES,
+  MAX_TRANSCRIPT_REQUEST_BYTES,
+  MAX_CANVAS_ID_CHARS,
+} from "../constants/transcribe.js";
+
+const routeSource = readFileSync(
+  fileURLToPath(new URL("../pages/api/transcript/[itemId].js", import.meta.url)),
+  "utf8",
+);
+
+// Next statically analyses `export const config`, so the route can't import
+// MAX_TRANSCRIPT_REQUEST_BYTES — it repeats the number as a literal. Without this check
+// the two can drift apart silently.
+test("the transcript route's sizeLimit literal matches MAX_TRANSCRIPT_REQUEST_BYTES", () => {
+  const match = routeSource.match(/sizeLimit:\s*(\d+)/);
+  assert.ok(match, "no numeric sizeLimit literal found in the transcript route");
+  assert.equal(Number(match[1]), MAX_TRANSCRIPT_REQUEST_BYTES);
+});
+
+// The whole point of the headroom: a transcript at exactly the text cap must reach the
+// handler, so the handler's own byte check decides and returns its documented JSON 413,
+// rather than the body parser rejecting it first with an unexplained one. Newlines are
+// the worst case for ordinary text — every byte escapes to two on the wire.
+test("a newline-heavy transcript at the text cap still fits under the wire limit", () => {
+  const text = "\n".repeat(MAX_TRANSCRIPT_TEXT_BYTES);
+  assert.equal(Buffer.byteLength(text, "utf8"), MAX_TRANSCRIPT_TEXT_BYTES);
+
+  const body = JSON.stringify({
+    canvasId: "https://example.org/".padEnd(MAX_CANVAS_ID_CHARS, "x"),
+    text,
+    status: "nothing_to_transcribe", // longest value in TRANSCRIPT_STATUSES
+  });
+
+  const wireBytes = Buffer.byteLength(body, "utf8");
+  assert.ok(
+    wireBytes <= MAX_TRANSCRIPT_REQUEST_BYTES,
+    `worst-case body is ${wireBytes} bytes, over the ${MAX_TRANSCRIPT_REQUEST_BYTES} limit`,
+  );
+});
+
+// A transcript one byte over the text cap must still be small enough on the wire to reach
+// the handler, so the user gets "text exceeds 380000 bytes" and not a bare parser 413.
+test("a transcript just over the text cap still reaches the handler", () => {
+  const body = JSON.stringify({
+    canvasId: "https://example.org/iiif/canvas/1",
+    text: "a".repeat(MAX_TRANSCRIPT_TEXT_BYTES + 1),
+    status: "in_progress",
+  });
+  assert.ok(Buffer.byteLength(body, "utf8") <= MAX_TRANSCRIPT_REQUEST_BYTES);
+});

--- a/pages/api/thumbnail-error.js
+++ b/pages/api/thumbnail-error.js
@@ -1,3 +1,9 @@
+// Public unauthenticated POST. The field caps below total well under 8kb, and the rate
+// limiter can't help here — Next parses the body before the handler runs, so even a
+// request that gets a 429 has already been buffered. Numeric so raw-body skips a
+// bytes.parse per request. Without this the route would inherit Next's 1mb default.
+export const config = { api: { bodyParser: { sizeLimit: 8 * 1024 } } };
+
 const MAX_URL_LENGTH = 2048;
 const MAX_PROVIDER_LENGTH = 256;
 const MAX_SOURCE_URL_LENGTH = 2048;

--- a/pages/api/thumbnail-error.js
+++ b/pages/api/thumbnail-error.js
@@ -2,7 +2,7 @@
 // limiter can't help here — Next parses the body before the handler runs, so even a
 // request that gets a 429 has already been buffered. Numeric so raw-body skips a
 // bytes.parse per request. Without this the route would inherit Next's 1mb default.
-export const config = { api: { bodyParser: { sizeLimit: 8 * 1024 } } };
+export const config = { api: { bodyParser: { sizeLimit: 8192 } } };
 
 const MAX_URL_LENGTH = 2048;
 const MAX_PROVIDER_LENGTH = 256;

--- a/pages/api/transcript/[itemId].js
+++ b/pages/api/transcript/[itemId].js
@@ -6,9 +6,16 @@ import { DPLA_ITEM_ID_REGEX } from "constants/items";
 import {
   TRANSCRIPT_STATUSES,
   MAX_TRANSCRIPT_TEXT_BYTES,
+  MAX_TRANSCRIPT_REQUEST_BYTES,
   MAX_CANVAS_ID_CHARS,
 } from "constants/transcribe";
 import { getTranscriptsForItem, putCanvasTranscript } from "lib/transcriptStore";
+
+// Narrows Next's 1mb default to what this route actually accepts. Only has any effect
+// because server.js mounts no app-level body parser — see the comment there.
+export const config = {
+  api: { bodyParser: { sizeLimit: MAX_TRANSCRIPT_REQUEST_BYTES } },
+};
 
 function getErrorMessage(err) {
   if (err instanceof Error) return err.message;

--- a/pages/api/transcript/[itemId].js
+++ b/pages/api/transcript/[itemId].js
@@ -6,15 +6,17 @@ import { DPLA_ITEM_ID_REGEX } from "constants/items";
 import {
   TRANSCRIPT_STATUSES,
   MAX_TRANSCRIPT_TEXT_BYTES,
-  MAX_TRANSCRIPT_REQUEST_BYTES,
   MAX_CANVAS_ID_CHARS,
 } from "constants/transcribe";
 import { getTranscriptsForItem, putCanvasTranscript } from "lib/transcriptStore";
 
-// Narrows Next's 1mb default to what this route actually accepts. Only has any effect
-// because server.js mounts no app-level body parser — see the comment there.
+// Narrows Next's 1mb default to what this route actually accepts. Next statically
+// analyses this export, so the value has to be a literal and cannot reference
+// MAX_TRANSCRIPT_REQUEST_BYTES in constants/transcribe — lib/transcriptRequestLimit.test.mjs
+// asserts the two match. Only has any effect because server.js mounts no app-level body
+// parser — see the comment there.
 export const config = {
-  api: { bodyParser: { sizeLimit: MAX_TRANSCRIPT_REQUEST_BYTES } },
+  api: { bodyParser: { sizeLimit: 768192 } },
 };
 
 function getErrorMessage(err) {

--- a/pages/api/wikimedia/commons.js
+++ b/pages/api/wikimedia/commons.js
@@ -7,7 +7,7 @@ import { WIKIMEDIA_USER_AGENT } from 'lib/wikimediaUserAgent';
 
 // wbeditentity payloads can be sizeable, so keep the 100kb ceiling this route had from
 // the app-level parser that server.js used to mount, rather than inheriting Next's 1mb.
-export const config = { api: { bodyParser: { sizeLimit: 100 * 1024 } } };
+export const config = { api: { bodyParser: { sizeLimit: 102400 } } };
 
 const COMMONS_API = 'https://commons.wikimedia.org/w/api.php';
 const TOKEN_COOKIE = 'wm_access_token';

--- a/pages/api/wikimedia/commons.js
+++ b/pages/api/wikimedia/commons.js
@@ -5,6 +5,10 @@
 
 import { WIKIMEDIA_USER_AGENT } from 'lib/wikimediaUserAgent';
 
+// wbeditentity payloads can be sizeable, so keep the 100kb ceiling this route had from
+// the app-level parser that server.js used to mount, rather than inheriting Next's 1mb.
+export const config = { api: { bodyParser: { sizeLimit: 100 * 1024 } } };
+
 const COMMONS_API = 'https://commons.wikimedia.org/w/api.php';
 const TOKEN_COOKIE = 'wm_access_token';
 const FETCH_TIMEOUT_MS = 10000;

--- a/server.js
+++ b/server.js
@@ -59,6 +59,16 @@ function leader() {
   }
 }
 
+// Parsers for the handful of express routes below that read req.body. Shared across
+// routes: body-parser does all its setup in the factory, so the returned middleware is
+// stateless. 64kb is far more than these form fields need and less than the 100kb they
+// used to get from the app-level parser.
+const FORM_BODY_LIMIT = 64 * 1024;
+const formBody = [
+  express.urlencoded({ extended: true, limit: FORM_BODY_LIMIT }),
+  express.json({ limit: FORM_BODY_LIMIT }),
+];
+
 function follower() {
   const nextApp = next({ dev });
   const handle = nextApp.getRequestHandler();
@@ -67,8 +77,12 @@ function follower() {
     const expressApp = express();
     Sentry.setupExpressErrorHandler(expressApp);
     expressApp.disable("x-powered-by");
-    expressApp.use(express.urlencoded({ extended: true }));
-    expressApp.use(express.json());
+    // Do NOT mount a body parser app-wide. It would consume the request stream before the
+    // Next.js catchall below, so its limit (100kb by default) would silently become the
+    // ceiling for every Next API route, and Next would skip its own parsing because
+    // req.body is already set — which also makes a parser on the catchall dead code.
+    // Express routes that read req.body attach `formBody` themselves; everything under
+    // the catchall is parsed by Next, where each API route sets its own sizeLimit.
     expressApp.get("/healthcheck", healthcheck());
     expressApp.get("/robots.txt", robotsTxt());
 
@@ -78,9 +92,9 @@ function follower() {
       process.env.NEXT_PUBLIC_SITE_ENV === "pro"
     ) {
       expressApp.get("/wp-content/*path", wpContent());
-      expressApp.post("/mailchimp", doMailchimp());
-      expressApp.post("/g/contact", doContact());
-      expressApp.post("/g/feedback", feedback());
+      expressApp.post("/mailchimp", formBody, doMailchimp());
+      expressApp.post("/g/contact", formBody, doContact());
+      expressApp.post("/g/feedback", formBody, feedback());
     }
 
     expressApp.all("*path", catchall(handle));


### PR DESCRIPTION
## Problem

`server.js` mounted `express.json()` app-wide with no `limit`, applying express's **100kb default to every request** — including the `expressApp.all("*path", catchall(handle))` route that hands off to Next.js.

Express consumed and parsed the body stream before Next saw it, so a transcript PUT between 100kb and the route's own 380,000-byte cap got an opaque 413 from body-parser and never reached the handler. The route's own byte check — and its clear JSON error — were unreachable.

Next then skipped its own parsing entirely, because `req.body` was already set:

```js
// next/dist/server/api-utils/node/api-resolver.js
if (bodyParser && !apiReq.body) {
  apiReq.body = await parseBody(apiReq, config.api?.bodyParser?.sizeLimit ?? '1mb')
}
```

That is also why a parser mounted on the catchall would have been dead code — the app-level parser has already consumed the stream.

Reproduced on express 5.2.1 / body-parser 2.3.0 (matching `yarn.lock`):

| PUT body | text bytes | before |
|---|---|---|
| 50 KB | 50,000 | reached the route |
| 200 KB | 200,000 | **413 `PayloadTooLargeError`**, HTML error page, never reached Next |
| 400 KB | 400,000 | **413** from body-parser; the route's own 413 unreachable |

A 200,000-byte transcript is well inside the cap and should save.

## Fix

Remove the app-level parsers. Parsing is now scoped:

- **Three express form routes** (`/mailchimp`, `/g/contact`, `/g/feedback`) attach a shared `formBody` parser pair at **64kb** — down from the 100kb they had. Sharing instances is safe: body-parser does all its setup in the factory and the returned middleware is stateless.
- **Everything under the catchall** is parsed by Next, where each API route declares its own `sizeLimit`.

Per-route limits:

| route | limit | why |
|---|---|---|
| `/api/transcript/[itemId]` | `MAX_TRANSCRIPT_REQUEST_BYTES` | Derived as `MAX_TRANSCRIPT_TEXT_BYTES * 2` so it cannot drift when the text cap moves. Twice the text cap is the worst case for ordinary text once JSON-escaped — a newline, quote or backslash each cost two bytes on the wire. |
| `/api/thumbnail-error` | 8kb | Its field caps total well under that. Without this it would inherit Next's 1mb default — a 10x loosening on a public unauthenticated POST. |
| `/api/wikimedia/commons` | 100kb | Preserves what it effectively had before. |

The headroom on the transcript route is the point: an over-long transcript must be rejected by the handler's own check, which returns a legible JSON 413, rather than by the parser, whose 413 explains nothing.

`thumbnail-error` deserves a note — its rate limiter is no defense against an oversized body, because Next parses the body *before* invoking the handler, so even a request that ends in a 429 has already been buffered in full.

## Verification

All against a local server on the production dependency versions.

| case | after |
|---|---|
| 50 KB / 200 KB / exactly 380,000 bytes | reaches the handler and saves |
| 380,001 bytes | `413 {"error":"text exceeds 380000 bytes."}` |
| 400 KB / 600 KB / 700 KB | `413 {"error":"text exceeds 380000 bytes."}` |
| 800 KB | `413 Body exceeded 760000 limit` |
| form routes: small JSON / urlencoded / 80 KB | 200 / 200 / 413 |
| `thumbnail-error`: small / 20 KB | 204 / 413 |

`npm test` (79/79 + favicon check) and `npx eslint .` pass. Prettier reports pre-existing formatting in `server.js` and the transcript route; no added line is affected, so no unrelated reformatting is included.

## Notes for review

- **A guard-rail comment replaces the deleted `app.use` lines**, at the exact spot someone would re-add one. Removing app-level parsing means a new express route that reads `req.body` gets `undefined` unless it attaches `formBody`, which would surface as a confusing 400.
- **`express.urlencoded` is deliberately retained** on the three form routes. Nothing in the repo posts urlencoded — all three clients send JSON and all three `<form>` elements are `onSubmit` with no `action` — but dropping it narrows what those endpoints accept, which is a separate decision from fixing a size limit. Tracked separately; happy to fold it in if reviewers prefer.
- Docs updated in `docs/transcribe/transcription-storage.md`, including why no app-level parser can be reintroduced.

Related but **not** fixed here: #1589 (express-level 5xx invisible to Sentry, plus a live 500 in `/mailchimp`). Found while diagnosing this; independent fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Scoped request-body parsing to prevent Express’s default 100 KB limit from blocking transcript PUT requests.
- Added route-specific limits:
  - Form routes: 64 KB.
  - Transcript requests: 768,192 bytes, including JSON envelope headroom.
  - `/api/thumbnail-error`: 8 KB.
  - `/api/wikimedia/commons`: 100 KB.
- Added regression tests for transcript request limits, newline-heavy payloads, and control-character-heavy payloads.
- Preserved handler-level JSON 413 responses for oversized transcripts.
- Updated transcription storage documentation.

This change does not modify environment variables, AWS Secrets Manager keys, databases, shared infrastructure configuration, endpoints, or public response shapes. It does not change authentication or credential handling. No manual pipeline trigger or ECS redeployment is required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->